### PR TITLE
issue #86: first attempt to fix the proximal operator overwriting

### DIFF
--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -7,6 +7,7 @@ with various optimization methods, and they can be applied depending on the mode
 """
 import abc
 import inspect
+import warnings
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import jax.numpy as jnp
@@ -74,13 +75,10 @@ class Regularizer(Base, abc.ABC):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._check_solver(solver_name)
-        self._solver_name = solver_name
+        self.solver_name = solver_name
         if solver_kwargs is None:
-            self._solver_kwargs = dict()
-        else:
-            self._solver_kwargs = solver_kwargs
-        self._check_solver_kwargs(self.solver_name, self.solver_kwargs)
+            solver_kwargs = dict()
+        self.solver_kwargs = solver_kwargs
 
     @property
     def solver_name(self):
@@ -146,7 +144,7 @@ class Regularizer(Base, abc.ABC):
             )
 
     def instantiate_solver(
-        self, loss: Callable, *args: Any, **kwargs: Any
+        self, loss: Callable, *args: Any, prox: Optional[Callable] = None, **kwargs: Any
     ) -> SolverRunner:
         """
         Instantiate the solver with the provided loss function.
@@ -159,6 +157,9 @@ class Regularizer(Base, abc.ABC):
         *args:
             Positional arguments for the jaxopt `solver.run` method, e.g. the regularizing
             strength for proximal gradient methods.
+
+        prox:
+            Optional, the proximal projection operator.
 
         *kwargs:
             Keyword arguments for the jaxopt `solver.run` method.
@@ -174,7 +175,25 @@ class Regularizer(Base, abc.ABC):
         # get the solver with given arguments.
         # The "fun" argument is not always the first one, but it is always KEYWORD
         # see jaxopt.EqualityConstrainedQP for example. The most general way is to pass it as keyword.
-        solver = getattr(jaxopt, self.solver_name)(fun=loss, **self.solver_kwargs)
+        # The proximal gradient is added to the kwargs if passed. This avoids issues with over-writing
+        # the proximal operator.
+        if prox is not None:
+            solver_kwargs = self.solver_kwargs.copy()
+            solver_kwargs.update(prox=prox)
+            if "prox" in self.solver_kwargs:
+                warnings.warn(
+                    "Overwritten the user-defined proximal operator! "
+                    "There is only one valid proximal operator for each regularizer type.",
+                    UserWarning,
+                )
+        # hit this if users define a proximal operator for differentiable objectives.
+        elif "prox" in self.solver_kwargs:
+            raise ValueError(
+                f"Regularizer of type {self.__class__.__name__} does not require a proximal operator!"
+            )
+        else:
+            solver_kwargs = self.solver_kwargs
+        solver = getattr(jaxopt, self.solver_name)(fun=loss, **solver_kwargs)
 
         def solver_run(
             init_params: Tuple[DESIGN_INPUT_TYPE, jnp.ndarray], *run_args: jnp.ndarray
@@ -328,10 +347,6 @@ class ProxGradientRegularizer(Regularizer, abc.ABC):
         regularizer_strength: float = 1.0,
         **kwargs,
     ):
-        if solver_kwargs is None:
-            solver_kwargs = dict(prox=self._get_proximal_operator())
-        else:
-            solver_kwargs["prox"] = self._get_proximal_operator()
         super().__init__(solver_name, solver_kwargs=solver_kwargs)
         self.regularizer_strength = regularizer_strength
 
