### PR TITLE
Changes basis inheritance of evaluate / evaluate_on_grid

### DIFF
--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import abc
 from typing import Generator, Tuple
 
-import jax.numpy
 import numpy as np
 import scipy.linalg
 from numpy.typing import ArrayLike, NDArray

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -64,7 +64,7 @@ class Basis(abc.ABC):
         pass
 
     @staticmethod
-    def _get_samples(*n_samples: int):
+    def _get_samples(*n_samples: int) -> Generator[NDArray, ...]:
         """Get equi-spaced samples for all the input dimensions.
 
         This will be used to evaluate the basis on a grid of

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -188,7 +188,7 @@ class Basis(abc.ABC):
             If the number of inputs doesn't match what the Basis object requires.
         """
         if len(xi) != self._n_input_dimensionality:
-            raise ValueError(
+            raise TypeError(
                 f"Input dimensionality mismatch. This basis evaluation requires {self._n_input_dimensionality} inputs, "
                 f"{len(xi)} inputs provided instead."
             )

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -542,7 +542,7 @@ class MSplineBasis(SplineBasis):
             Evaluated spline basis functions, shape (n_samples, n_basis_funcs).
 
         """
-        sample_pts, = self._check_evaluate_input(sample_pts)
+        (sample_pts,) = self._check_evaluate_input(sample_pts)
         # add knots if not passed
         knot_locs = self._generate_knots(
             sample_pts, perc_low=0.0, perc_high=1.0, is_cyclic=False
@@ -574,6 +574,7 @@ class MSplineBasis(SplineBasis):
 
         """
         return super().evaluate_on_grid(n_samples)
+
 
 class BSplineBasis(SplineBasis):
     """
@@ -628,7 +629,7 @@ class BSplineBasis(SplineBasis):
         The evaluation is performed by looping over each element and using `splev`
         from SciPy to compute the basis values.
         """
-        sample_pts, = self._check_evaluate_input(sample_pts)
+        (sample_pts,) = self._check_evaluate_input(sample_pts)
 
         # add knots
         knot_locs = self._generate_knots(sample_pts, 0.0, 1.0)
@@ -712,7 +713,7 @@ class CyclicBSplineBasis(SplineBasis):
         SciPy to compute the basis values.
 
         """
-        sample_pts, = self._check_evaluate_input(sample_pts)
+        (sample_pts,) = self._check_evaluate_input(sample_pts)
 
         knot_locs = self._generate_knots(sample_pts, 0.0, 1.0, is_cyclic=True)
 
@@ -769,6 +770,7 @@ class CyclicBSplineBasis(SplineBasis):
         """
         return super().evaluate_on_grid(n_samples)
 
+
 class RaisedCosineBasis(Basis, abc.ABC):
     def __init__(self, n_basis_funcs: int) -> None:
         super().__init__(n_basis_funcs)
@@ -809,7 +811,7 @@ class RaisedCosineBasis(Basis, abc.ABC):
             If the sample provided do not lie in [0,1].
 
         """
-        sample_pts, = self._check_evaluate_input(sample_pts)
+        (sample_pts,) = self._check_evaluate_input(sample_pts)
         if any(sample_pts < 0) or any(sample_pts > 1):
             raise ValueError("Sample points for RaisedCosine basis must lie in [0,1]!")
 
@@ -1079,7 +1081,7 @@ class OrthExponentialBasis(Basis):
             orthogonalized, shape (n_samples, n_basis_funcs)
 
         """
-        sample_pts, = self._check_evaluate_input(sample_pts)
+        (sample_pts,) = self._check_evaluate_input(sample_pts)
         self._check_sample_range(sample_pts)
         self._check_sample_size(sample_pts)
         # because of how scipy.linalg.orth works, have to create a matrix of

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -69,21 +69,14 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             self.cls(5).evaluate(samples)
 
     @pytest.mark.parametrize(
-        "arraylike", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
+        "eval_input", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = self.cls(n_basis_funcs=5)
-        raise_exception = not isinstance(
-            arraylike, (tuple, list, np.ndarray, jax.numpy.ndarray)
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(arraylike)
-        else:
-            basis_obj.evaluate(arraylike)
+        basis_obj.evaluate(eval_input)
 
     @pytest.mark.parametrize(
         "args, sample_size",
@@ -237,21 +230,14 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
             self.cls(5).evaluate(samples)
 
     @pytest.mark.parametrize(
-        "arraylike", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
+        "eval_input", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = self.cls(n_basis_funcs=5)
-        raise_exception = not isinstance(
-            arraylike, (tuple, list, np.ndarray, jax.numpy.ndarray)
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(arraylike)
-        else:
-            basis_obj.evaluate(arraylike)
+        basis_obj.evaluate(eval_input)
 
     @pytest.mark.parametrize(
         "args, sample_size",
@@ -403,21 +389,14 @@ class TestMSplineBasis(BasisFuncsTesting):
             self.cls(5).evaluate(samples)
 
     @pytest.mark.parametrize(
-        "arraylike", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
+        "eval_input", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = self.cls(n_basis_funcs=5)
-        raise_exception = not isinstance(
-            arraylike, (tuple, list, np.ndarray, jax.numpy.ndarray)
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(arraylike)
-        else:
-            basis_obj.evaluate(arraylike)
+        basis_obj.evaluate(eval_input)
 
     @pytest.mark.parametrize("n_basis_funcs", [6, 8, 10])
     @pytest.mark.parametrize("order", range(1, 6))
@@ -568,21 +547,19 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
             self.cls(5, decay_rates=np.arange(1, 6)).evaluate(samples)
 
     @pytest.mark.parametrize(
-        "arraylike", [0, [0]*6, (0,)*6, np.array([0]*6), jax.numpy.array([0]*6)]
+        "eval_input", [0, [0]*6, (0,)*6, np.array([0]*6), jax.numpy.array([0]*6)]
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = self.cls(n_basis_funcs=5, decay_rates=np.arange(1, 6))
-        raise_exception = not isinstance(
-            arraylike, (tuple, list, np.ndarray, jax.numpy.ndarray)
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(arraylike)
+        if isinstance(eval_input, int):
+            # OrthExponentialBasis is special -- cannot accept int input
+            with pytest.raises(ValueError, match="OrthExponentialBasis requires at least as many samples"):
+                basis_obj.evaluate(eval_input)
         else:
-            basis_obj.evaluate(arraylike)
+            basis_obj.evaluate(eval_input)
 
     @pytest.mark.parametrize("n_basis_funcs", [1, 2, 4, 8])
     @pytest.mark.parametrize("sample_size", [10, 1000])
@@ -766,21 +743,14 @@ class TestBSplineBasis(BasisFuncsTesting):
             self.cls(5).evaluate(samples)
 
     @pytest.mark.parametrize(
-        "arraylike", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
+        "eval_input", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = self.cls(n_basis_funcs=5)
-        raise_exception = not isinstance(
-            arraylike, (tuple, list, np.ndarray, jax.numpy.ndarray)
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(arraylike)
-        else:
-            basis_obj.evaluate(arraylike)
+        basis_obj.evaluate(eval_input)
 
     @pytest.mark.parametrize("n_basis_funcs", [6, 8, 10])
     @pytest.mark.parametrize("order", range(1, 6))
@@ -948,21 +918,14 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
             self.cls(5).evaluate(samples)
 
     @pytest.mark.parametrize(
-        "arraylike", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
+        "eval_input", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = self.cls(n_basis_funcs=5)
-        raise_exception = not isinstance(
-            arraylike, (tuple, list, np.ndarray, jax.numpy.ndarray)
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(arraylike)
-        else:
-            basis_obj.evaluate(arraylike)
+        basis_obj.evaluate(eval_input)
 
     @pytest.mark.parametrize("n_basis_funcs", [8, 10])
     @pytest.mark.parametrize("order", range(2, 6))
@@ -1191,7 +1154,7 @@ class TestAdditiveBasis(CombinedBasis):
             basis_obj.evaluate(*samples)
 
     @pytest.mark.parametrize(
-        "arraylike",
+        "eval_input",
         [
             [0, 0],
             [[0], [0]],
@@ -1200,20 +1163,12 @@ class TestAdditiveBasis(CombinedBasis):
             [jax.numpy.array([0]), [0]],
         ],
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = basis.MSplineBasis(5) + basis.MSplineBasis(5)
-        raise_exception = not all(
-            isinstance(a, (tuple, list, np.ndarray, jax.numpy.ndarray))
-            for a in arraylike
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(*arraylike)
-        else:
-            basis_obj.evaluate(*arraylike)
+        basis_obj.evaluate(*eval_input)
 
     @pytest.mark.parametrize("n_basis_a", [5, 6])
     @pytest.mark.parametrize("n_basis_b", [5, 6])
@@ -1418,7 +1373,7 @@ class TestMultiplicativeBasis(CombinedBasis):
             basis_obj.evaluate(*samples)
 
     @pytest.mark.parametrize(
-        "arraylike",
+        "eval_input",
         [
             [0, 0],
             [[0], [0]],
@@ -1427,20 +1382,12 @@ class TestMultiplicativeBasis(CombinedBasis):
             [jax.numpy.array([0]), [0]],
         ],
     )
-    def test_input_to_evaluate_is_arraylike(self, arraylike):
+    def test_evaluate_input(self, eval_input):
         """
         Checks that the sample size of the output from the evaluate() method matches the input sample size.
         """
         basis_obj = basis.MSplineBasis(5) * basis.MSplineBasis(5)
-        raise_exception = not all(
-            isinstance(a, (tuple, list, np.ndarray, jax.numpy.ndarray))
-            for a in arraylike
-        )
-        if raise_exception:
-            with pytest.raises(TypeError, match="Input samples must be array-like"):
-                basis_obj.evaluate(*arraylike)
-        else:
-            basis_obj.evaluate(*arraylike)
+        basis_obj.evaluate(*eval_input)
 
     @pytest.mark.parametrize("n_basis_a", [5, 6])
     @pytest.mark.parametrize("n_basis_b", [5, 6])

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -7,6 +7,7 @@ import pytest
 import utils_testing
 
 import nemos.basis as basis
+from contextlib import nullcontext as does_not_raise
 
 # automatic define user accessible basis and check the methods
 
@@ -153,16 +154,14 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         Confirms that the evaluate() method correctly handles the number of input samples that are provided.
         """
         basis_obj = self.cls(n_basis_funcs=5)
-        raise_exception = n_input != basis_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ "
-                "inputs,",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
@@ -204,15 +203,13 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         """
         basis_obj = self.cls(n_basis_funcs=5)
         inputs = [10] * n_input
-        raise_exception = n_input != basis_obj._n_input_dimensionality
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch\. This basis evaluation requires [0-9]+ inputs, "
-                r"[0-9]+ inputs provided instead.",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
 
@@ -313,15 +310,14 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
         Confirms that the evaluate() method correctly handles the number of input samples that are provided.
         """
         basis_obj = self.cls(n_basis_funcs=5)
-        raise_exception = n_input != basis_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs,",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
@@ -363,15 +359,13 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
         """
         basis_obj = self.cls(n_basis_funcs=5)
         inputs = [10] * n_input
-        raise_exception = n_input != basis_obj._n_input_dimensionality
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch\. This basis evaluation requires [0-9]+ inputs, "
-                r"[0-9]+ inputs provided instead.",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
 
@@ -470,15 +464,14 @@ class TestMSplineBasis(BasisFuncsTesting):
         Confirms that the evaluate() method correctly handles the number of input samples that are provided.
         """
         basis_obj = self.cls(n_basis_funcs=5, order=3)
-        raise_exception = n_input != basis_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs,",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
@@ -520,15 +513,13 @@ class TestMSplineBasis(BasisFuncsTesting):
         """
         basis_obj = self.cls(n_basis_funcs=5, order=3)
         inputs = [10] * n_input
-        raise_exception = n_input != basis_obj._n_input_dimensionality
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch\. This basis evaluation requires [0-9]+ inputs, "
-                r"[0-9]+ inputs provided instead.",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
 
@@ -633,15 +624,14 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
     def test_number_of_required_inputs_evaluate(self, n_input):
         """Tests whether the evaluate method correctly processes the number of required inputs."""
         basis_obj = self.cls(n_basis_funcs=5, decay_rates=np.arange(1, 6))
-        raise_exception = n_input != basis_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs,",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 2, 3, 4, 5, 6, 10, 11, 100])
@@ -682,15 +672,13 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         """Tests whether the evaluate_on_grid method correctly processes the Input dimensionality."""
         basis_obj = self.cls(n_basis_funcs=5, decay_rates=np.arange(1, 6))
         inputs = [10] * n_input
-        raise_exception = n_input != basis_obj._n_input_dimensionality
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch\. This basis evaluation requires [0-9]+ inputs, "
-                r"[0-9]+ inputs provided instead.",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
     @pytest.mark.parametrize(
@@ -839,15 +827,14 @@ class TestBSplineBasis(BasisFuncsTesting):
         Confirms that the evaluate() method correctly handles the number of input samples that are provided.
         """
         basis_obj = self.cls(n_basis_funcs=5, order=3)
-        raise_exception = n_input != basis_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs,",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
@@ -893,14 +880,13 @@ class TestBSplineBasis(BasisFuncsTesting):
         """
         basis_obj = self.cls(n_basis_funcs=5, order=3)
         inputs = [10] * n_input
-        raise_exception = n_input != basis_obj._n_input_dimensionality
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch\. This basis evaluation requires [0-9]+ inputs",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
 
@@ -1032,15 +1018,14 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
         Confirms that the evaluate() method correctly handles the number of input samples that are provided.
         """
         basis_obj = self.cls(n_basis_funcs=5, order=3)
-        raise_exception = n_input != basis_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
@@ -1086,14 +1071,13 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
         """
         basis_obj = self.cls(n_basis_funcs=5, order=3)
         inputs = [10] * n_input
-        raise_exception = n_input != basis_obj._n_input_dimensionality
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch\. This basis evaluation requires [0-9]+ inputs",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        if n_input == 0:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) missing 1 required positional argument")
+        elif n_input != basis_obj._n_input_dimensionality:
+            expectation = pytest.raises(TypeError, match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",)
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
 
@@ -1254,18 +1238,13 @@ class TestAdditiveBasis(CombinedBasis):
         basis_a_obj = self.instantiate_basis(n_basis_a, basis_a)
         basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
         basis_obj = basis_a_obj + basis_b_obj
-        raise_exception = (
-            n_input
-            != basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
-        )
+        required_dim = basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs,",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input != required_dim:
+            expectation = pytest.raises(TypeError, match="Input dimensionality mismatch.")
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [11, 20])
@@ -1341,18 +1320,12 @@ class TestAdditiveBasis(CombinedBasis):
         basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
         basis_obj = basis_a_obj + basis_b_obj
         inputs = [20] * n_input
-        raise_exception = (
-            n_input
-            != basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
-        )
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch\. This basis evaluation requires [0-9]+ inputs, "
-                r"[0-9]+ inputs provided instead.",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        required_dim = basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
+        if n_input != required_dim:
+            expectation = pytest.raises(TypeError, match="Input dimensionality mismatch.")
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
 
@@ -1473,18 +1446,13 @@ class TestMultiplicativeBasis(CombinedBasis):
         basis_a_obj = self.instantiate_basis(n_basis_a, basis_a)
         basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
         basis_obj = basis_a_obj * basis_b_obj
-        raise_exception = (
-            n_input
-            != basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
-        )
+        required_dim = basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
         inputs = [np.linspace(0, 1, 20)] * n_input
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match="Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs,",
-            ):
-                basis_obj.evaluate(*inputs)
+        if n_input != required_dim:
+            expectation = pytest.raises(TypeError, match="Input dimensionality mismatch.")
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate(*inputs)
 
     @pytest.mark.parametrize("sample_size", [11, 20])
@@ -1560,18 +1528,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
         basis_obj = basis_a_obj * basis_b_obj
         inputs = [20] * n_input
-        raise_exception = (
-            n_input
-            != basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
-        )
-        if raise_exception:
-            with pytest.raises(
-                ValueError,
-                match=r"Input dimensionality mismatch. This basis evaluation requires [0-9]+ inputs, "
-                r"[0-9]+ inputs provided instead.",
-            ):
-                basis_obj.evaluate_on_grid(*inputs)
+        required_dim = basis_a_obj._n_input_dimensionality + basis_b_obj._n_input_dimensionality
+        if n_input != required_dim:
+            expectation = pytest.raises(TypeError, match="Input dimensionality mismatch.")
         else:
+            expectation = does_not_raise()
+        with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
     @pytest.mark.parametrize("basis_a", [basis.MSplineBasis])


### PR DESCRIPTION
This PR is an implementation of #30 : it changes where the public instantiation of the basis `evaluate` / `evaluate_on_grid` happens so that the user-facing docstring and function signature are more transparent. 

Previously, the docstring that showed up for these two methods was the one from the super class, which was generic and suggested that they could accept an arbitrary number of inputs, but e.g., the following:
```python
bs = nsl.basis.MSplineBasis()
bs.evaluate_on_grid(5,5)
```

fails. Now, the docstring for `evaluate` and `evaluate_on_grid` make it clear that they expect a single input.

This required renaming the superclass `evaluate` to `_check_evaluate_input`, and then all the subclasses call that method first.

The superclass `evaluate_on_grid` method is still public, and it's the one used directly by `AdditiveBasis` and `MultiplicativeBasis`

Also:
- Did some minor cleaning up of the docstrings.
- Made some changes for what we check for in evaluate input. We no longer test the type of `sample_pts` directly, instead we see if it can be cast to a numpy array with floating point type, of at least 1d.

I'm not super happy about:
- `AdditiveBasis` and `MultiplicativeBasis` still have the less informative docstring. Given their recursive nature, I'm not sure there's a way around this without doing something real weird like setting `self.evaluate.__func__.__doc__` during initialization, which seems ... bad
- There's a lot of repetition of `evaluate_on_grid`: whereas every concrete class had an `_evaluate` method that just got promoted to `evaluate`, none of them had anything like that for `evaluate_on_grid`. So now each has a new `evaluate_on_grid` whose entire point is just to define the docstring -- the only thing it does is call `super().evaluate_on_grid(n_samples)`. I still think this is better than previously, because the docstring and function signature are clear, but ... it's ugly.

I also think the new docstrings can probably be made more informative. Happy to go and do that if people think this is worth doing.