@@ -365,7 +380,9 @@ class ProxGradientRegularizer(Regularizer, abc.ABC):
         :
             A function that runs the solver with the provided loss and proximal operator.
         """
-        return super().instantiate_solver(loss, self.regularizer_strength)
+        return super().instantiate_solver(
+            loss, self.regularizer_strength, prox=self._get_proximal_operator()
+        )
 
 
 class Lasso(ProxGradientRegularizer):

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -1,9 +1,12 @@
+import warnings
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 import statsmodels.api as sm
 from sklearn.linear_model import PoissonRegressor
+from contextlib import nullcontext as does_not_raise
 
 import nemos as nmo
 
@@ -147,6 +150,19 @@ class TestUnRegularized:
         if (not match_weights) or (not match_intercepts):
             raise ValueError("Ridge GLM regularizer estimate does not match sklearn!")
 
+    @pytest.mark.parametrize("solver_name", ["GradientDescent", "BFGS"])
+    @pytest.mark.parametrize("kwargs, expectation", [
+        ({}, does_not_raise()),
+        ({"prox": 0}, pytest.raises(ValueError, match=r"Regularizer of type [A-z]+ does not require a "
+                                                      r"proximal operator!")),
+    ])
+    def test_overwritten_proximal_operator(self, solver_name, kwargs, expectation,
+                                           poissonGLM_model_instantiation):
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        with expectation:
+            model.regularizer.solver_kwargs = kwargs
+            model.fit(X, y)
+
 
 class TestRidge:
     cls = nmo.regularizer.Ridge
@@ -289,6 +305,19 @@ class TestRidge:
         if (not match_weights) or (not match_intercepts):
             raise ValueError("Ridge GLM solver estimate does not match sklearn!")
 
+    @pytest.mark.parametrize("solver_name", ["GradientDescent", "BFGS"])
+    @pytest.mark.parametrize("kwargs, expectation", [
+        ({}, does_not_raise()),
+        ({"prox": 0}, pytest.raises(ValueError, match=r"Regularizer of type [A-z]+ does not require a "
+                                                      r"proximal operator!")),
+    ])
+    def test_overwritten_proximal_operator(self, solver_name, kwargs, expectation,
+                                           poissonGLM_model_instantiation):
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        with expectation:
+            model.regularizer.solver_kwargs = kwargs
+            model.fit(X, y)
+
 
 class TestLasso:
     cls = nmo.regularizer.Lasso
@@ -385,6 +414,18 @@ class TestLasso:
         if not match_weights:
             raise ValueError("Lasso GLM solver estimate does not match statsmodels!")
 
+    @pytest.mark.parametrize("solver_name", ["ProximalGradient"])
+    @pytest.mark.parametrize("kwargs, expectation", [
+        ({}, does_not_raise()),
+        ({"prox": 0}, pytest.warns(UserWarning, match=r"Overwritten the user-defined proximal operator")),
+    ])
+    def test_overwritten_proximal_operator(self, solver_name, kwargs, expectation,
+                                           poissonGLM_model_instantiation):
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.regularizer = nmo.regularizer.Lasso()
+        with expectation:
+            model.regularizer.solver_kwargs = kwargs
+            model.fit(X, y)
 
 class TestGroupLasso:
     cls = nmo.regularizer.GroupLasso
@@ -737,3 +778,16 @@ class TestGroupLasso:
                 regularizer.set_params(mask=mask)
         else:
             regularizer.set_params(mask=mask)
+
+    @pytest.mark.parametrize("solver_name", ["ProximalGradient"])
+    @pytest.mark.parametrize("kwargs, expectation", [
+        ({}, does_not_raise()),
+        ({"prox": 0}, pytest.warns(UserWarning, match=r"Overwritten the user-defined proximal operator")),
+    ])
+    def test_overwritten_proximal_operator(self, solver_name, kwargs, expectation,
+                                           poissonGLM_model_instantiation):
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.regularizer = nmo.regularizer.Lasso()
+        with expectation:
+            model.regularizer.solver_kwargs = kwargs
+            model.fit(X, y)


### PR DESCRIPTION
Started a PR to fix the edge case of user overwriting the proximal operator [issue #86](https://github.com/flatironinstitute/nemos/issues/86).

The solution adopted here should be discussed and it is a first attempt. I think overwriting user defined proximal operators is a good idea because each regularization type has its own specific operator.

Another option would be add/overwriting the prox in the setter for `solver_kwargs`; this has the benefit of raising the warning when the solver argument is passed and when fit is called. However, in this case it feels weird to add items to the user defined `solver_kwargs` (this is what happened so far and created the unexpected behavior we describe in the issue bug) . 