### PR TITLE
Population glm

### DIFF
--- a/docs/api_guide/plot_03_glm_pytree.py
+++ b/docs/api_guide/plot_03_glm_pytree.py
@@ -86,36 +86,36 @@ except ValueError as e:
 # %%
 #
 # FeaturePytrees are intended to be used with
-# [jax.tree_map](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map.html),
+# [jax.tree_util.tree_map](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map.html),
 # a useful function for performing computations on arbitrary pytrees,
 # preserving their structure.
 
 # %%
 # We can map lambda functions:
-mapped = jax.tree_map(lambda x: x**2, example_pytree)
+mapped = jax.tree_util.tree_map(lambda x: x**2, example_pytree)
 print(mapped)
 mapped['feature_1']
 # %%
 # Or functions from jax or numpy that operate on arrays:
-mapped = jax.tree_map(jnp.exp, example_pytree)
+mapped = jax.tree_util.tree_map(jnp.exp, example_pytree)
 print(mapped)
 mapped['feature_1']
 # %%
 # We can change the dimensionality of our pytree:
-mapped = jax.tree_map(lambda x: jnp.mean(x, axis=-1), example_pytree)
+mapped = jax.tree_util.tree_map(lambda x: jnp.mean(x, axis=-1), example_pytree)
 print(mapped)
 mapped['feature_1']
 # %%
 # Or the number of time points:
-mapped = jax.tree_map(lambda x: x[::10], example_pytree)
+mapped = jax.tree_util.tree_map(lambda x: x[::10], example_pytree)
 print(mapped)
 mapped['feature_1']
 # %%
 #
 # If we map something whose output cannot be a FeaturePytree (because its
 # values are scalars or non-arrays), we return a dictionary of arrays instead:
-print(jax.tree_map(jnp.mean, example_pytree))
-print(jax.tree_map(lambda x: x.shape, example_pytree))
+print(jax.tree_util.tree_map(jnp.mean, example_pytree))
+print(jax.tree_util.tree_map(lambda x: x.shape, example_pytree))
 import fsspec
 import h5py
 import matplotlib.pyplot as plt

--- a/docs/api_guide/plot_04_population_glm.py
+++ b/docs/api_guide/plot_04_population_glm.py
@@ -103,8 +103,8 @@ print(feature_mask)
 # The mask can be passed at initialization or set after the model is initialized, but cannot be changed
 # after the model is fit.
 
-# set a quasi-newton solver for better numerical precision
-model = nmo.glm.PopulationGLM(regularizer=nmo.regularizer.UnRegularized("LBFGS"))
+# set a quasi-newton solver and low tolerance for better numerical precision
+model = nmo.glm.PopulationGLM(regularizer=nmo.regularizer.UnRegularized("LBFGS", solver_kwargs={"tol": 10**-12}))
 
 # set the mask
 model.feature_mask = feature_mask
@@ -134,7 +134,9 @@ coeff = np.zeros((2, 2))
 
 # loop over the neurons and fit a GLM
 for neuron in range(2):
-    model_neu = nmo.glm.GLM(regularizer=nmo.regularizer.UnRegularized("LBFGS"))
+    model_neu = nmo.glm.GLM(
+        regularizer=nmo.regularizer.UnRegularized("LBFGS", solver_kwargs={"tol":10**-12})
+    )
     model_neu.fit(input_features[:, features_by_neuron[neuron]], spikes[:, neuron])
     coeff[:, neuron] = model_neu.coef_
 
@@ -142,8 +144,9 @@ for neuron in range(2):
 fig, axs = plt.subplots(1, 2, figsize=(6, 3))
 for neuron in range(2):
     axs[neuron].set_title(f"neuron {neuron}")
-    axs[neuron].bar([0, 3], coeff[:, neuron], width=0.8, label="single neuron GLM")
-    axs[neuron].bar([1, 4], model.coef_[features_by_neuron[neuron], neuron], width=0.8, label="population GLM")
+    axs[neuron].bar([0, 4], w_true[features_by_neuron[neuron], neuron], width=0.8, label="true")
+    axs[neuron].bar([1, 5], coeff[:, neuron], width=0.8, label="single neuron GLM")
+    axs[neuron].bar([2, 6], model.coef_[features_by_neuron[neuron], neuron], width=0.8, label="population GLM")
     axs[neuron].set_ylabel("coefficient")
     axs[neuron].set_ylim(0, 0.8)
     axs[neuron].set_xticks([0.5, 3.5])

--- a/docs/api_guide/plot_04_population_glm.py
+++ b/docs/api_guide/plot_04_population_glm.py
@@ -1,0 +1,149 @@
+"""
+# Population GLM
+
+Fitting the activity of a neural population with `nemos` can be much more efficient than fitting each individual
+neuron in a loop. The reason for this is that `nemos` leverages the powerful GPU-vectorization implemented by `JAX`.
+
+
+!!! note
+    For an unregularized, Lasso, Ridge, or group-Lasso GLM, fitting a GLM one neuron at the time, or fitting jointly
+    the neural population is equivalent. The main difference between the approaches is that the former is more
+    memory efficient, the latter is computationally more efficient (it takes less time to fit).
+
+## Fitting a Population GLM
+
+`nemos` has a dedicated `nemos.GLM.PopulationGLM` class for fitting jointly a neural population. The API
+ is very similar to that the regular `nemos.glm.GLM`, but with a few differences:
+
+ 1. The `y` input to the methods `fit` and `score` must be a two-dimensional array of shape `(n_samples, n_neurons)`.
+ 2. You can optionally pass a `feature_mask` in the form of an array of 0s and 1s with shape `(n_features, n_neurons)`
+ that determines what features are used as regression for each neurons. The default is that each neuron has all the
+ features as predictors. More on this later.
+
+Let's generate some synthetic data and fit a population model.
+"""
+
+import jax.numpy as jnp
+import nemos as nmo
+import numpy as np
+import matplotlib.pyplot as plt
+
+np.random.seed(123)
+
+n_features = 5
+n_neurons = 2
+n_samples = 500
+
+# random design array. Shape (n_time_points, n_features).
+X = 0.5*np.random.normal(size=(n_samples, n_features))
+
+# log-rates & weights
+b_true = np.zeros((n_neurons, ))
+w_true = np.random.uniform(size=(n_features, n_neurons))
+
+
+# generate counts (spikes will be (n_samples, n_features)
+rate = jnp.exp(jnp.dot(X, w_true) + b_true)
+spikes = np.random.poisson(rate)
+
+print(spikes.shape)
+
+# %%
+# We can now instantiate the `PopulationGLM` model and  fit.
+model = nmo.glm.PopulationGLM()
+model.fit(X, spikes)
+
+print(f"population GLM log-likelihood: {model.score(X, spikes)}")
+
+# %%
+# ## Neuron-specific features
+# If you want to model neurons with different input features, the way to do so is to specify a `feature_mask`.
+# Let's assume that we have two neurons, share one shared input, and have an extra private one, for a total of
+# 3 inputs.
+
+# let's take the first three input
+n_features = 3
+input_features = X[:, :3]
+
+
+# %%
+# Let's assume that:
+#   - `input_features[:, 0]` is shared.
+#   - `input_features[:, 1]` is an input only for the first neuron.
+#   - `input_features[:, 2]` is an input only for the second neuron.
+#
+# We can simulate this scenario,
+
+# model the rate of the first neuron using only the first two features and weights.
+rate_neuron_1 = jnp.exp(np.dot(input_features[:, [0, 1]], w_true[: 2, 0]))
+
+# model the rate of the second neuron using only the first and last feature and weights.
+rate_neuron_2 = jnp.exp(np.dot(input_features[:, [0, 2]], w_true[[0, 2], 1]))
+
+# stack the rates in a (n_samples, n_neurons) array and generate spikes
+rate = np.hstack((rate_neuron_1[:, np.newaxis], rate_neuron_2[:, np.newaxis]))
+spikes = np.random.poisson(rate)
+
+# %%
+# We can impose the same constraint to the `PopulationGLM` by masking the weights.
+
+# initialize the mask to a matrix of 1s.
+feature_mask = np.ones((n_features, n_neurons))
+
+# remove the 3rd feature from the predictors of the first neuron
+feature_mask[2, 0] = 0
+
+# remove the 2nd feature from the predictors of the second neuron
+feature_mask[1, 1] = 0
+
+# visualize the mask
+print(feature_mask)
+
+# %%
+# The mask can be passed at initialization or set after the model is initialized, but cannot be changed
+# after the model is fit.
+
+# set the mask
+model = nmo.glm.PopulationGLM()
+model.feature_mask = feature_mask
+
+# fit the model
+model.fit(input_features, spikes)
+
+# %%
+# If we print the model coefficients, we can see the effect of the mask.
+
+print(model.coef_)
+
+# %%
+# The coefficient for the first neuron corresponding to the last feature is zero, as well as
+# the coefficient of the second neuron corresponding to the second feature.
+# To convince ourselves that this is equivalent to fit each neuron individually with the correct features,
+# let's go ahead try.
+
+# select the feature to use for each neuron
+features_by_neuron = {
+    0: [0, 1],
+    1: [0, 2]
+}
+# initialize the coefficients
+coeff = np.zeros((2, 2))
+for neuron in range(2):
+    model_neu = nmo.glm.GLM()
+    model_neu.fit(input_features[:, features_by_neuron[neuron]], spikes[:, neuron])
+    coeff[:, neuron] = model_neu.coef_
+
+# visually compare the estimated coeffeicients
+fig, axs = plt.subplots(1, 2, figsize=(6, 3))
+for neuron in range(2):
+    axs[neuron].set_title(f"neuron {neuron}")
+    axs[neuron].axhline(0, color="k")
+    axs[neuron].bar([0, 3], coeff[:, neuron], width=0.8, label="single neuron GLM")
+    axs[neuron].bar([1, 4], model.coef_[features_by_neuron[neuron], neuron], width=0.8, label="population GLM")
+    axs[neuron].set_ylabel("coefficient")
+    axs[neuron].set_ylim(0, 0.8)
+    axs[neuron].set_xticks([0.5, 3.5])
+    axs[neuron].set_xticklabels(["feature 0", f"feature {neuron + 1}"])
+    if neuron == 1:
+        plt.legend()
+plt.tight_layout()

--- a/docs/neural_modeling/examples_utils/model.py
+++ b/docs/neural_modeling/examples_utils/model.py
@@ -54,13 +54,13 @@ class GLM(nmo.glm.GLM):
             if len(init_params) != 2:
                 raise ValueError("Params must have length two.")
             init_params = (
-                jax.tree_map(lambda x: np.expand_dims(np.asarray(x, dtype=float), axis=0), init_params[0]),
-                jax.tree_map(lambda x: np.expand_dims(np.asarray(x, dtype=float), axis=0), init_params[1]),
+                jax.tree_util.tree_map(lambda x: np.expand_dims(np.asarray(x, dtype=float), axis=0), init_params[0]),
+                jax.tree_util.tree_map(lambda x: np.expand_dims(np.asarray(x, dtype=float), axis=0), init_params[1]),
             )
-        X = jax.tree_map(
+        X = jax.tree_util.tree_map(
             lambda x: jax.numpy.expand_dims(jax.numpy.asarray(x), axis=1), X
         )
-        y = jax.tree_map(
+        y = jax.tree_util.tree_map(
             lambda x: jax.numpy.expand_dims(jax.numpy.asarray(x), axis=1), y
         )
         if isinstance(X, nmo.pytrees.FeaturePytree):
@@ -68,23 +68,23 @@ class GLM(nmo.glm.GLM):
         try:
             super().fit(X, y, init_params=init_params)
         finally:
-            self.coef_ = jax.tree_map(lambda x: jnp.atleast_1d(np.squeeze(x)), self.coef_)
-            self.intercept_ = jax.tree_map(np.squeeze, self.intercept_)
+            self.coef_ = jax.tree_util.tree_map(lambda x: jnp.atleast_1d(np.squeeze(x)), self.coef_)
+            self.intercept_ = jax.tree_util.tree_map(np.squeeze, self.intercept_)
         return self
 
     def predict(self, X: DESIGN_INPUT_TYPE) -> jnp.ndarray:
-        X = jax.tree_map(
+        X = jax.tree_util.tree_map(
             lambda x: jax.numpy.expand_dims(jax.numpy.asarray(x), axis=1), X
         )
         if isinstance(X, nmo.pytrees.FeaturePytree):
             X = X.data
-        self.coef_ = jax.tree_map(lambda x: np.expand_dims(x, axis=0), self.coef_)
-        self.intercept_ = jax.tree_map(lambda x: np.expand_dims(x, axis=0), self.intercept_)
+        self.coef_ = jax.tree_util.tree_map(lambda x: np.expand_dims(x, axis=0), self.coef_)
+        self.intercept_ = jax.tree_util.tree_map(lambda x: np.expand_dims(x, axis=0), self.intercept_)
         try:
             rate = super().predict(X)
         finally:
-            self.coef_ = jax.tree_map(lambda x: jnp.atleast_1d(np.squeeze(x)), self.coef_)
-            self.intercept_ = jax.tree_map(np.squeeze, self.intercept_)
+            self.coef_ = jax.tree_util.tree_map(lambda x: jnp.atleast_1d(np.squeeze(x)), self.coef_)
+            self.intercept_ = jax.tree_util.tree_map(np.squeeze, self.intercept_)
         return jax.numpy.squeeze(rate)
 
     def score(
@@ -95,21 +95,21 @@ class GLM(nmo.glm.GLM):
             "log-likelihood", "pseudo-r2-McFadden", "pseudo-r2-Cohen"
         ] = "pseudo-r2-McFadden",
     ) -> jnp.ndarray:
-        X = jax.tree_map(
+        X = jax.tree_util.tree_map(
             lambda x: jax.numpy.expand_dims(jax.numpy.asarray(x), axis=1), X
         )
-        y = jax.tree_map(
+        y = jax.tree_util.tree_map(
             lambda x: jax.numpy.expand_dims(jax.numpy.asarray(x), axis=1), y
         )
         if isinstance(X, nmo.pytrees.FeaturePytree):
             X = X.data
-        self.coef_ = jax.tree_map(lambda x: np.expand_dims(x, axis=0), self.coef_)
-        self.intercept_ = jax.tree_map(lambda x: np.expand_dims(x, axis=0), self.intercept_)
+        self.coef_ = jax.tree_util.tree_map(lambda x: np.expand_dims(x, axis=0), self.coef_)
+        self.intercept_ = jax.tree_util.tree_map(lambda x: np.expand_dims(x, axis=0), self.intercept_)
         try:
             score = super().score(X, y, score_type=score_type)
         finally:
-            self.coef_ = jax.tree_map(lambda x: jnp.atleast_1d(np.squeeze(x)), self.coef_)
-            self.intercept_ = jax.tree_map(np.squeeze, self.intercept_)
+            self.coef_ = jax.tree_util.tree_map(lambda x: jnp.atleast_1d(np.squeeze(x)), self.coef_)
+            self.intercept_ = jax.tree_util.tree_map(np.squeeze, self.intercept_)
         return score
 
     @staticmethod
@@ -157,8 +157,8 @@ class GLM(nmo.glm.GLM):
             ):
                 raise ValueError(
                     "Inconsistent number of features. "
-                    f"spike basis coefficients has {jax.tree_map(lambda p: p.shape[1], params[0])} features, "
-                    f"X has {jax.tree_map(lambda x: x.shape[2], X)} features instead!"
+                    f"spike basis coefficients has {jax.tree_util.tree_map(lambda p: p.shape[1], params[0])} features, "
+                    f"X has {jax.tree_util.tree_map(lambda x: x.shape[2], X)} features instead!"
                 )
 
     @staticmethod
@@ -178,7 +178,7 @@ class GLM(nmo.glm.GLM):
             raise ValueError("Params must have length two.")
 
         try:
-            params = jax.tree_map(lambda x: jnp.asarray(x, dtype=data_type), params)
+            params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, dtype=data_type), params)
         except (ValueError, TypeError):
             raise TypeError(
                 "Initial parameters must be array-like objects (or pytrees of array-like objects) "
@@ -206,7 +206,7 @@ class GLM(nmo.glm.GLM):
     @staticmethod
     def _check_input_n_timepoints(X: Union[nmo.pytrees.FeaturePytree, jnp.ndarray], y: jnp.ndarray):
         if nmo.utils.pytree_map_and_reduce(
-                lambda x: jax.tree_map(lambda array: y.shape[0] != array.shape[0], x),
+                lambda x: jax.tree_util.tree_map(lambda array: y.shape[0] != array.shape[0], x),
                 any,
                 X
                 ):

--- a/docs/neural_modeling/examples_utils/plotting.py
+++ b/docs/neural_modeling/examples_utils/plotting.py
@@ -654,7 +654,7 @@ class PlotSlidingWindow():
 
     @staticmethod
     def set_lines_visible(line_tree, visible: bool):
-        jax.tree_map(lambda line: line.set_visible(visible), line_tree)
+        jax.tree_util.tree_map(lambda line: line.set_visible(visible), line_tree)
 
     def run(self):
         anim = FuncAnimation(self.fig, self.update_fig, self.n_shift, interval=self.interval, repeat=True)

--- a/src/nemos/base_class.py
+++ b/src/nemos/base_class.py
@@ -288,7 +288,7 @@ class BaseRegressor(Base, abc.ABC):
         validation.error_all_invalid(X, y)
 
         # validate input and params consistency
-        self._check_params(init_params)
+        init_params = self._check_params(init_params)
 
         # validate input
         validation.warn_invalid_entry(X, y)

--- a/src/nemos/convolve.py
+++ b/src/nemos/convolve.py
@@ -171,7 +171,7 @@ def _convolve_pad_and_shift(
     def conv(x):
         return _shift_time_axis_and_convolve(x, basis_matrix, axis=axis)
 
-    predictor = jax.tree_map(conv, time_series)
+    predictor = jax.tree_util.tree_map(conv, time_series)
 
     with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
@@ -300,13 +300,13 @@ def create_convolutional_predictor(
     ]
 
     # split epochs (adds one layer to pytree)
-    two_layer = jax.tree_map(_list_epochs, flat_tree)
+    two_layer = jax.tree_util.tree_map(_list_epochs, flat_tree)
 
     # check trial size (after splitting)
     utils.check_trials_longer_than_time_window(two_layer, basis_matrix.shape[0], axis)
 
     # convert to array
-    two_layer = jax.tree_map(jnp.asarray, two_layer)
+    two_layer = jax.tree_util.tree_map(jnp.asarray, two_layer)
 
     # convolve
     conv = _convolve_pad_and_shift(

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -693,7 +693,7 @@ class PopulationGLM(GLM):
     combination of exogenous inputs (like convolved currents or light intensities) and a choice of observation model.
     It is suitable for scenarios where the relationship between predictors and the response
     variable might be non-linear, and the residuals  don't follow a normal distribution. The predictors must be
-    stored in tabular format, shape (num_samples, num_features) or as [FeaturePytree](../pytrees).
+    stored in tabular format, shape (n_timebins, num_features) or as [FeaturePytree](../pytrees).
 
     Parameters
     ----------
@@ -957,10 +957,10 @@ class PopulationGLM(GLM):
         Parameters
         ----------
         X :
-            Predictors, array of shape (n_time_bins, n_features) or pytree of the same
+            Predictors, array of shape (n_timebins, n_features) or pytree of the same
             shape.
         y :
-            Target neural activity arranged in a matrix, shape (n_time_bins, n_neurons).
+            Target neural activity arranged in a matrix, shape (n_timebins, n_neurons).
         init_params :
             2-tuple of initial parameter values: (coefficients, intercepts). If
             None, we initialize coefficients with zeros, intercepts with the
@@ -1032,7 +1032,7 @@ class PopulationGLM(GLM):
         Returns
         -------
         :
-            The predicted rates. Shape (n_time_bins, ).
+            The predicted rates. Shape (n_timebins, n_neurons).
         """
         Ws, bs = params
         return self._observation_model.inverse_link_function(

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -949,7 +949,7 @@ class PopulationGLM(GLM):
     ):
         """Fit GLM to the activity of a population of neurons.
 
-        Fit and store the model parameters as attributes `coef_` and ``coef_``.
+        Fit and store the model parameters as attributes `coef_` and `intercept_`.
         Each neuron can have different predictors. tThe `feature_mask` will determine which
         feature will be used for which neurons. See the note below for more information on
         the `feature_mask`.

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -905,11 +905,12 @@ class PopulationGLM(GLM):
         """
         Predicts firing rates based on given parameters and design matrix.
 
-        This function computes the predicted firing rates using the provided parameters
-        and model design matrix `X`. It is a streamlined version used internally within
+        This function computes the predicted firing rates using the provided parameters, the feature
+        mask and model design matrix `X`. It is a streamlined version used internally within
         optimization routines, where it serves as the loss function. Unlike the `GLM.predict`
         method, it does not perform any input validation, assuming that the inputs are pre-validated.
-
+        The parameters are first element-wise multiplied with the mask, then the canonical
+        linear-non-linear GLM map is applied.
 
         Parameters
         ----------

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -508,7 +508,7 @@ class GLM(BaseRegressor):
             #   n_features), this will be an array of shape (n_features,).
             jax.tree_map(lambda x: jnp.zeros((*x[0].shape, *y.shape[1:])), data),
             # intercept, bias terms, keepdims=False needed by PopulationGLM
-            jnp.atleast_1d(jnp.log(jnp.mean(y, axis=0))),
+            jnp.atleast_1d(jnp.log(jnp.mean(y, axis=0, keepdims=False))),
         )
         return init_params
 

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -899,7 +899,7 @@ class PopulationGLM(GLM):
                         f"params[0] is of {jax.tree_util.tree_structure(params[0])} structure instead!",
         )
         if isinstance(params[0], dict):
-            neural_axis = 0
+            neural_axis = 1
         else:
             neural_axis = 1
             # check the consistency of the feature axis

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -507,8 +507,8 @@ class GLM(BaseRegressor):
             # - If X is an array of shape (n_timebins,
             #   n_features), this will be an array of shape (n_features,).
             jax.tree_map(lambda x: jnp.zeros((*x[0].shape, *y.shape[1:])), data),
-            # intercept, bias terms
-            jnp.log(jnp.mean(y, axis=0, keepdims=False)),
+            # intercept, bias terms, keepdims=False needed by PopulationGLM
+            jnp.atleast_1d(jnp.log(jnp.mean(y, axis=0))),
         )
         return init_params
 

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -739,15 +739,13 @@ class PopulationGLM(GLM):
         return self._feature_mask
 
     @feature_mask.setter
+    @cast_to_jax
     def feature_mask(self, feature_mask: Union[DESIGN_INPUT_TYPE, dict]):
         # do not allow reassignment after fit
         if (self.coef_ is not None) and (self.intercept_ is not None):
             raise AttributeError(
                 "property 'feature_mask' of 'populationGLM' cannot be set after fitting."
             )
-        feature_mask = jax.tree_util.tree_map(
-            lambda x: jnp.asarray(x, dtype=float), feature_mask
-        )
 
         # check if the mask is of 0s and 1s
         if tree_utils.pytree_map_and_reduce(
@@ -761,7 +759,7 @@ class PopulationGLM(GLM):
             raise_exception = False
         elif isinstance(feature_mask, (FeaturePytree, dict)):
             raise_exception = tree_utils.pytree_map_and_reduce(
-                lambda x: x.ndim != 1, any, feature_mask
+                lambda x: x.ndim != 1 if hasattr(x, "ndim") else True, any, feature_mask
             )
         elif hasattr(feature_mask, "ndim"):
             raise_exception = feature_mask.ndim != 2

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -722,6 +722,7 @@ class PopulationGLM(GLM):
         - If provided `regularizer` or `observation_model` are not valid.
         - If provided `feature_mask` is not an array-like of dimension two.
     """
+
     def __init__(
         self,
         observation_model: obs.Observations = obs.PoissonObservations(),
@@ -745,7 +746,9 @@ class PopulationGLM(GLM):
         feature_mask = jax.tree_map(lambda x: jnp.asarray(x, dtype=float), feature_mask)
 
         # check if the mask is of 0s and 1s
-        if tree_utils.pytree_map_and_reduce(lambda x: jnp.any(jnp.logical_and(x != 0, x != 1)), any, feature_mask):
+        if tree_utils.pytree_map_and_reduce(
+            lambda x: jnp.any(jnp.logical_and(x != 0, x != 1)), any, feature_mask
+        ):
             raise ValueError("'feature_mask' must contain only 0s and 1s!")
 
         # check the mask type and ndim
@@ -753,15 +756,19 @@ class PopulationGLM(GLM):
             self._feature_mask = feature_mask
             raise_exception = False
         elif isinstance(feature_mask, (FeaturePytree, dict)):
-            raise_exception = tree_utils.pytree_map_and_reduce(lambda x: x.ndim != 1, any, feature_mask)
+            raise_exception = tree_utils.pytree_map_and_reduce(
+                lambda x: x.ndim != 1, any, feature_mask
+            )
         elif hasattr(feature_mask, "ndim"):
             raise_exception = feature_mask.ndim != 2
         else:
             raise_exception = True
 
         if raise_exception:
-            raise ValueError("'feature_mask' of 'populationGLM' must be a 2-dimensional array, (n_features, n_neurons) "
-                             "or a `FeaturePytree` of shape (n_neurons, ).")
+            raise ValueError(
+                "'feature_mask' of 'populationGLM' must be a 2-dimensional array, (n_features, n_neurons) "
+                "or a `FeaturePytree` of shape (n_neurons, )."
+            )
 
         self._feature_mask = feature_mask
 
@@ -823,7 +830,9 @@ class PopulationGLM(GLM):
             err_message="params[1] must be of shape (n_neurons,) but "
             f"params[1] has {params[1].ndim} dimensions!",
         )
-        if tree_utils.pytree_map_and_reduce(lambda x: x.shape[1] != params[1].shape[0], all, params[0]):
+        if tree_utils.pytree_map_and_reduce(
+            lambda x: x.shape[1] != params[1].shape[0], all, params[0]
+        ):
             raise ValueError(
                 "Inconsistent number of neurons. "
                 f"The intercept assumes {params[1].shape[0]} neurons, "
@@ -900,8 +909,8 @@ class PopulationGLM(GLM):
                 data,
                 self.feature_mask,
                 err_message=f"feature_mask and X must have the same structure, but feature_mask has structure  "
-                            f"{jax.tree_util.tree_structure(X)}, params[0] is of "
-                            f"{jax.tree_util.tree_structure(self.feature_mask)} structure instead!",
+                f"{jax.tree_util.tree_structure(X)}, params[0] is of "
+                f"{jax.tree_util.tree_structure(self.feature_mask)} structure instead!",
             )
 
         if isinstance(params[0], dict):
@@ -915,8 +924,8 @@ class PopulationGLM(GLM):
                 axis_1=0,
                 axis_2=0,
                 err_message="Inconsistent number of features. "
-                            f"feature_mask has {jax.tree_map(lambda m: m.shape[0], self.feature_mask)} neurons, "
-                            f"model coefficients have {jax.tree_map(lambda x: x.shape[1], X)}  instead!",
+                f"feature_mask has {jax.tree_map(lambda m: m.shape[0], self.feature_mask)} neurons, "
+                f"model coefficients have {jax.tree_map(lambda x: x.shape[1], X)}  instead!",
             )
         # check the consistency of the feature axis
         validation.check_tree_axis_consistency(
@@ -925,8 +934,8 @@ class PopulationGLM(GLM):
             axis_1=neural_axis,
             axis_2=1,
             err_message="Inconsistent number of neurons. "
-                        f"feature_mask has {jax.tree_map(lambda m: m.shape[neural_axis], self.feature_mask)} neurons, "
-                        f"model coefficients have {jax.tree_map(lambda x: x.shape[1], X)}  instead!",
+            f"feature_mask has {jax.tree_map(lambda m: m.shape[neural_axis], self.feature_mask)} neurons, "
+            f"model coefficients have {jax.tree_map(lambda x: x.shape[1], X)}  instead!",
         )
 
     @cast_to_jax
@@ -989,15 +998,12 @@ class PopulationGLM(GLM):
             # static checker does not realize conversion to ndarray happened in cast_to_jax.
             if isinstance(X, FeaturePytree):
                 self._feature_mask = jax.tree_map(
-                    lambda x: jnp.ones((y.shape[1], )), X.data
+                    lambda x: jnp.ones((y.shape[1],)), X.data
                 )
             elif isinstance(X, dict):
-                self._feature_mask = jax.tree_map(
-                    lambda x: jnp.ones((y.shape[1],)), X
-                )
+                self._feature_mask = jax.tree_map(lambda x: jnp.ones((y.shape[1],)), X)
             else:
                 self._feature_mask = jnp.ones((X.shape[1], y.shape[1]))
-
 
     def _predict(
         self, params: Tuple[DESIGN_INPUT_TYPE, jnp.ndarray], X: jnp.ndarray
@@ -1034,5 +1040,3 @@ class PopulationGLM(GLM):
             )
             + bs
         )
-
-

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -950,7 +950,7 @@ class PopulationGLM(GLM):
         """Fit GLM to the activity of a population of neurons.
 
         Fit and store the model parameters as attributes `coef_` and `intercept_`.
-        Each neuron can have different predictors. tThe `feature_mask` will determine which
+        Each neuron can have different predictors. The `feature_mask` will determine which
         feature will be used for which neurons. See the note below for more information on
         the `feature_mask`.
 

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -502,9 +502,9 @@ class GLM(BaseRegressor):
             #   dict with n_features arrays of shape (n_features,).
             # - If X is an array of shape (n_timebins,
             #   n_features), this will be an array of shape (n_features,).
-            jax.tree_map(lambda x: jnp.zeros_like(x[0]), data),
+            jax.tree_map(lambda x: jnp.zeros((*x[0].shape, *y.shape[1:])), data),
             # intercept, bias terms
-            jax.tree_map(lambda x: jnp.log(jnp.mean(x, axis=0, keepdims=True)), y),
+            jnp.log(jnp.mean(y, axis=0, keepdims=False)),
         )
         return init_params
 
@@ -693,7 +693,7 @@ class PopulationGLM(GLM):
 
     @feature_mask.setter
     def feature_mask(self, feature_mask: jax.numpy.ndarray):
-        if self._check_is_fit():
+        if (self.coef_ is not None) and (self.intercept_ is not None):
             raise AttributeError("property 'feature_mask' of 'populationGLM' cannot be set fitting.")
         if feature_mask.ndim != 2:
             raise ValueError("'feature_mask' of 'populationGLM' must be 2-dimensional, (n_features, n_neurons).")
@@ -832,7 +832,7 @@ class PopulationGLM(GLM):
     def fit(self,
         X: Union[DESIGN_INPUT_TYPE, ArrayLike],
         y: ArrayLike,
-        init_params: Optional[Tuple[Union[dict, ArrayLike], ArrayLike]] = None,):
+        init_params: Optional[Tuple[Union[dict, ArrayLike], ArrayLike]] = None):
 
         self._initialize_feature_mask(X, y)
 

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -739,7 +739,7 @@ class PopulationGLM(GLM):
     def feature_mask(self, feature_mask: Union[DESIGN_INPUT_TYPE, dict]):
         if (self.coef_ is not None) and (self.intercept_ is not None):
             raise AttributeError(
-                "property 'feature_mask' of 'populationGLM' cannot be set fitting."
+                "property 'feature_mask' of 'populationGLM' cannot be set after fitting."
             )
         # check the mask type and ndim
         if feature_mask is None:
@@ -981,7 +981,7 @@ class PopulationGLM(GLM):
     def _initialize_feature_mask(self, X, y):
         if self.feature_mask is None:
             # static checker does not realize conversion to ndarray happened in cast_to_jax.
-            self.feature_mask = jax.tree_map(
+            self._feature_mask = jax.tree_map(
                 lambda x: jnp.ones((x.shape[1], y.shape[1])), X
             )
 

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -987,10 +987,10 @@ class PopulationGLM(GLM):
         The `feature_mask` is used to select features for each neuron, and it is
         an NDArray or a `FeaturePytree` of 0s and 1s. In particular,
 
-        - If the mask is in array format, feature `j` is a predictor for neuron `i` if
+        - If the mask is in array format, feature `i` is a predictor for neuron `j` if
         `feature_mask[i, j] == 1`.
-        - If the mask is a `FeaturePytree`, then `"feature_name"` is a predictor of neuron `i` if
-        `feature_mask["feature_name"][i] == 1`.
+        - If the mask is a `FeaturePytree`, then `"feature_name"` is a predictor of neuron `j` if
+        `feature_mask["feature_name"][j] == 1`.
 
         """
         return super().fit(X, y, init_params)

--- a/src/nemos/proximal_operator.py
+++ b/src/nemos/proximal_operator.py
@@ -65,9 +65,11 @@ def _norm2_masked(weight_neuron: jnp.ndarray, mask: jnp.ndarray) -> jnp.ndarray:
     return jnp.linalg.norm(weight_neuron * mask, 2) / jnp.sqrt(mask.sum())
 
 
-# # vectorize the norm function above
-# [(n_features), (n_groups, n_features)] -> (n_groups, )
-_vmap_norm2_masked = jax.vmap(_norm2_masked, in_axes=(None, 0), out_axes=0)
+# vectorize the norm function above
+# [(n_neurons, n_features), (n_features)] -> (n_neurons, )
+_vmap_norm2_masked_1 = jax.vmap(_norm2_masked, in_axes=(0, None), out_axes=0)
+# [(n_neurons, n_features), (n_groups, n_features)] -> (n_neurons, n_groups)
+_vmap_norm2_masked_2 = jax.vmap(_vmap_norm2_masked_1, in_axes=(None, 0), out_axes=1)
 
 
 def prox_group_lasso(
@@ -81,8 +83,8 @@ def prox_group_lasso(
     Parameters
     ----------
     params:
-        Weights, shape (n_features, ) or pytree of same; intercept,
-        shape (1, ).
+        Weights, shape (n_neurons, n_features) or pytree of same; intercept,
+        shape (n_neurons, )
     regularizer_strength:
         The regularization hyperparameter.
     mask:
@@ -130,11 +132,13 @@ def prox_group_lasso(
 
     """
     weights, intercepts = params
-    # [(n_features), (n_groups, n_features)] -> (n_groups)
-    l2_norm = _vmap_norm2_masked(weights, mask)
+    # add an extra dim if not 2D, do nothing otherwise.
+    weights = jnp.atleast_2d(weights.T)
+    # [(n_neurons, n_features), (n_groups, n_features)] -> (n_neurons, n_groups)
+    l2_norm = _vmap_norm2_masked_2(weights, mask)
     factor = 1 - regularizer_strength * scaling / l2_norm
     factor = jax.nn.relu(factor)
     # Avoid shrinkage of features that do not belong to any group
     # by setting the shrinkage factor to 1.
-    not_regularized = 1 - mask.sum(axis=0)
-    return weights * (factor @ mask + not_regularized), intercepts
+    not_regularized = jnp.outer(jnp.ones(factor.shape[0]), 1 - mask.sum(axis=0))
+    return jnp.squeeze(weights * (factor @ mask + not_regularized)).T, intercepts

--- a/src/nemos/proximal_operator.py
+++ b/src/nemos/proximal_operator.py
@@ -132,6 +132,8 @@ def prox_group_lasso(
 
     """
     weights, intercepts = params
+    # divide the reg strength by the number of neurons
+    regularizer_strength /= intercepts.shape[0]
     # add an extra dim if not 2D, do nothing otherwise.
     weights = jnp.atleast_2d(weights.T)
     # [(n_neurons, n_features), (n_groups, n_features)] -> (n_neurons, n_groups)

--- a/src/nemos/pytrees.py
+++ b/src/nemos/pytrees.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import warnings
 from collections import UserDict
 
 import jax

--- a/src/nemos/pytrees.py
+++ b/src/nemos/pytrees.py
@@ -92,8 +92,4 @@ class FeaturePytree(UserDict):
         try:
             return cls(**jax.tree_util.tree_unflatten(aux_data, children))
         except ValueError:
-            warnings.warn(
-                "Output is not a FeaturePytree (e.g., because at least one "
-                "value is not an array), returning dict instead"
-            )
             return jax.tree_util.tree_unflatten(aux_data, children)

--- a/src/nemos/pytrees.py
+++ b/src/nemos/pytrees.py
@@ -16,7 +16,7 @@ class FeaturePytree(UserDict):
     n-dimensional array-like objects as its values. FeaturePytree objects can
     only have a depth of 1, and we allow joint slicing.
 
-    This is intended to be used with jax.tree_map and similar functionality.
+    This is intended to be used with jax.tree_util.tree_map and similar functionality.
 
     """
 
@@ -68,7 +68,7 @@ class FeaturePytree(UserDict):
             return self.data[key]
         # Or the time dimension
         else:
-            return jax.tree_map(lambda x: x[key], self)
+            return jax.tree_util.tree_map(lambda x: x[key], self)
 
     def __repr__(self):
         # Show the shape and data type of each array

--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -429,6 +429,7 @@ class Lasso(ProxGradientRegularizer):
 
         def prox_op(params, l1reg, scaling=1.0):
             Ws, bs = params
+            l1reg /= bs.shape[0]
             # if Ws is a pytree, l1reg needs to be a pytree with the same
             # structure
             if isinstance(Ws, (dict, FeaturePytree)):

--- a/src/nemos/simulation.py
+++ b/src/nemos/simulation.py
@@ -224,7 +224,7 @@ def simulate_recurrent(
     coupling_coef = jnp.asarray(coupling_coef, dtype=float)
     feedforward_coef = jnp.asarray(feedforward_coef, dtype=float)
     intercepts = jnp.asarray(intercepts, dtype=float)
-    feedforward_input = jax.tree_map(
+    feedforward_input = jax.tree_util.tree_map(
         lambda x: jnp.asarray(x, dtype=float), feedforward_input
     )
     init_y = jnp.asarray(init_y, dtype=float)
@@ -255,8 +255,8 @@ def simulate_recurrent(
         axis_1=1,
         axis_2=2,
         err_message="Inconsistent number of features. "
-        f"spike basis coefficients has {jax.tree_map(lambda p: p.shape[0], feedforward_coef)} features, "
-        f"X has {jax.tree_map(lambda x: x.shape[2], feedforward_input)} features instead!",
+        f"spike basis coefficients has {jax.tree_util.tree_map(lambda p: p.shape[0], feedforward_coef)} features, "
+        f"X has {jax.tree_util.tree_map(lambda x: x.shape[2], feedforward_input)} features instead!",
     )
 
     validation.error_invalid_entry(feedforward_input)

--- a/src/nemos/tree_utils.py
+++ b/src/nemos/tree_utils.py
@@ -71,7 +71,7 @@ def _get_valid_tree(tree: Any) -> jnp.ndarray:
         while False indicates an invalid (NaN or infinite) entry.
     """
     valid = jax.tree_util.tree_leaves(
-        jax.tree_map(lambda x: _get_not_inf(x) & _get_not_nan(x), tree)
+        jax.tree_util.tree_map(lambda x: _get_not_inf(x) & _get_not_nan(x), tree)
     )
     return reduce(jnp.logical_and, valid)
 
@@ -137,6 +137,6 @@ def pytree_map_and_reduce(
     >>> # Example usage
     >>> result_any = pytree_map_and_reduce(map_fn, any, pytree1, pytree2)
     """
-    cond_tree = jax.tree_map(map_fn, *pytrees, is_leaf=is_leaf)
+    cond_tree = jax.tree_util.tree_map(map_fn, *pytrees, is_leaf=is_leaf)
     # for some reason, tree_reduce doesn't work well with any.
     return reduce_fn(jax.tree_util.tree_leaves(cond_tree))

--- a/src/nemos/type_casting.py
+++ b/src/nemos/type_casting.py
@@ -230,7 +230,9 @@ def get_time_info(*args, **kwargs):
         Time axis and support information of the first pynapple object detected.
     """
     # list of bool
-    flat, _ = jax.tree_util.tree_flatten(jax.tree_map(is_pynapple_tsd, (args, kwargs)))
+    flat, _ = jax.tree_util.tree_flatten(
+        jax.tree_util.tree_map(is_pynapple_tsd, (args, kwargs))
+    )
 
     idx = flat.index(True)
 
@@ -372,7 +374,7 @@ def support_pynapple(conv_type: Literal["jax", "numpy"] = "jax") -> Callable:
 
                 def cast_out(tree):
                     # cast back to pynapple
-                    return jax.tree_map(
+                    return jax.tree_util.tree_map(
                         lambda x: cast_to_pynapple(x, time, time_support), tree
                     )
 
@@ -382,10 +384,10 @@ def support_pynapple(conv_type: Literal["jax", "numpy"] = "jax") -> Callable:
 
             if conv_type == "jax":
                 # cast to jax
-                args, kwargs = jax.tree_map(jnp_asarray_if, (args, kwargs))
+                args, kwargs = jax.tree_util.tree_map(jnp_asarray_if, (args, kwargs))
             elif conv_type == "numpy":
                 # cast to numpy
-                args, kwargs = jax.tree_map(np_asarray_if, (args, kwargs))
+                args, kwargs = jax.tree_util.tree_map(np_asarray_if, (args, kwargs))
             else:
                 raise NotImplementedError(
                     f"Conversion of type '{conv_type}' not implemented!"

--- a/src/nemos/type_casting.py
+++ b/src/nemos/type_casting.py
@@ -276,7 +276,7 @@ def cast_to_pynapple(
 def jnp_asarray_if(
     x: Any,
     condition: Callable[[Any], bool] = is_numpy_array_like,
-    dtype: type = Optional[Type],
+    dtype: Optional[Type] = None,
 ) -> Any:
     """
     Conditionally convert an object to a JAX array.

--- a/src/nemos/type_casting.py
+++ b/src/nemos/type_casting.py
@@ -274,7 +274,9 @@ def cast_to_pynapple(
 
 
 def jnp_asarray_if(
-    x: Any, condition: Callable[[Any], bool] = is_numpy_array_like, dtype: type = Optional[Type]
+    x: Any,
+    condition: Callable[[Any], bool] = is_numpy_array_like,
+    dtype: type = Optional[Type],
 ) -> Any:
     """
     Conditionally convert an object to a JAX array.

--- a/src/nemos/type_casting.py
+++ b/src/nemos/type_casting.py
@@ -10,7 +10,7 @@ to JAX arrays and, where applicable, converts outputs back to pynapple TSD objec
 """
 
 from functools import wraps
-from typing import Any, Callable, List, Literal, Union
+from typing import Any, Callable, List, Literal, Optional, Type, Union
 
 import jax
 import jax.numpy as jnp
@@ -274,7 +274,7 @@ def cast_to_pynapple(
 
 
 def jnp_asarray_if(
-    x: Any, condition: Callable[[Any], bool] = is_numpy_array_like
+    x: Any, condition: Callable[[Any], bool] = is_numpy_array_like, dtype: type = Optional[Type]
 ) -> Any:
     """
     Conditionally convert an object to a JAX array.
@@ -288,6 +288,8 @@ def jnp_asarray_if(
         Object to potentially convert.
     condition:
         A callable that determines whether conversion should occur.
+    dtype:
+        dtype for the conversion.
 
     Returns
     -------
@@ -295,7 +297,7 @@ def jnp_asarray_if(
         The original object or its conversion to a JAX array, based on the condition.
     """
     if condition(x):
-        x = jnp.asarray(x)
+        x = jnp.asarray(x, dtype=dtype)
     return x
 
 

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -261,7 +261,7 @@ def nan_pad(
         )
 
     # convert to jax ndarray
-    conv_time_series = jax.tree_map(jnp.asarray, conv_time_series)
+    conv_time_series = jax.tree_util.tree_map(jnp.asarray, conv_time_series)
 
     # validate the axis
     validate_axis(conv_time_series, axis)
@@ -284,7 +284,7 @@ def nan_pad(
             conv_time_series,
         ):
             raise ValueError("All leaves of conv_time_series must have a float dtype!")
-        return jax.tree_map(
+        return jax.tree_util.tree_map(
             lambda trial: _pad_dimension(
                 trial, axis, pad_size, predictor_causality, constant_values=jnp.nan
             ),
@@ -357,12 +357,12 @@ def shift_time_series(
         )
 
     # compute the start, end indices tree
-    adjust_idx = jax.tree_map(
+    adjust_idx = jax.tree_util.tree_map(
         lambda x: _compute_index_adjust(x, predictor_causality, axis), time_series
     )
 
     # convert to jax ndarray
-    time_series = jax.tree_map(jnp.asarray, time_series)
+    time_series = jax.tree_util.tree_map(jnp.asarray, time_series)
 
     if is_numpy_array_like(time_series):
 
@@ -380,7 +380,7 @@ def shift_time_series(
             lambda trial: not np.issubdtype(trial.dtype, np.floating), any, time_series
         ):
             raise ValueError("All leaves of time_series must have a float dtype!")
-        return jax.tree_map(
+        return jax.tree_util.tree_map(
             lambda trial, idx: _pad_dimension(
                 jnp.take(trial, jnp.arange(*idx), axis=axis),
                 axis,

--- a/src/nemos/validation.py
+++ b/src/nemos/validation.py
@@ -22,8 +22,12 @@ def warn_invalid_entry(*pytree: Any):
         dictionaries, or other containers, with leaves that are arrays.
 
     """
-    any_infs = pytree_map_and_reduce(jnp.any, any, jax.tree_map(jnp.isinf, pytree))
-    any_nans = pytree_map_and_reduce(jnp.any, any, jax.tree_map(jnp.isnan, pytree))
+    any_infs = pytree_map_and_reduce(
+        jnp.any, any, jax.tree_util.tree_map(jnp.isinf, pytree)
+    )
+    any_nans = pytree_map_and_reduce(
+        jnp.any, any, jax.tree_util.tree_map(jnp.isnan, pytree)
+    )
     if any_infs and any_nans:
         warnings.warn(
             message="The provided trees contain Infs and Nans!", category=UserWarning
@@ -49,8 +53,12 @@ def error_invalid_entry(*pytree: Any):
     ValueError
         If any NaN or Inf values are found in the provided pytrees.
     """
-    any_infs = pytree_map_and_reduce(jnp.any, any, jax.tree_map(jnp.isinf, pytree))
-    any_nans = pytree_map_and_reduce(jnp.any, any, jax.tree_map(jnp.isnan, pytree))
+    any_infs = pytree_map_and_reduce(
+        jnp.any, any, jax.tree_util.tree_map(jnp.isinf, pytree)
+    )
+    any_nans = pytree_map_and_reduce(
+        jnp.any, any, jax.tree_util.tree_map(jnp.isnan, pytree)
+    )
     if any_infs and any_nans:
         raise ValueError("The provided trees contain Infs and Nans!")
     elif any_infs:
@@ -132,7 +140,7 @@ def convert_tree_leaves_to_jax_array(
         to JAX arrays.
     """
     try:
-        tree = jax.tree_map(lambda x: jnp.asarray(x, dtype=data_type), tree)
+        tree = jax.tree_util.tree_map(lambda x: jnp.asarray(x, dtype=data_type), tree)
     except (ValueError, TypeError):
         raise TypeError(err_message)
     return tree

--- a/src/nemos/validation.py
+++ b/src/nemos/validation.py
@@ -184,19 +184,20 @@ def check_same_shape_on_axis(*arrays: NDArray, axis: int = 0, err_message: str):
 
 
 def check_array_shape_match_tree(
-    tree: Any, array: NDArray, axis: int, err_message: str
+    tree1: Any, tree2: Any, axis: Union[int, slice], err_message: str
 ):
     """
     Check if the shape of an array matches the shape of arrays in a pytree along a specified axis.
 
     Parameters
     ----------
-    tree :
+    tree1 :
         Pytree with arrays as leaves.
-    array :
-        Array to compare the shape with.
+    tree2 :
+        Pytree to compare the shape with.
     axis :
-        Axis along which to compare the shape.
+        Axis along which to compare the shape, could be a slice used to select elements of the shape
+        tuple.
     err_message :
         Error message to raise if the shapes do not match.
 
@@ -205,9 +206,9 @@ def check_array_shape_match_tree(
     ValueError
         If the array's shape does not match the pytree leaves' shapes along the specified axis.
     """
-    if pytree_map_and_reduce(
-        lambda arr: arr.shape[axis] != array.shape[axis], any, tree
-    ):
+    arr1 = jax.tree_util.tree_leaves(tree1)
+    arr2 = jax.tree_util.tree_leaves(tree2)
+    if any(arr.shape[axis] != arr2[k].shape[axis] for k, arr in enumerate(arr1)):
         raise ValueError(err_message)
 
 

--- a/src/nemos/validation.py
+++ b/src/nemos/validation.py
@@ -184,20 +184,19 @@ def check_same_shape_on_axis(*arrays: NDArray, axis: int = 0, err_message: str):
 
 
 def check_array_shape_match_tree(
-    tree1: Any, tree2: Any, axis: Union[int, slice], err_message: str
+    tree: Any, array: NDArray, axis: int, err_message: str
 ):
     """
     Check if the shape of an array matches the shape of arrays in a pytree along a specified axis.
 
     Parameters
     ----------
-    tree1 :
+    tree :
         Pytree with arrays as leaves.
-    tree2 :
-        Pytree to compare the shape with.
+    array :
+        Array to compare the shape with.
     axis :
-        Axis along which to compare the shape, could be a slice used to select elements of the shape
-        tuple.
+        Axis along which to compare the shape.
     err_message :
         Error message to raise if the shapes do not match.
 
@@ -206,9 +205,9 @@ def check_array_shape_match_tree(
     ValueError
         If the array's shape does not match the pytree leaves' shapes along the specified axis.
     """
-    arr1 = jax.tree_util.tree_leaves(tree1)
-    arr2 = jax.tree_util.tree_leaves(tree2)
-    if any(arr.shape[axis] != arr2[k].shape[axis] for k, arr in enumerate(arr1)):
+    if pytree_map_and_reduce(
+        lambda arr: arr.shape[axis] != array.shape[axis], any, tree
+    ):
         raise ValueError(err_message)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,37 @@ def group_sparse_poisson_glm_model_instantiation():
 
 
 @pytest.fixture
+def group_sparse_poisson_glm_population():
+    """Set up a Poisson GLM for testing purposes with group sparse weights.
+
+    This fixture initializes a Poisson GLM with random, group sparse, parameters, simulates its response, and
+    returns the test data, expected output, the model instance, true parameters, and the rate
+    of response
+
+    Returns:
+        tuple: A tuple containing:
+            - X (numpy.ndarray): Simulated input data.
+            - np.random.poisson(rate) (numpy.ndarray): Simulated spike responses.
+            - model (nmo.glm.PoissonGLM): Initialized model instance.
+            - (w_true, b_true) (tuple): True weight and bias parameters.
+            - rate (jax.numpy.ndarray): Simulated rate of response.
+    """
+    np.random.seed(123)
+    X = np.random.normal(size=(100, 5))
+    b_true = np.zeros((3,))
+    w_true = np.random.normal(size=(5, 3))
+    w_true[1:4, 0] = 0.0
+    mask = np.zeros((2, 5))
+    mask[0, 1:4] = 1
+    mask[1, [0, 4]] = 1
+    observation_model = nmo.observation_models.PoissonObservations(jnp.exp)
+    regularizer = nmo.regularizer.UnRegularized("GradientDescent", {})
+    model = nmo.glm.PopulationGLM(observation_model, regularizer)
+    rate = jax.numpy.exp(jax.numpy.einsum("k,tk->t", w_true, X) + b_true)
+    return X, np.random.poisson(rate), model, (w_true, b_true), rate, mask
+
+
+@pytest.fixture
 def example_data_prox_operator():
     n_features = 4
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,32 @@ def poissonGLM_model_instantiation():
 
 
 @pytest.fixture
+def poisson_population_GLM_model():
+    """Set up a population Poisson GLM for testing purposes.
+
+    This fixture initializes a Poisson GLM with random parameters, simulates its response, and
+    returns the test data, expected output, the model instance, true parameters, and the rate
+    of response.
+
+    Returns:
+        tuple: A tuple containing:
+            - X (numpy.ndarray): Simulated input data.
+            - np.random.poisson(rate) (numpy.ndarray): Simulated spike responses.
+            - model (nmo.glm.PoissonGLM): Initialized model instance.
+            - (w_true, b_true) (tuple): True weight and bias parameters.
+            - rate (jax.numpy.ndarray): Simulated rate of response.
+    """
+    np.random.seed(123)
+    X = np.random.normal(size=(100, 5))
+    b_true = np.zeros((3,))
+    w_true = np.random.normal(size=(5, 3))
+    observation_model = nmo.observation_models.PoissonObservations(jnp.exp)
+    regularizer = nmo.regularizer.UnRegularized("GradientDescent", {})
+    model = nmo.glm.PopulationGLM(observation_model, regularizer)
+    rate = jnp.exp(jnp.einsum("ki,tk->ti", w_true, X) + b_true)
+    return X, np.random.poisson(rate), model, (w_true, b_true), rate
+
+@pytest.fixture
 def poissonGLM_model_instantiation_pytree(poissonGLM_model_instantiation):
     """Set up a Poisson GLM for testing purposes.
 
@@ -336,3 +362,7 @@ def mock_data():
 @pytest.fixture()
 def glm_class():
     return nmo.glm.GLM
+
+@pytest.fixture()
+def population_glm_class():
+    return nmo.glm.PopulationGLM

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,6 +328,24 @@ def example_data_prox_operator():
 
 
 @pytest.fixture
+def example_data_prox_operator_multineuron():
+    n_features = 4
+    n_neurons = 3
+
+    params = (
+        jnp.ones((n_features, n_neurons)),
+        jnp.zeros(
+            n_neurons,
+        ),
+    )
+    regularizer_strength = 0.1
+    mask = jnp.array([[1, 0, 1, 0], [0, 1, 0, 1]], dtype=jnp.float32)
+    scaling = 0.5
+
+    return params, regularizer_strength, mask, scaling
+
+
+@pytest.fixture
 def poisson_observation_model():
     return nmo.observation_models.PoissonObservations(jnp.exp)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,33 @@ def poisson_population_GLM_model():
     rate = jnp.exp(jnp.einsum("ki,tk->ti", w_true, X) + b_true)
     return X, np.random.poisson(rate), model, (w_true, b_true), rate
 
+
+@pytest.fixture
+def poisson_population_GLM_model_pytree(poisson_population_GLM_model):
+    """Set up a population Poisson GLM for testing purposes.
+
+    This fixture initializes a Poisson GLM with random parameters, simulates its response, and
+    returns the test data, expected output, the model instance, true parameters, and the rate
+    of response.
+
+    Returns:
+        tuple: A tuple containing:
+            - X (numpy.ndarray): Simulated input data.
+            - np.random.poisson(rate) (numpy.ndarray): Simulated spike responses.
+            - model (nmo.glm.PoissonGLM): Initialized model instance.
+            - (w_true, b_true) (tuple): True weight and bias parameters.
+            - rate (jax.numpy.ndarray): Simulated rate of response.
+    """
+    X, spikes, model, true_params, rate = poisson_population_GLM_model
+    X_tree = nmo.pytrees.FeaturePytree(input_1=X[..., :3], input_2=X[..., 3:])
+    true_params_tree = (
+        dict(input_1=true_params[0][:3], input_2=true_params[0][3:]),
+        true_params[1],
+    )
+    model_tree = nmo.glm.PopulationGLM(model.observation_model, model.regularizer)
+    return X_tree, np.random.poisson(rate), model_tree, true_params_tree, rate
+
+
 @pytest.fixture
 def poissonGLM_model_instantiation_pytree(poissonGLM_model_instantiation):
     """Set up a Poisson GLM for testing purposes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,8 +173,8 @@ def poisson_population_GLM_model():
             - rate (jax.numpy.ndarray): Simulated rate of response.
     """
     np.random.seed(123)
-    X = np.random.normal(size=(100, 5))
-    b_true = np.zeros((3,))
+    X = np.random.normal(size=(500, 5))
+    b_true = -2 * np.ones((3,))
     w_true = np.random.normal(size=(5, 3))
     observation_model = nmo.observation_models.PoissonObservations(jnp.exp)
     regularizer = nmo.regularizer.UnRegularized("GradientDescent", {})

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2064,7 +2064,7 @@ class TestPopulationGLM:
                 coef_stack = coef_
                 return ind_array, coef_stack
 
-        mask_bool = jax.tree_map(lambda x: np.asarray(x.T, dtype=bool), mask)
+        mask_bool = jax.tree_util.tree_map(lambda x: np.asarray(x.T, dtype=bool), mask)
         # fit pop glm
         model.feature_mask = mask
         model.regularizer = regularizer

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -61,12 +61,12 @@ class TestGLM:
             ),
         ],
     )
-    def test_solver_type(self, regularizer, expectation, glm_class):
+    def test_solver_type(self, regularizer, expectation, population_glm_class):
         """
         Test that an error is raised if a non-compatible solver is passed.
         """
         with expectation:
-            glm_class(regularizer=regularizer)
+            population_glm_class(regularizer=regularizer)
 
     @pytest.mark.parametrize(
         "observation, expectation",
@@ -89,27 +89,27 @@ class TestGLM:
         ],
     )
     def test_init_observation_type(
-        self, observation, expectation, glm_class, ridge_regularizer
+        self, observation, expectation, population_glm_class, ridge_regularizer
     ):
         """
         Test initialization with different regularizer names. Check if an appropriate exception is raised
         when the regularizer name is not present in jaxopt.
         """
         with expectation:
-            glm_class(regularizer=ridge_regularizer, observation_model=observation)
+            population_glm_class(regularizer=ridge_regularizer, observation_model=observation)
 
     @pytest.mark.parametrize(
         "X, y",
         [
-            (jnp.zeros((2, 4)), jnp.zeros((2,))),
-            (jnp.zeros((2, 4)), jnp.zeros((2,))),
+            (jnp.zeros((2, 4)), jnp.zeros((2, 2))),
+            (jnp.zeros((2, 4)), jnp.zeros((2, 3))),
         ],
     )
-    def test_parameter_initialization(self, X, y, poissonGLM_model_instantiation):
-        _, _, model, _, _ = poissonGLM_model_instantiation
+    def test_parameter_initialization(self, X, y, poisson_population_GLM_model):
+        _, _, model, _, _ = poisson_population_GLM_model
         coef, inter = model._initialize_parameters(X, y)
-        assert coef.shape == (X.shape[1],)
-        assert inter.shape == (1,)
+        assert coef.shape == (X.shape[1], y.shape[1])
+        assert inter.shape == (y.shape[1],)
 
     #######################
     # Test model.fit
@@ -124,13 +124,13 @@ class TestGLM:
         ],
     )
     def test_fit_param_length(
-        self, n_params, expectation, poissonGLM_model_instantiation
+        self, n_params, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method with different numbers of initial parameters.
         Check for correct number of parameters.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         if n_params == 0:
             init_params = tuple()
         elif n_params == 1:
@@ -168,12 +168,12 @@ class TestGLM:
         ],
     )
     def test_fit_param_values(
-        self, add_entry, add_to, expectation, poissonGLM_model_instantiation
+        self, add_entry, add_to, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method with altered X or y values. Ensure the method raises exceptions for NaN or Inf values.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         if add_to == "X":
             # get an index to be edited
             idx = np.unravel_index(np.random.choice(X.size), X.shape)
@@ -192,19 +192,19 @@ class TestGLM:
                 0,
                 pytest.raises(
                     ValueError,
-                    match=r"Inconsistent number of features",
+                    match=r"params\[0\] must be an array or .* of shape \(n_features",
                 ),
             ),
             (
                 1,
-                does_not_raise(),
-            ),
-            (
-                2,
                 pytest.raises(
                     ValueError,
                     match=r"params\[0\] must be an array or .* of shape \(n_features",
                 ),
+            ),
+            (
+                2,
+                does_not_raise(),
             ),
             (
                 3,
@@ -216,15 +216,15 @@ class TestGLM:
         ],
     )
     def test_fit_weights_dimensionality(
-        self, dim_weights, expectation, poissonGLM_model_instantiation
+        self, dim_weights, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method with weight matrices of different dimensionalities.
         Check for correct dimensionality.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         n_samples, n_features = X.shape
-        n_neurons = 4
+        n_neurons = 3
         if dim_weights == 0:
             init_w = jnp.array([])
         elif dim_weights == 1:
@@ -246,38 +246,29 @@ class TestGLM:
         ],
     )
     def test_fit_intercepts_dimensionality(
-        self, dim_intercepts, expectation, poissonGLM_model_instantiation
+        self, dim_intercepts, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method with intercepts of different dimensionalities. Check for correct dimensionality.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         n_samples, n_features = X.shape
-        init_b = jnp.zeros((1,) * dim_intercepts)
-        init_w = jnp.zeros((n_features,))
+        init_b = jnp.zeros((y.shape[1],) * dim_intercepts)
+        init_w = jnp.zeros((n_features, y.shape[1]))
         with expectation:
             model.fit(X, y, init_params=(init_w, init_b))
 
     @pytest.mark.parametrize(
         "init_params, expectation",
         [
-            ([jnp.zeros((5,)), jnp.zeros((1,))], does_not_raise()),
+            ([jnp.zeros((5, 3)), jnp.zeros((3,))], does_not_raise()),
             (
-                [[jnp.zeros((1, 5)), jnp.zeros((1,))]],
+                [[jnp.zeros((1, 5)), jnp.zeros((3,))]],
                 pytest.raises(ValueError, match="Params must have length two."),
             ),
-            (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), pytest.raises(KeyError)),
+            (dict(p1=jnp.zeros((3, 3)), p2=jnp.zeros((3, 2))), pytest.raises(KeyError)),
             (
-                (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), jnp.zeros((1,))),
-                pytest.raises(
-                    TypeError, match=r"X and params\[0\] must be the same type"
-                ),
-            ),
-            (
-                (
-                    FeaturePytree(p1=jnp.zeros((5,)), p2=jnp.zeros((5,))),
-                    jnp.zeros((1,)),
-                ),
+                (dict(p1=jnp.zeros((3, 3)), p2=jnp.zeros((2, 3))), jnp.zeros((3,))),
                 pytest.raises(
                     TypeError, match=r"X and params\[0\] must be the same type"
                 ),
@@ -298,13 +289,13 @@ class TestGLM:
         ],
     )
     def test_fit_init_params_type(
-        self, init_params, expectation, poissonGLM_model_instantiation
+        self, init_params, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method with various types of initial parameters. Ensure that the provided initial parameters
         are array-like.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         with expectation:
             model.fit(X, y, init_params=init_params)
 
@@ -317,12 +308,12 @@ class TestGLM:
         ],
     )
     def test_fit_x_dimensionality(
-        self, delta_dim, expectation, poissonGLM_model_instantiation
+        self, delta_dim, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         if delta_dim == -1:
             X = np.zeros((X.shape[0],))
         elif delta_dim == 1:
@@ -333,22 +324,22 @@ class TestGLM:
     @pytest.mark.parametrize(
         "delta_dim, expectation",
         [
-            (-1, pytest.raises(ValueError, match="y must be one-dimensional")),
+            (-1, pytest.raises(ValueError, match="y must be two-dimensional")),
             (0, does_not_raise()),
-            (1, pytest.raises(ValueError, match="y must be one-dimensional")),
+            (1, pytest.raises(ValueError, match="y must be two-dimensional")),
         ],
     )
     def test_fit_y_dimensionality(
-        self, delta_dim, expectation, poissonGLM_model_instantiation
+        self, delta_dim, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method with y target data of different dimensionalities. Ensure correct dimensionality for y.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         if delta_dim == -1:
-            y = np.zeros([])
+            y = y[:, 0]
         elif delta_dim == 1:
-            y = np.zeros((y.shape[0], 1))
+            y = np.zeros((*y.shape, 1))
         with expectation:
             model.fit(X, y, init_params=true_params)
 
@@ -361,16 +352,16 @@ class TestGLM:
         ],
     )
     def test_fit_n_feature_consistency_weights(
-        self, delta_n_features, expectation, poissonGLM_model_instantiation
+        self, delta_n_features, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method for inconsistencies between data features and initial weights provided.
         Ensure the number of features align.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        init_w = jnp.zeros((X.shape[1] + delta_n_features))
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        init_w = jnp.zeros((X.shape[1] + delta_n_features, y.shape[1]))
         init_b = jnp.zeros(
-            1,
+            y.shape[1],
         )
         with expectation:
             model.fit(X, y, init_params=(init_w, init_b))
@@ -384,13 +375,13 @@ class TestGLM:
         ],
     )
     def test_fit_n_feature_consistency_x(
-        self, delta_n_features, expectation, poissonGLM_model_instantiation
+        self, delta_n_features, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method for inconsistencies between data features and model's expectations.
         Ensure the number of features in X aligns.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         if delta_n_features == 1:
             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
         elif delta_n_features == -1:
@@ -413,12 +404,12 @@ class TestGLM:
         ],
     )
     def test_fit_time_points_x(
-        self, delta_tp, expectation, poissonGLM_model_instantiation
+        self, delta_tp, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method for inconsistencies in time-points in data X. Ensure the correct number of time-points.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
         with expectation:
             model.fit(X, y, init_params=true_params)
@@ -438,515 +429,1432 @@ class TestGLM:
         ],
     )
     def test_fit_time_points_y(
-        self, delta_tp, expectation, poissonGLM_model_instantiation
+        self, delta_tp, expectation, poisson_population_GLM_model
     ):
         """
         Test the `fit` method for inconsistencies in time-points in y. Ensure the correct number of time-points.
         """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
         with expectation:
             model.fit(X, y, init_params=true_params)
 
-    def test_fit_mask_grouplasso(self, group_sparse_poisson_glm_model_instantiation):
-        """Test that the group lasso fit goes through"""
-        X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
-        model.set_params(
-            regularizer=nmo.regularizer.GroupLasso(
-                solver_name="ProximalGradient", mask=mask
-            )
-        )
-        model.fit(X, y)
-
-    def test_fit_pytree_equivalence(
-        self, poissonGLM_model_instantiation, poissonGLM_model_instantiation_pytree
-    ):
-        """Check that the glm fit with pytree learns the same parameters."""
-        # required for numerical precision of coeffs
-        jax.config.update("jax_enable_x64", True)
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        X_tree, _, model_tree, true_params_tree, _ = (
-            poissonGLM_model_instantiation_pytree
-        )
-        # fit both models
-        model.fit(X, y, init_params=true_params)
-        model_tree.fit(X_tree, y, init_params=true_params_tree)
-
-        # get the flat parameters
-        flat_coef = np.concatenate(
-            jax.tree_util.tree_flatten(model_tree.coef_)[0], axis=-1
-        )
-
-        # assert equivalence of solutions
-        assert np.allclose(model.coef_, flat_coef)
-        assert np.allclose(model.intercept_, model_tree.intercept_)
-        assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
-        assert np.allclose(model.predict(X), model_tree.predict(X_tree))
-
-    @pytest.mark.parametrize(
-        "fill_val, expectation",
-        [
-            (0, does_not_raise()),
-            (
-                jnp.inf,
-                pytest.raises(
-                    ValueError, match="At least a NaN or an Inf at all sample points"
-                ),
-            ),
-            (
-                jnp.nan,
-                pytest.raises(
-                    ValueError, match="At least a NaN or an Inf at all sample points"
-                ),
-            ),
-        ],
-    )
-    def test_fit_all_invalid_X(
-        self, fill_val, expectation, poissonGLM_model_instantiation
-    ):
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        X.fill(fill_val)
-        with expectation:
-            model.fit(X, y)
-
-    #######################
-    # Test model.score
-    #######################
-    @pytest.mark.parametrize(
-        "delta_dim, expectation",
-        [
-            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-            (0, does_not_raise()),
-            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-        ],
-    )
-    def test_score_x_dimensionality(
-        self, delta_dim, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `score` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        if delta_dim == -1:
-            X = np.zeros((X.shape[0],))
-        elif delta_dim == 1:
-            X = np.zeros((X.shape[0], X.shape[1], 1))
-        with expectation:
-            model.score(X, y)
-
-    @pytest.mark.parametrize(
-        "delta_dim, expectation",
-        [
-            (
-                -1,
-                pytest.raises(
-                    ValueError, match="y must be one-dimensional, with shape"
-                ),
-            ),
-            (0, does_not_raise()),
-            (
-                1,
-                pytest.raises(
-                    ValueError, match="y must be one-dimensional, with shape"
-                ),
-            ),
-        ],
-    )
-    def test_score_y_dimensionality(
-        self, delta_dim, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `score` method with y of different dimensionalities.
-        Ensure correct dimensionality for y.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        if delta_dim == -1:
-            y = np.zeros([])
-        elif delta_dim == 1:
-            y = np.zeros((X.shape[0], X.shape[1]))
-        with expectation:
-            model.score(X, y)
-
-    @pytest.mark.parametrize(
-        "delta_n_features, expectation",
-        [
-            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-            (0, does_not_raise()),
-            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-        ],
-    )
-    def test_score_n_feature_consistency_x(
-        self, delta_n_features, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `score` method for inconsistencies in features of X.
-        Ensure the number of features in X aligns with the model params.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        if delta_n_features == 1:
-            X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
-        elif delta_n_features == -1:
-            X = X[..., :-1]
-        with expectation:
-            model.score(X, y)
-
-    @pytest.mark.parametrize(
-        "is_fit, expectation",
-        [
-            (True, does_not_raise()),
-            (
-                False,
-                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-            ),
-        ],
-    )
-    def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-        """
-        Test the `score` method on models based on their fit status.
-        Ensure scoring is only possible on fitted models.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        if is_fit:
-            model.fit(X, y)
-        with expectation:
-            model.predict(X)
-
-    @pytest.mark.parametrize(
-        "delta_tp, expectation",
-        [
-            (
-                -1,
-                pytest.raises(ValueError, match="The number of time-points in X and y"),
-            ),
-            (0, does_not_raise()),
-            (
-                1,
-                pytest.raises(ValueError, match="The number of time-points in X and y"),
-            ),
-        ],
-    )
-    def test_score_time_points_x(
-        self, delta_tp, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `score` method for inconsistencies in time-points in X.
-        Ensure that the number of time-points in X and y matches.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
-        with expectation:
-            model.score(X, y)
-
-    @pytest.mark.parametrize(
-        "delta_tp, expectation",
-        [
-            (
-                -1,
-                pytest.raises(ValueError, match="The number of time-points in X and y"),
-            ),
-            (0, does_not_raise()),
-            (
-                1,
-                pytest.raises(ValueError, match="The number of time-points in X and y"),
-            ),
-        ],
-    )
-    def test_score_time_points_y(
-        self, delta_tp, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `score` method for inconsistencies in time-points in y.
-        Ensure that the number of time-points in X and y matches.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
-        with expectation:
-            model.score(X, y)
-
-    @pytest.mark.parametrize(
-        "score_type, expectation",
-        [
-            ("pseudo-r2-McFadden", does_not_raise()),
-            ("pseudo-r2-Cohen", does_not_raise()),
-            ("log-likelihood", does_not_raise()),
-            (
-                "not-implemented",
-                pytest.raises(
-                    NotImplementedError,
-                    match="Scoring method not-implemented not implemented",
-                ),
-            ),
-        ],
-    )
-    def test_score_type_r2(
-        self, score_type, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `score` method for unsupported scoring types.
-        Ensure only valid score types are used.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        with expectation:
-            model.score(X, y, score_type=score_type)
-
-    def test_loglikelihood_against_scipy_stats(self, poissonGLM_model_instantiation):
-        """
-        Compare the model's log-likelihood computation against `jax.scipy`.
-        Ensure consistent and correct calculations.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        # set model coeff
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        # get the rate
-        mean_firing = model.predict(X)
-        # compute the log-likelihood using jax.scipy
-        mean_ll_jax = jax.scipy.stats.poisson.logpmf(y, mean_firing).mean()
-        model_ll = model.score(X, y, score_type="log-likelihood")
-        if not np.allclose(mean_ll_jax, model_ll):
-            raise ValueError(
-                "Log-likelihood of PoissonModel does not match" "that of jax.scipy!"
-            )
-
-    #######################
-    # Test model.predict
-    #######################
-    @pytest.mark.parametrize(
-        "delta_dim, expectation",
-        [
-            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-            (0, does_not_raise()),
-            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-        ],
-    )
-    def test_predict_x_dimensionality(
-        self, delta_dim, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `predict` method with x input data of different dimensionalities.
-        Ensure correct dimensionality for x.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        if delta_dim == -1:
-            X = np.zeros((X.shape[0],))
-        elif delta_dim == 1:
-            X = np.zeros((X.shape[0], X.shape[1], 1))
-        with expectation:
-            model.predict(X)
-
-    @pytest.mark.parametrize(
-        "delta_n_features, expectation",
-        [
-            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-            (0, does_not_raise()),
-            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-        ],
-    )
-    def test_predict_n_feature_consistency_x(
-        self, delta_n_features, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `predict` method ensuring the number of features in x input data
-        is consistent with the model's `model.coef_`.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        if delta_n_features == 1:
-            X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
-        elif delta_n_features == -1:
-            X = X[..., :-1]
-        with expectation:
-            model.predict(X)
-
-    @pytest.mark.parametrize(
-        "is_fit, expectation",
-        [
-            (True, does_not_raise()),
-            (
-                False,
-                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-            ),
-        ],
-    )
-    def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-        """
-        Test the `score` method on models based on their fit status.
-        Ensure scoring is only possible on fitted models.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        if is_fit:
-            model.fit(X, y)
-        with expectation:
-            model.predict(X)
-
-    #######################
-    # Test model.simulate
-    #######################
-    @pytest.mark.parametrize(
-        "delta_dim, expectation",
-        [
-            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-            (0, does_not_raise()),
-            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-        ],
-    )
-    def test_simulate_input_dimensionality(
-        self, delta_dim, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `simulate` method with input data of different dimensionalities.
-        Ensure correct dimensionality for input.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        if delta_dim == -1:
-            X = np.zeros(X.shape[:-1])
-        elif delta_dim == 1:
-            X = np.zeros(X.shape + (1,))
-        with expectation:
-            model.simulate(
-                random_key=jax.random.key(123),
-                feedforward_input=X,
-            )
-
-    @pytest.mark.parametrize(
-        "is_fit, expectation",
-        [
-            (True, does_not_raise()),
-            (
-                False,
-                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-            ),
-        ],
-    )
-    def test_simulate_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-        """
-        Test if the model raises a ValueError when trying to simulate before it's fitted.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        if is_fit:
-            model.coef_ = true_params[0]
-            model.intercept_ = true_params[1]
-        with expectation:
-            model.simulate(
-                random_key=jax.random.key(123),
-                feedforward_input=X,
-            )
-
-    @pytest.mark.parametrize(
-        "delta_features, expectation",
-        [
-            (
-                -1,
-                pytest.raises(
-                    ValueError,
-                    match="Inconsistent number of features. spike basis coefficients has",
-                ),
-            ),
-            (0, does_not_raise()),
-            (
-                1,
-                pytest.raises(
-                    ValueError,
-                    match="Inconsistent number of features. spike basis coefficients has",
-                ),
-            ),
-        ],
-    )
-    def test_simulate_feature_consistency_input(
-        self, delta_features, expectation, poissonGLM_model_instantiation
-    ):
-        """
-        Test the `simulate` method ensuring the number of features in `feedforward_input` is
-        consistent with the model's expected number of features.
-
-        Notes
-        -----
-        The total feature number `model.coef_.shape[1]` must be equal to
-        `feedforward_input.shape[2] + coupling_basis.shape[1]*n_neurons`
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        feedforward_input = jnp.zeros(
-            (
-                X.shape[0],
-                X.shape[1] + delta_features,
-            )
-        )
-        with expectation:
-            model.simulate(
-                random_key=jax.random.key(123),
-                feedforward_input=feedforward_input,
-            )
-
-    def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
-        """Test that simulate goes through"""
-        X, y, model, params, rate = poissonGLM_model_instantiation
-        model.coef_ = params[0]
-        model.intercept_ = params[1]
-        ysim, ratesim = model.simulate(jax.random.key(123), X)
-        # check that the expected dimensionality is returned
-        assert ysim.ndim == 1
-        assert ratesim.ndim == 1
-        # check that the rates and spikes has the same shape
-        assert ratesim.shape[0] == ysim.shape[0]
-        # check the time point number is that expected (same as the input)
-        assert ysim.shape[0] == X.shape[0]
-
-    @pytest.mark.parametrize(
-        "insert, expectation",
-        [
-            (0, does_not_raise()),
-            (np.nan, pytest.warns(UserWarning, match=r"The provided trees contain")),
-            (np.inf, pytest.warns(UserWarning, match=r"The provided trees contain")),
-        ],
-    )
-    def test_simulate_invalid_feedforward(
-        self, insert, expectation, poissonGLM_model_instantiation
-    ):
-        X, y, model, params, rate = poissonGLM_model_instantiation
-        model.coef_ = params[0]
-        model.intercept_ = params[1]
-        X[0] = insert
-        with expectation:
-            model.simulate(jax.random.key(123), X)
-
-    #######################################
-    # Compare with standard implementation
-    #######################################
-    def test_deviance_against_statsmodels(self, poissonGLM_model_instantiation):
-        """
-        Compare fitted parameters to statsmodels.
-        Assesses if the model estimates are close to statsmodels' results.
-        """
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        # set model coeff
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        # get the rate
-        dev = sm.families.Poisson().deviance(y, firing_rate)
-        dev_model = model.observation_model.deviance(firing_rate, y).sum()
-        if not np.allclose(dev, dev_model):
-            raise ValueError("Deviance doesn't match statsmodels!")
-
-    def test_compatibility_with_sklearn_cv(self, poissonGLM_model_instantiation):
-        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
-        GridSearchCV(model, param_grid).fit(X, y)
+#     def test_fit_mask_grouplasso(self, group_sparse_poisson_glm_model_instantiation):
+#         """Test that the group lasso fit goes through"""
+#         X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
+#         model.set_params(
+#             regularizer=nmo.regularizer.GroupLasso(
+#                 solver_name="ProximalGradient", mask=mask
+#             )
+#         )
+#         model.fit(X, y)
+#
+#     def test_fit_pytree_equivalence(
+#         self, poissonGLM_model_instantiation, poissonGLM_model_instantiation_pytree
+#     ):
+#         """Check that the glm fit with pytree learns the same parameters."""
+#         # required for numerical precision of coeffs
+#         jax.config.update("jax_enable_x64", True)
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         X_tree, _, model_tree, true_params_tree, _ = (
+#             poissonGLM_model_instantiation_pytree
+#         )
+#         # fit both models
+#         model.fit(X, y, init_params=true_params)
+#         model_tree.fit(X_tree, y, init_params=true_params_tree)
+#
+#         # get the flat parameters
+#         flat_coef = np.concatenate(
+#             jax.tree_util.tree_flatten(model_tree.coef_)[0], axis=-1
+#         )
+#
+#         # assert equivalence of solutions
+#         assert np.allclose(model.coef_, flat_coef)
+#         assert np.allclose(model.intercept_, model_tree.intercept_)
+#         assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
+#         assert np.allclose(model.predict(X), model_tree.predict(X_tree))
+#
+#     @pytest.mark.parametrize(
+#         "fill_val, expectation",
+#         [
+#             (0, does_not_raise()),
+#             (
+#                 jnp.inf,
+#                 pytest.raises(
+#                     ValueError, match="At least a NaN or an Inf at all sample points"
+#                 ),
+#             ),
+#             (
+#                 jnp.nan,
+#                 pytest.raises(
+#                     ValueError, match="At least a NaN or an Inf at all sample points"
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_fit_all_invalid_X(
+#         self, fill_val, expectation, poissonGLM_model_instantiation
+#     ):
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         X.fill(fill_val)
+#         with expectation:
+#             model.fit(X, y)
+#
+#     #######################
+#     # Test model.score
+#     #######################
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#         ],
+#     )
+#     def test_score_x_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             X = np.zeros((X.shape[0],))
+#         elif delta_dim == 1:
+#             X = np.zeros((X.shape[0], X.shape[1], 1))
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(
+#                     ValueError, match="y must be one-dimensional, with shape"
+#                 ),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(
+#                     ValueError, match="y must be one-dimensional, with shape"
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_score_y_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method with y of different dimensionalities.
+#         Ensure correct dimensionality for y.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             y = np.zeros([])
+#         elif delta_dim == 1:
+#             y = np.zeros((X.shape[0], X.shape[1]))
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "delta_n_features, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#         ],
+#     )
+#     def test_score_n_feature_consistency_x(
+#         self, delta_n_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for inconsistencies in features of X.
+#         Ensure the number of features in X aligns with the model params.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_n_features == 1:
+#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+#         elif delta_n_features == -1:
+#             X = X[..., :-1]
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "is_fit, expectation",
+#         [
+#             (True, does_not_raise()),
+#             (
+#                 False,
+#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+#             ),
+#         ],
+#     )
+#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+#         """
+#         Test the `score` method on models based on their fit status.
+#         Ensure scoring is only possible on fitted models.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if is_fit:
+#             model.fit(X, y)
+#         with expectation:
+#             model.predict(X)
+#
+#     @pytest.mark.parametrize(
+#         "delta_tp, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#         ],
+#     )
+#     def test_score_time_points_x(
+#         self, delta_tp, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for inconsistencies in time-points in X.
+#         Ensure that the number of time-points in X and y matches.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "delta_tp, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#         ],
+#     )
+#     def test_score_time_points_y(
+#         self, delta_tp, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for inconsistencies in time-points in y.
+#         Ensure that the number of time-points in X and y matches.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "score_type, expectation",
+#         [
+#             ("pseudo-r2-McFadden", does_not_raise()),
+#             ("pseudo-r2-Cohen", does_not_raise()),
+#             ("log-likelihood", does_not_raise()),
+#             (
+#                 "not-implemented",
+#                 pytest.raises(
+#                     NotImplementedError,
+#                     match="Scoring method not-implemented not implemented",
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_score_type_r2(
+#         self, score_type, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for unsupported scoring types.
+#         Ensure only valid score types are used.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         with expectation:
+#             model.score(X, y, score_type=score_type)
+#
+#     def test_loglikelihood_against_scipy_stats(self, poissonGLM_model_instantiation):
+#         """
+#         Compare the model's log-likelihood computation against `jax.scipy`.
+#         Ensure consistent and correct calculations.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         # set model coeff
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         # get the rate
+#         mean_firing = model.predict(X)
+#         # compute the log-likelihood using jax.scipy
+#         mean_ll_jax = jax.scipy.stats.poisson.logpmf(y, mean_firing).mean()
+#         model_ll = model.score(X, y, score_type="log-likelihood")
+#         if not np.allclose(mean_ll_jax, model_ll):
+#             raise ValueError(
+#                 "Log-likelihood of PoissonModel does not match" "that of jax.scipy!"
+#             )
+#
+#     #######################
+#     # Test model.predict
+#     #######################
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#         ],
+#     )
+#     def test_predict_x_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `predict` method with x input data of different dimensionalities.
+#         Ensure correct dimensionality for x.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             X = np.zeros((X.shape[0],))
+#         elif delta_dim == 1:
+#             X = np.zeros((X.shape[0], X.shape[1], 1))
+#         with expectation:
+#             model.predict(X)
+#
+#     @pytest.mark.parametrize(
+#         "delta_n_features, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#         ],
+#     )
+#     def test_predict_n_feature_consistency_x(
+#         self, delta_n_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `predict` method ensuring the number of features in x input data
+#         is consistent with the model's `model.coef_`.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_n_features == 1:
+#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+#         elif delta_n_features == -1:
+#             X = X[..., :-1]
+#         with expectation:
+#             model.predict(X)
+#
+#     @pytest.mark.parametrize(
+#         "is_fit, expectation",
+#         [
+#             (True, does_not_raise()),
+#             (
+#                 False,
+#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+#             ),
+#         ],
+#     )
+#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+#         """
+#         Test the `score` method on models based on their fit status.
+#         Ensure scoring is only possible on fitted models.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if is_fit:
+#             model.fit(X, y)
+#         with expectation:
+#             model.predict(X)
+#
+#     #######################
+#     # Test model.simulate
+#     #######################
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#         ],
+#     )
+#     def test_simulate_input_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `simulate` method with input data of different dimensionalities.
+#         Ensure correct dimensionality for input.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             X = np.zeros(X.shape[:-1])
+#         elif delta_dim == 1:
+#             X = np.zeros(X.shape + (1,))
+#         with expectation:
+#             model.simulate(
+#                 random_key=jax.random.key(123),
+#                 feedforward_input=X,
+#             )
+#
+#     @pytest.mark.parametrize(
+#         "is_fit, expectation",
+#         [
+#             (True, does_not_raise()),
+#             (
+#                 False,
+#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+#             ),
+#         ],
+#     )
+#     def test_simulate_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+#         """
+#         Test if the model raises a ValueError when trying to simulate before it's fitted.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if is_fit:
+#             model.coef_ = true_params[0]
+#             model.intercept_ = true_params[1]
+#         with expectation:
+#             model.simulate(
+#                 random_key=jax.random.key(123),
+#                 feedforward_input=X,
+#             )
+#
+#     @pytest.mark.parametrize(
+#         "delta_features, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(
+#                     ValueError,
+#                     match="Inconsistent number of features. spike basis coefficients has",
+#                 ),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(
+#                     ValueError,
+#                     match="Inconsistent number of features. spike basis coefficients has",
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_simulate_feature_consistency_input(
+#         self, delta_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `simulate` method ensuring the number of features in `feedforward_input` is
+#         consistent with the model's expected number of features.
+#
+#         Notes
+#         -----
+#         The total feature number `model.coef_.shape[1]` must be equal to
+#         `feedforward_input.shape[2] + coupling_basis.shape[1]*n_neurons`
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         feedforward_input = jnp.zeros(
+#             (
+#                 X.shape[0],
+#                 X.shape[1] + delta_features,
+#             )
+#         )
+#         with expectation:
+#             model.simulate(
+#                 random_key=jax.random.key(123),
+#                 feedforward_input=feedforward_input,
+#             )
+#
+#     def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
+#         """Test that simulate goes through"""
+#         X, y, model, params, rate = poissonGLM_model_instantiation
+#         model.coef_ = params[0]
+#         model.intercept_ = params[1]
+#         ysim, ratesim = model.simulate(jax.random.key(123), X)
+#         # check that the expected dimensionality is returned
+#         assert ysim.ndim == 1
+#         assert ratesim.ndim == 1
+#         # check that the rates and spikes has the same shape
+#         assert ratesim.shape[0] == ysim.shape[0]
+#         # check the time point number is that expected (same as the input)
+#         assert ysim.shape[0] == X.shape[0]
+#
+#     @pytest.mark.parametrize(
+#         "insert, expectation",
+#         [
+#             (0, does_not_raise()),
+#             (np.nan, pytest.warns(UserWarning, match=r"The provided trees contain")),
+#             (np.inf, pytest.warns(UserWarning, match=r"The provided trees contain")),
+#         ],
+#     )
+#     def test_simulate_invalid_feedforward(
+#         self, insert, expectation, poissonGLM_model_instantiation
+#     ):
+#         X, y, model, params, rate = poissonGLM_model_instantiation
+#         model.coef_ = params[0]
+#         model.intercept_ = params[1]
+#         X[0] = insert
+#         with expectation:
+#             model.simulate(jax.random.key(123), X)
+#
+#     #######################################
+#     # Compare with standard implementation
+#     #######################################
+#     def test_deviance_against_statsmodels(self, poissonGLM_model_instantiation):
+#         """
+#         Compare fitted parameters to statsmodels.
+#         Assesses if the model estimates are close to statsmodels' results.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         # set model coeff
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         # get the rate
+#         dev = sm.families.Poisson().deviance(y, firing_rate)
+#         dev_model = model.observation_model.deviance(firing_rate, y).sum()
+#         if not np.allclose(dev, dev_model):
+#             raise ValueError("Deviance doesn't match statsmodels!")
+#
+#     def test_compatibility_with_sklearn_cv(self, poissonGLM_model_instantiation):
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
+#         GridSearchCV(model, param_grid).fit(X, y)
+#
+#
+# class TestPopulationGLM:
+#     """
+#     Unit tests for the PoissonGLM class.
+#     """
+#
+#     #######################
+#     # Test model.__init__
+#     #######################
+#     @pytest.mark.parametrize(
+#         "regularizer, expectation",
+#         [
+#             (nmo.regularizer.Ridge("BFGS"), does_not_raise()),
+#             (
+#                 None,
+#                 pytest.raises(
+#                     AttributeError, match="The provided `solver` doesn't implement "
+#                 ),
+#             ),
+#             (
+#                 nmo.regularizer.Ridge,
+#                 pytest.raises(
+#                     TypeError, match="The provided `solver` cannot be instantiated"
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_solver_type(self, regularizer, expectation, glm_class):
+#         """
+#         Test that an error is raised if a non-compatible solver is passed.
+#         """
+#         with expectation:
+#             glm_class(regularizer=regularizer)
+#
+#     @pytest.mark.parametrize(
+#         "observation, expectation",
+#         [
+#             (nmo.observation_models.PoissonObservations(), does_not_raise()),
+#             (
+#                 nmo.regularizer.Regularizer,
+#                 pytest.raises(
+#                     AttributeError,
+#                     match="The provided object does not have the required",
+#                 ),
+#             ),
+#             (
+#                 1,
+#                 pytest.raises(
+#                     AttributeError,
+#                     match="The provided object does not have the required",
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_init_observation_type(
+#         self, observation, expectation, glm_class, ridge_regularizer
+#     ):
+#         """
+#         Test initialization with different regularizer names. Check if an appropriate exception is raised
+#         when the regularizer name is not present in jaxopt.
+#         """
+#         with expectation:
+#             glm_class(regularizer=ridge_regularizer, observation_model=observation)
+#
+#     @pytest.mark.parametrize(
+#         "X, y",
+#         [
+#             (jnp.zeros((2, 4)), jnp.zeros((2,))),
+#             (jnp.zeros((2, 4)), jnp.zeros((2,))),
+#         ],
+#     )
+#     def test_parameter_initialization(self, X, y, poissonGLM_model_instantiation):
+#         _, _, model, _, _ = poissonGLM_model_instantiation
+#         coef, inter = model._initialize_parameters(X, y)
+#         assert coef.shape == (X.shape[1],)
+#         assert inter.shape == (1,)
+#
+#     #######################
+#     # Test model.fit
+#     #######################
+#     @pytest.mark.parametrize(
+#         "n_params, expectation",
+#         [
+#             (0, pytest.raises(ValueError, match="Params must have length two.")),
+#             (1, pytest.raises(ValueError, match="Params must have length two.")),
+#             (2, does_not_raise()),
+#             (3, pytest.raises(ValueError, match="Params must have length two.")),
+#         ],
+#     )
+#     def test_fit_param_length(
+#         self, n_params, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method with different numbers of initial parameters.
+#         Check for correct number of parameters.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if n_params == 0:
+#             init_params = tuple()
+#         elif n_params == 1:
+#             init_params = (true_params[0],)
+#         else:
+#             init_params = true_params + (true_params[0],) * (n_params - 2)
+#         with expectation:
+#             model.fit(X, y, init_params=init_params)
+#
+#     @pytest.mark.parametrize(
+#         "add_entry, add_to, expectation",
+#         [
+#             (0, "X", does_not_raise()),
+#             (
+#                 np.nan,
+#                 "X",
+#                 pytest.warns(UserWarning, match="The provided trees contain"),
+#             ),
+#             (
+#                 np.inf,
+#                 "X",
+#                 pytest.warns(UserWarning, match="The provided trees contain"),
+#             ),
+#             (0, "y", does_not_raise()),
+#             (
+#                 np.nan,
+#                 "y",
+#                 pytest.warns(UserWarning, match="The provided trees contain"),
+#             ),
+#             (
+#                 np.inf,
+#                 "y",
+#                 pytest.warns(UserWarning, match="The provided trees contain"),
+#             ),
+#         ],
+#     )
+#     def test_fit_param_values(
+#         self, add_entry, add_to, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method with altered X or y values. Ensure the method raises exceptions for NaN or Inf values.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if add_to == "X":
+#             # get an index to be edited
+#             idx = np.unravel_index(np.random.choice(X.size), X.shape)
+#             X[idx] = add_entry
+#         elif add_to == "y":
+#             idx = np.unravel_index(np.random.choice(y.size), y.shape)
+#             y = np.asarray(y, dtype=np.float32)
+#             y[idx] = add_entry
+#         with expectation:
+#             model.fit(X, y, init_params=true_params)
+#
+#     @pytest.mark.parametrize(
+#         "dim_weights, expectation",
+#         [
+#             (
+#                 0,
+#                 pytest.raises(
+#                     ValueError,
+#                     match=r"Inconsistent number of features",
+#                 ),
+#             ),
+#             (
+#                 1,
+#                 does_not_raise(),
+#             ),
+#             (
+#                 2,
+#                 pytest.raises(
+#                     ValueError,
+#                     match=r"params\[0\] must be an array or .* of shape \(n_features",
+#                 ),
+#             ),
+#             (
+#                 3,
+#                 pytest.raises(
+#                     ValueError,
+#                     match=r"params\[0\] must be an array or .* of shape \(n_features",
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_fit_weights_dimensionality(
+#         self, dim_weights, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method with weight matrices of different dimensionalities.
+#         Check for correct dimensionality.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         n_samples, n_features = X.shape
+#         n_neurons = 4
+#         if dim_weights == 0:
+#             init_w = jnp.array([])
+#         elif dim_weights == 1:
+#             init_w = jnp.zeros((n_features,))
+#         elif dim_weights == 2:
+#             init_w = jnp.zeros((n_features, n_neurons))
+#         else:
+#             init_w = jnp.zeros((n_features, n_neurons) + (1,) * (dim_weights - 2))
+#         with expectation:
+#             model.fit(X, y, init_params=(init_w, true_params[1]))
+#
+#     @pytest.mark.parametrize(
+#         "dim_intercepts, expectation",
+#         [
+#             (0, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
+#             (1, does_not_raise()),
+#             (2, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
+#             (3, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
+#         ],
+#     )
+#     def test_fit_intercepts_dimensionality(
+#         self, dim_intercepts, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method with intercepts of different dimensionalities. Check for correct dimensionality.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         n_samples, n_features = X.shape
+#         init_b = jnp.zeros((1,) * dim_intercepts)
+#         init_w = jnp.zeros((n_features,))
+#         with expectation:
+#             model.fit(X, y, init_params=(init_w, init_b))
+#
+#     @pytest.mark.parametrize(
+#         "init_params, expectation",
+#         [
+#             ([jnp.zeros((5,)), jnp.zeros((1,))], does_not_raise()),
+#             (
+#                 [[jnp.zeros((1, 5)), jnp.zeros((1,))]],
+#                 pytest.raises(ValueError, match="Params must have length two."),
+#             ),
+#             (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), pytest.raises(KeyError)),
+#             (
+#                 (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), jnp.zeros((1,))),
+#                 pytest.raises(
+#                     TypeError, match=r"X and params\[0\] must be the same type"
+#                 ),
+#             ),
+#             (
+#                 (
+#                     FeaturePytree(p1=jnp.zeros((5,)), p2=jnp.zeros((5,))),
+#                     jnp.zeros((1,)),
+#                 ),
+#                 pytest.raises(
+#                     TypeError, match=r"X and params\[0\] must be the same type"
+#                 ),
+#             ),
+#             (0, pytest.raises(ValueError, match="Params must have length two.")),
+#             (
+#                 {0, 1},
+#                 pytest.raises(TypeError, match="Initial parameters must be array-like"),
+#             ),
+#             (
+#                 [jnp.zeros((1, 5)), ""],
+#                 pytest.raises(TypeError, match="Initial parameters must be array-like"),
+#             ),
+#             (
+#                 ["", jnp.zeros((1,))],
+#                 pytest.raises(TypeError, match="Initial parameters must be array-like"),
+#             ),
+#         ],
+#     )
+#     def test_fit_init_params_type(
+#         self, init_params, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method with various types of initial parameters. Ensure that the provided initial parameters
+#         are array-like.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         with expectation:
+#             model.fit(X, y, init_params=init_params)
+#
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#         ],
+#     )
+#     def test_fit_x_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if delta_dim == -1:
+#             X = np.zeros((X.shape[0],))
+#         elif delta_dim == 1:
+#             X = np.zeros((X.shape[0], 1, X.shape[1]))
+#         with expectation:
+#             model.fit(X, y, init_params=true_params)
+#
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="y must be one-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="y must be one-dimensional")),
+#         ],
+#     )
+#     def test_fit_y_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method with y target data of different dimensionalities. Ensure correct dimensionality for y.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if delta_dim == -1:
+#             y = np.zeros([])
+#         elif delta_dim == 1:
+#             y = np.zeros((y.shape[0], 1))
+#         with expectation:
+#             model.fit(X, y, init_params=true_params)
+#
+#     @pytest.mark.parametrize(
+#         "delta_n_features, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#         ],
+#     )
+#     def test_fit_n_feature_consistency_weights(
+#         self, delta_n_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method for inconsistencies between data features and initial weights provided.
+#         Ensure the number of features align.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         init_w = jnp.zeros((X.shape[1] + delta_n_features))
+#         init_b = jnp.zeros(
+#             1,
+#         )
+#         with expectation:
+#             model.fit(X, y, init_params=(init_w, init_b))
+#
+#     @pytest.mark.parametrize(
+#         "delta_n_features, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#         ],
+#     )
+#     def test_fit_n_feature_consistency_x(
+#         self, delta_n_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method for inconsistencies between data features and model's expectations.
+#         Ensure the number of features in X aligns.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if delta_n_features == 1:
+#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+#         elif delta_n_features == -1:
+#             X = X[..., :-1]
+#         with expectation:
+#             model.fit(X, y, init_params=true_params)
+#
+#     @pytest.mark.parametrize(
+#         "delta_tp, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#         ],
+#     )
+#     def test_fit_time_points_x(
+#         self, delta_tp, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method for inconsistencies in time-points in data X. Ensure the correct number of time-points.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
+#         with expectation:
+#             model.fit(X, y, init_params=true_params)
+#
+#     @pytest.mark.parametrize(
+#         "delta_tp, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#         ],
+#     )
+#     def test_fit_time_points_y(
+#         self, delta_tp, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `fit` method for inconsistencies in time-points in y. Ensure the correct number of time-points.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
+#         with expectation:
+#             model.fit(X, y, init_params=true_params)
+#
+#     def test_fit_mask_grouplasso(self, group_sparse_poisson_glm_model_instantiation):
+#         """Test that the group lasso fit goes through"""
+#         X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
+#         model.set_params(
+#             regularizer=nmo.regularizer.GroupLasso(
+#                 solver_name="ProximalGradient", mask=mask
+#             )
+#         )
+#         model.fit(X, y)
+#
+#     def test_fit_pytree_equivalence(
+#         self, poissonGLM_model_instantiation, poissonGLM_model_instantiation_pytree
+#     ):
+#         """Check that the glm fit with pytree learns the same parameters."""
+#         # required for numerical precision of coeffs
+#         jax.config.update("jax_enable_x64", True)
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         X_tree, _, model_tree, true_params_tree, _ = (
+#             poissonGLM_model_instantiation_pytree
+#         )
+#         # fit both models
+#         model.fit(X, y, init_params=true_params)
+#         model_tree.fit(X_tree, y, init_params=true_params_tree)
+#
+#         # get the flat parameters
+#         flat_coef = np.concatenate(
+#             jax.tree_util.tree_flatten(model_tree.coef_)[0], axis=-1
+#         )
+#
+#         # assert equivalence of solutions
+#         assert np.allclose(model.coef_, flat_coef)
+#         assert np.allclose(model.intercept_, model_tree.intercept_)
+#         assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
+#         assert np.allclose(model.predict(X), model_tree.predict(X_tree))
+#
+#     @pytest.mark.parametrize(
+#         "fill_val, expectation",
+#         [
+#             (0, does_not_raise()),
+#             (
+#                 jnp.inf,
+#                 pytest.raises(
+#                     ValueError, match="At least a NaN or an Inf at all sample points"
+#                 ),
+#             ),
+#             (
+#                 jnp.nan,
+#                 pytest.raises(
+#                     ValueError, match="At least a NaN or an Inf at all sample points"
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_fit_all_invalid_X(
+#         self, fill_val, expectation, poissonGLM_model_instantiation
+#     ):
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         X.fill(fill_val)
+#         with expectation:
+#             model.fit(X, y)
+#
+#     #######################
+#     # Test model.score
+#     #######################
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#         ],
+#     )
+#     def test_score_x_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             X = np.zeros((X.shape[0],))
+#         elif delta_dim == 1:
+#             X = np.zeros((X.shape[0], X.shape[1], 1))
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(
+#                     ValueError, match="y must be one-dimensional, with shape"
+#                 ),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(
+#                     ValueError, match="y must be one-dimensional, with shape"
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_score_y_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method with y of different dimensionalities.
+#         Ensure correct dimensionality for y.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             y = np.zeros([])
+#         elif delta_dim == 1:
+#             y = np.zeros((X.shape[0], X.shape[1]))
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "delta_n_features, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#         ],
+#     )
+#     def test_score_n_feature_consistency_x(
+#         self, delta_n_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for inconsistencies in features of X.
+#         Ensure the number of features in X aligns with the model params.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_n_features == 1:
+#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+#         elif delta_n_features == -1:
+#             X = X[..., :-1]
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "is_fit, expectation",
+#         [
+#             (True, does_not_raise()),
+#             (
+#                 False,
+#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+#             ),
+#         ],
+#     )
+#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+#         """
+#         Test the `score` method on models based on their fit status.
+#         Ensure scoring is only possible on fitted models.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if is_fit:
+#             model.fit(X, y)
+#         with expectation:
+#             model.predict(X)
+#
+#     @pytest.mark.parametrize(
+#         "delta_tp, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#         ],
+#     )
+#     def test_score_time_points_x(
+#         self, delta_tp, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for inconsistencies in time-points in X.
+#         Ensure that the number of time-points in X and y matches.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "delta_tp, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
+#             ),
+#         ],
+#     )
+#     def test_score_time_points_y(
+#         self, delta_tp, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for inconsistencies in time-points in y.
+#         Ensure that the number of time-points in X and y matches.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
+#         with expectation:
+#             model.score(X, y)
+#
+#     @pytest.mark.parametrize(
+#         "score_type, expectation",
+#         [
+#             ("pseudo-r2-McFadden", does_not_raise()),
+#             ("pseudo-r2-Cohen", does_not_raise()),
+#             ("log-likelihood", does_not_raise()),
+#             (
+#                 "not-implemented",
+#                 pytest.raises(
+#                     NotImplementedError,
+#                     match="Scoring method not-implemented not implemented",
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_score_type_r2(
+#         self, score_type, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `score` method for unsupported scoring types.
+#         Ensure only valid score types are used.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         with expectation:
+#             model.score(X, y, score_type=score_type)
+#
+#     def test_loglikelihood_against_scipy_stats(self, poissonGLM_model_instantiation):
+#         """
+#         Compare the model's log-likelihood computation against `jax.scipy`.
+#         Ensure consistent and correct calculations.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         # set model coeff
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         # get the rate
+#         mean_firing = model.predict(X)
+#         # compute the log-likelihood using jax.scipy
+#         mean_ll_jax = jax.scipy.stats.poisson.logpmf(y, mean_firing).mean()
+#         model_ll = model.score(X, y, score_type="log-likelihood")
+#         if not np.allclose(mean_ll_jax, model_ll):
+#             raise ValueError(
+#                 "Log-likelihood of PoissonModel does not match" "that of jax.scipy!"
+#             )
+#
+#     #######################
+#     # Test model.predict
+#     #######################
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#         ],
+#     )
+#     def test_predict_x_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `predict` method with x input data of different dimensionalities.
+#         Ensure correct dimensionality for x.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             X = np.zeros((X.shape[0],))
+#         elif delta_dim == 1:
+#             X = np.zeros((X.shape[0], X.shape[1], 1))
+#         with expectation:
+#             model.predict(X)
+#
+#     @pytest.mark.parametrize(
+#         "delta_n_features, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+#         ],
+#     )
+#     def test_predict_n_feature_consistency_x(
+#         self, delta_n_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `predict` method ensuring the number of features in x input data
+#         is consistent with the model's `model.coef_`.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_n_features == 1:
+#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+#         elif delta_n_features == -1:
+#             X = X[..., :-1]
+#         with expectation:
+#             model.predict(X)
+#
+#     @pytest.mark.parametrize(
+#         "is_fit, expectation",
+#         [
+#             (True, does_not_raise()),
+#             (
+#                 False,
+#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+#             ),
+#         ],
+#     )
+#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+#         """
+#         Test the `score` method on models based on their fit status.
+#         Ensure scoring is only possible on fitted models.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if is_fit:
+#             model.fit(X, y)
+#         with expectation:
+#             model.predict(X)
+#
+#     #######################
+#     # Test model.simulate
+#     #######################
+#     @pytest.mark.parametrize(
+#         "delta_dim, expectation",
+#         [
+#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#             (0, does_not_raise()),
+#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+#         ],
+#     )
+#     def test_simulate_input_dimensionality(
+#         self, delta_dim, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `simulate` method with input data of different dimensionalities.
+#         Ensure correct dimensionality for input.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         if delta_dim == -1:
+#             X = np.zeros(X.shape[:-1])
+#         elif delta_dim == 1:
+#             X = np.zeros(X.shape + (1,))
+#         with expectation:
+#             model.simulate(
+#                 random_key=jax.random.key(123),
+#                 feedforward_input=X,
+#             )
+#
+#     @pytest.mark.parametrize(
+#         "is_fit, expectation",
+#         [
+#             (True, does_not_raise()),
+#             (
+#                 False,
+#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+#             ),
+#         ],
+#     )
+#     def test_simulate_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+#         """
+#         Test if the model raises a ValueError when trying to simulate before it's fitted.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         if is_fit:
+#             model.coef_ = true_params[0]
+#             model.intercept_ = true_params[1]
+#         with expectation:
+#             model.simulate(
+#                 random_key=jax.random.key(123),
+#                 feedforward_input=X,
+#             )
+#
+#     @pytest.mark.parametrize(
+#         "delta_features, expectation",
+#         [
+#             (
+#                 -1,
+#                 pytest.raises(
+#                     ValueError,
+#                     match="Inconsistent number of features. spike basis coefficients has",
+#                 ),
+#             ),
+#             (0, does_not_raise()),
+#             (
+#                 1,
+#                 pytest.raises(
+#                     ValueError,
+#                     match="Inconsistent number of features. spike basis coefficients has",
+#                 ),
+#             ),
+#         ],
+#     )
+#     def test_simulate_feature_consistency_input(
+#         self, delta_features, expectation, poissonGLM_model_instantiation
+#     ):
+#         """
+#         Test the `simulate` method ensuring the number of features in `feedforward_input` is
+#         consistent with the model's expected number of features.
+#
+#         Notes
+#         -----
+#         The total feature number `model.coef_.shape[1]` must be equal to
+#         `feedforward_input.shape[2] + coupling_basis.shape[1]*n_neurons`
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         feedforward_input = jnp.zeros(
+#             (
+#                 X.shape[0],
+#                 X.shape[1] + delta_features,
+#             )
+#         )
+#         with expectation:
+#             model.simulate(
+#                 random_key=jax.random.key(123),
+#                 feedforward_input=feedforward_input,
+#             )
+#
+#     def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
+#         """Test that simulate goes through"""
+#         X, y, model, params, rate = poissonGLM_model_instantiation
+#         model.coef_ = params[0]
+#         model.intercept_ = params[1]
+#         ysim, ratesim = model.simulate(jax.random.key(123), X)
+#         # check that the expected dimensionality is returned
+#         assert ysim.ndim == 1
+#         assert ratesim.ndim == 1
+#         # check that the rates and spikes has the same shape
+#         assert ratesim.shape[0] == ysim.shape[0]
+#         # check the time point number is that expected (same as the input)
+#         assert ysim.shape[0] == X.shape[0]
+#
+#     @pytest.mark.parametrize(
+#         "insert, expectation",
+#         [
+#             (0, does_not_raise()),
+#             (np.nan, pytest.warns(UserWarning, match=r"The provided trees contain")),
+#             (np.inf, pytest.warns(UserWarning, match=r"The provided trees contain")),
+#         ],
+#     )
+#     def test_simulate_invalid_feedforward(
+#         self, insert, expectation, poissonGLM_model_instantiation
+#     ):
+#         X, y, model, params, rate = poissonGLM_model_instantiation
+#         model.coef_ = params[0]
+#         model.intercept_ = params[1]
+#         X[0] = insert
+#         with expectation:
+#             model.simulate(jax.random.key(123), X)
+#
+#     #######################################
+#     # Compare with standard implementation
+#     #######################################
+#     def test_deviance_against_statsmodels(self, poissonGLM_model_instantiation):
+#         """
+#         Compare fitted parameters to statsmodels.
+#         Assesses if the model estimates are close to statsmodels' results.
+#         """
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         # set model coeff
+#         model.coef_ = true_params[0]
+#         model.intercept_ = true_params[1]
+#         # get the rate
+#         dev = sm.families.Poisson().deviance(y, firing_rate)
+#         dev_model = model.observation_model.deviance(firing_rate, y).sum()
+#         if not np.allclose(dev, dev_model):
+#             raise ValueError("Deviance doesn't match statsmodels!")
+#
+#     def test_compatibility_with_sklearn_cv(self, poissonGLM_model_instantiation):
+#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+#         param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
+#         GridSearchCV(model, param_grid).fit(X, y)

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -448,31 +448,31 @@ class TestGLM:
             )
         )
         model.fit(X, y)
-#
-#     def test_fit_pytree_equivalence(
-#         self, poissonGLM_model_instantiation, poissonGLM_model_instantiation_pytree
-#     ):
-#         """Check that the glm fit with pytree learns the same parameters."""
-#         # required for numerical precision of coeffs
-#         jax.config.update("jax_enable_x64", True)
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         X_tree, _, model_tree, true_params_tree, _ = (
-#             poissonGLM_model_instantiation_pytree
-#         )
-#         # fit both models
-#         model.fit(X, y, init_params=true_params)
-#         model_tree.fit(X_tree, y, init_params=true_params_tree)
-#
-#         # get the flat parameters
-#         flat_coef = np.concatenate(
-#             jax.tree_util.tree_flatten(model_tree.coef_)[0], axis=-1
-#         )
-#
-#         # assert equivalence of solutions
-#         assert np.allclose(model.coef_, flat_coef)
-#         assert np.allclose(model.intercept_, model_tree.intercept_)
-#         assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
-#         assert np.allclose(model.predict(X), model_tree.predict(X_tree))
+
+    def test_fit_pytree_equivalence(
+        self, poisson_population_GLM_model, poisson_population_GLM_model_pytree
+    ):
+        """Check that the glm fit with pytree learns the same parameters."""
+        # required for numerical precision of coeffs
+        jax.config.update("jax_enable_x64", True)
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        X_tree, _, model_tree, true_params_tree, _ = (
+            poisson_population_GLM_model_pytree
+        )
+        # fit both models
+        model.fit(X, y, init_params=true_params)
+        model_tree.fit(X_tree, y, init_params=true_params_tree)
+
+        # get the flat parameters
+        flat_coef = np.concatenate(
+            jax.tree_util.tree_flatten(model_tree.coef_)[0], axis=0
+        )
+
+        # assert equivalence of solutions
+        assert np.allclose(model.coef_, flat_coef)
+        assert np.allclose(model.intercept_, model_tree.intercept_)
+        assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
+        assert np.allclose(model.predict(X), model_tree.predict(X_tree))
 #
 #     @pytest.mark.parametrize(
 #         "fill_val, expectation",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -893,38 +893,39 @@ class TestGLM:
                 feedforward_input=feedforward_input,
             )
 
-#     def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
-#         """Test that simulate goes through"""
-#         X, y, model, params, rate = poissonGLM_model_instantiation
-#         model.coef_ = params[0]
-#         model.intercept_ = params[1]
-#         ysim, ratesim = model.simulate(jax.random.key(123), X)
-#         # check that the expected dimensionality is returned
-#         assert ysim.ndim == 1
-#         assert ratesim.ndim == 1
-#         # check that the rates and spikes has the same shape
-#         assert ratesim.shape[0] == ysim.shape[0]
-#         # check the time point number is that expected (same as the input)
-#         assert ysim.shape[0] == X.shape[0]
-#
-#     @pytest.mark.parametrize(
-#         "insert, expectation",
-#         [
-#             (0, does_not_raise()),
-#             (np.nan, pytest.warns(UserWarning, match=r"The provided trees contain")),
-#             (np.inf, pytest.warns(UserWarning, match=r"The provided trees contain")),
-#         ],
-#     )
-#     def test_simulate_invalid_feedforward(
-#         self, insert, expectation, poissonGLM_model_instantiation
-#     ):
-#         X, y, model, params, rate = poissonGLM_model_instantiation
-#         model.coef_ = params[0]
-#         model.intercept_ = params[1]
-#         X[0] = insert
-#         with expectation:
-#             model.simulate(jax.random.key(123), X)
-#
+    def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
+        """Test that simulate goes through"""
+        X, y, model, params, rate = poissonGLM_model_instantiation
+        model.coef_ = params[0]
+        model.intercept_ = params[1]
+        ysim, ratesim = model.simulate(jax.random.key(123), X)
+        # check that the expected dimensionality is returned
+        assert ysim.ndim == 1
+        assert ratesim.ndim == 1
+        # check that the rates and spikes has the same shape
+        assert ratesim.shape[0] == ysim.shape[0]
+        # check the time point number is that expected (same as the input)
+        assert ysim.shape[0] == X.shape[0]
+
+    @pytest.mark.parametrize(
+        "insert, expectation",
+        [
+            (0, does_not_raise()),
+            (np.nan, pytest.warns(UserWarning, match=r"The provided trees contain")),
+            (np.inf, pytest.warns(UserWarning, match=r"The provided trees contain")),
+        ],
+    )
+    def test_simulate_invalid_feedforward(
+        self, insert, expectation, poisson_population_GLM_model
+    ):
+        X, y, model, params, rate = poisson_population_GLM_model
+        model.coef_ = params[0]
+        model.intercept_ = params[1]
+        model._initialize_feature_mask(X, y)
+        X[0] = insert
+        with expectation:
+            model.simulate(jax.random.key(123), X)
+
 #     #######################################
 #     # Compare with standard implementation
 #     #######################################

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2033,7 +2033,6 @@ class TestPopulationGLM:
     @pytest.mark.parametrize(
         "mask",
         [
-            np.ones((5, 3)),
             np.array([
                 [0, 0, 1],
                 [0, 1, 0],
@@ -2047,6 +2046,7 @@ class TestPopulationGLM:
         jax.config.update("jax_enable_x64", True)
         if isinstance(mask, dict):
             X, y, model, true_params, firing_rate = poisson_population_GLM_model_pytree
+
             def map_neu(k, coef_):
                 key_ind = {"input_1": [0, 1, 2], "input_2": [3, 4]}
                 ind_array = np.zeros((0, ), dtype=int)
@@ -2058,12 +2058,11 @@ class TestPopulationGLM:
                 return ind_array, coef_stack
         else:
             X, y, model, true_params, firing_rate = poisson_population_GLM_model
+
             def map_neu(k, coef_):
                 ind_array = np.where(mask[:, k])[0]
                 coef_stack = coef_
                 return ind_array, coef_stack
-
-
 
         mask_bool = jax.tree_map(lambda x: np.asarray(x.T, dtype=bool), mask)
         # fit pop glm

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -473,196 +473,196 @@ class TestGLM:
         assert np.allclose(model.intercept_, model_tree.intercept_)
         assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
         assert np.allclose(model.predict(X), model_tree.predict(X_tree))
-#
-#     @pytest.mark.parametrize(
-#         "fill_val, expectation",
-#         [
-#             (0, does_not_raise()),
-#             (
-#                 jnp.inf,
-#                 pytest.raises(
-#                     ValueError, match="At least a NaN or an Inf at all sample points"
-#                 ),
-#             ),
-#             (
-#                 jnp.nan,
-#                 pytest.raises(
-#                     ValueError, match="At least a NaN or an Inf at all sample points"
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_fit_all_invalid_X(
-#         self, fill_val, expectation, poissonGLM_model_instantiation
-#     ):
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         X.fill(fill_val)
-#         with expectation:
-#             model.fit(X, y)
-#
-#     #######################
-#     # Test model.score
-#     #######################
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#         ],
-#     )
-#     def test_score_x_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             X = np.zeros((X.shape[0],))
-#         elif delta_dim == 1:
-#             X = np.zeros((X.shape[0], X.shape[1], 1))
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(
-#                     ValueError, match="y must be one-dimensional, with shape"
-#                 ),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(
-#                     ValueError, match="y must be one-dimensional, with shape"
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_score_y_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method with y of different dimensionalities.
-#         Ensure correct dimensionality for y.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             y = np.zeros([])
-#         elif delta_dim == 1:
-#             y = np.zeros((X.shape[0], X.shape[1]))
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "delta_n_features, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#         ],
-#     )
-#     def test_score_n_feature_consistency_x(
-#         self, delta_n_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for inconsistencies in features of X.
-#         Ensure the number of features in X aligns with the model params.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_n_features == 1:
-#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
-#         elif delta_n_features == -1:
-#             X = X[..., :-1]
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "is_fit, expectation",
-#         [
-#             (True, does_not_raise()),
-#             (
-#                 False,
-#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-#             ),
-#         ],
-#     )
-#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-#         """
-#         Test the `score` method on models based on their fit status.
-#         Ensure scoring is only possible on fitted models.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if is_fit:
-#             model.fit(X, y)
-#         with expectation:
-#             model.predict(X)
-#
-#     @pytest.mark.parametrize(
-#         "delta_tp, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#         ],
-#     )
-#     def test_score_time_points_x(
-#         self, delta_tp, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for inconsistencies in time-points in X.
-#         Ensure that the number of time-points in X and y matches.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "delta_tp, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#         ],
-#     )
-#     def test_score_time_points_y(
-#         self, delta_tp, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for inconsistencies in time-points in y.
-#         Ensure that the number of time-points in X and y matches.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
-#         with expectation:
-#             model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "fill_val, expectation",
+        [
+            (0, does_not_raise()),
+            (
+                jnp.inf,
+                pytest.raises(
+                    ValueError, match="At least a NaN or an Inf at all sample points"
+                ),
+            ),
+            (
+                jnp.nan,
+                pytest.raises(
+                    ValueError, match="At least a NaN or an Inf at all sample points"
+                ),
+            ),
+        ],
+    )
+    def test_fit_all_invalid_X(
+        self, fill_val, expectation, poisson_population_GLM_model
+    ):
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        X.fill(fill_val)
+        with expectation:
+            model.fit(X, y)
+
+    #######################
+    # Test model.score
+    #######################
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+        ],
+    )
+    def test_score_x_dimensionality(
+        self, delta_dim, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `score` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_dim == -1:
+            X = np.zeros((X.shape[0],))
+        elif delta_dim == 1:
+            X = np.zeros((X.shape[0], X.shape[1], 1))
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (
+                -1,
+                pytest.raises(
+                    ValueError, match="y must be two-dimensional, with shape"
+                ),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(
+                    ValueError, match="y must be two-dimensional, with shape"
+                ),
+            ),
+        ],
+    )
+    def test_score_y_dimensionality(
+        self, delta_dim, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `score` method with y of different dimensionalities.
+        Ensure correct dimensionality for y.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_dim == -1:
+            y = y[:, 0]
+        elif delta_dim == 1:
+            y = np.zeros((*y.shape, 1))
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "delta_n_features, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+        ],
+    )
+    def test_score_n_feature_consistency_x(
+        self, delta_n_features, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `score` method for inconsistencies in features of X.
+        Ensure the number of features in X aligns with the model params.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_n_features == 1:
+            X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+        elif delta_n_features == -1:
+            X = X[..., :-1]
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "is_fit, expectation",
+        [
+            (True, does_not_raise()),
+            (
+                False,
+                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+            ),
+        ],
+    )
+    def test_predict_is_fit(self, is_fit, expectation, poisson_population_GLM_model):
+        """
+        Test the `score` method on models based on their fit status.
+        Ensure scoring is only possible on fitted models.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        if is_fit:
+            model.fit(X, y)
+        with expectation:
+            model.predict(X)
+
+    @pytest.mark.parametrize(
+        "delta_tp, expectation",
+        [
+            (
+                -1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+        ],
+    )
+    def test_score_time_points_x(
+        self, delta_tp, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `score` method for inconsistencies in time-points in X.
+        Ensure that the number of time-points in X and y matches.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "delta_tp, expectation",
+        [
+            (
+                -1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+        ],
+    )
+    def test_score_time_points_y(
+        self, delta_tp, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `score` method for inconsistencies in time-points in y.
+        Ensure that the number of time-points in X and y matches.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
+        with expectation:
+            model.score(X, y)
 #
 #     @pytest.mark.parametrize(
 #         "score_type, expectation",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2007,6 +2007,7 @@ class TestPopulationGLM:
             idx, coef = map_neu(k, model_single_neu.coef_)
             coef_loop[idx, k] = coef
             intercept_loop[k] = np.array(model_single_neu.intercept_)[0]
-        assert np.allclose(coef_loop, coef_vectorized, atol=10**-6, rtol=0)
+        print(f"\nMAX ERR: {np.abs(coef_loop - coef_vectorized).max()}")
+        assert np.allclose(coef_loop, coef_vectorized, atol=10**-5, rtol=0)
 
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2089,7 +2089,6 @@ class TestPopulationGLM:
             idx, coef = map_neu(k, model_single_neu.coef_)
             coef_loop[idx, k] = coef
             intercept_loop[k] = np.array(model_single_neu.intercept_)[0]
-        print(f"\n MAX ERR {regularizer} - {regularizer.solver_name}: {np.max(np.abs(coef_loop - coef_vectorized))}")
         assert np.allclose(coef_loop, coef_vectorized, atol=10**-4, rtol=0)
 
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -663,230 +663,236 @@ class TestGLM:
         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
         with expectation:
             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "score_type, expectation",
-#         [
-#             ("pseudo-r2-McFadden", does_not_raise()),
-#             ("pseudo-r2-Cohen", does_not_raise()),
-#             ("log-likelihood", does_not_raise()),
-#             (
-#                 "not-implemented",
-#                 pytest.raises(
-#                     NotImplementedError,
-#                     match="Scoring method not-implemented not implemented",
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_score_type_r2(
-#         self, score_type, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for unsupported scoring types.
-#         Ensure only valid score types are used.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         with expectation:
-#             model.score(X, y, score_type=score_type)
-#
-#     def test_loglikelihood_against_scipy_stats(self, poissonGLM_model_instantiation):
-#         """
-#         Compare the model's log-likelihood computation against `jax.scipy`.
-#         Ensure consistent and correct calculations.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         # set model coeff
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         # get the rate
-#         mean_firing = model.predict(X)
-#         # compute the log-likelihood using jax.scipy
-#         mean_ll_jax = jax.scipy.stats.poisson.logpmf(y, mean_firing).mean()
-#         model_ll = model.score(X, y, score_type="log-likelihood")
-#         if not np.allclose(mean_ll_jax, model_ll):
-#             raise ValueError(
-#                 "Log-likelihood of PoissonModel does not match" "that of jax.scipy!"
-#             )
-#
-#     #######################
-#     # Test model.predict
-#     #######################
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#         ],
-#     )
-#     def test_predict_x_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `predict` method with x input data of different dimensionalities.
-#         Ensure correct dimensionality for x.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             X = np.zeros((X.shape[0],))
-#         elif delta_dim == 1:
-#             X = np.zeros((X.shape[0], X.shape[1], 1))
-#         with expectation:
-#             model.predict(X)
-#
-#     @pytest.mark.parametrize(
-#         "delta_n_features, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#         ],
-#     )
-#     def test_predict_n_feature_consistency_x(
-#         self, delta_n_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `predict` method ensuring the number of features in x input data
-#         is consistent with the model's `model.coef_`.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_n_features == 1:
-#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
-#         elif delta_n_features == -1:
-#             X = X[..., :-1]
-#         with expectation:
-#             model.predict(X)
-#
-#     @pytest.mark.parametrize(
-#         "is_fit, expectation",
-#         [
-#             (True, does_not_raise()),
-#             (
-#                 False,
-#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-#             ),
-#         ],
-#     )
-#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-#         """
-#         Test the `score` method on models based on their fit status.
-#         Ensure scoring is only possible on fitted models.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if is_fit:
-#             model.fit(X, y)
-#         with expectation:
-#             model.predict(X)
-#
-#     #######################
-#     # Test model.simulate
-#     #######################
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#         ],
-#     )
-#     def test_simulate_input_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `simulate` method with input data of different dimensionalities.
-#         Ensure correct dimensionality for input.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             X = np.zeros(X.shape[:-1])
-#         elif delta_dim == 1:
-#             X = np.zeros(X.shape + (1,))
-#         with expectation:
-#             model.simulate(
-#                 random_key=jax.random.key(123),
-#                 feedforward_input=X,
-#             )
-#
-#     @pytest.mark.parametrize(
-#         "is_fit, expectation",
-#         [
-#             (True, does_not_raise()),
-#             (
-#                 False,
-#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-#             ),
-#         ],
-#     )
-#     def test_simulate_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-#         """
-#         Test if the model raises a ValueError when trying to simulate before it's fitted.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if is_fit:
-#             model.coef_ = true_params[0]
-#             model.intercept_ = true_params[1]
-#         with expectation:
-#             model.simulate(
-#                 random_key=jax.random.key(123),
-#                 feedforward_input=X,
-#             )
-#
-#     @pytest.mark.parametrize(
-#         "delta_features, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(
-#                     ValueError,
-#                     match="Inconsistent number of features. spike basis coefficients has",
-#                 ),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(
-#                     ValueError,
-#                     match="Inconsistent number of features. spike basis coefficients has",
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_simulate_feature_consistency_input(
-#         self, delta_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `simulate` method ensuring the number of features in `feedforward_input` is
-#         consistent with the model's expected number of features.
-#
-#         Notes
-#         -----
-#         The total feature number `model.coef_.shape[1]` must be equal to
-#         `feedforward_input.shape[2] + coupling_basis.shape[1]*n_neurons`
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         feedforward_input = jnp.zeros(
-#             (
-#                 X.shape[0],
-#                 X.shape[1] + delta_features,
-#             )
-#         )
-#         with expectation:
-#             model.simulate(
-#                 random_key=jax.random.key(123),
-#                 feedforward_input=feedforward_input,
-#             )
-#
+
+    @pytest.mark.parametrize(
+        "score_type, expectation",
+        [
+            ("pseudo-r2-McFadden", does_not_raise()),
+            ("pseudo-r2-Cohen", does_not_raise()),
+            ("log-likelihood", does_not_raise()),
+            (
+                "not-implemented",
+                pytest.raises(
+                    NotImplementedError,
+                    match="Scoring method not-implemented not implemented",
+                ),
+            ),
+        ],
+    )
+    def test_score_type_r2(
+        self, score_type, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `score` method for unsupported scoring types.
+        Ensure only valid score types are used.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        with expectation:
+            model.score(X, y, score_type=score_type)
+
+    def test_loglikelihood_against_scipy_stats(self, poisson_population_GLM_model):
+        """
+        Compare the model's log-likelihood computation against `jax.scipy`.
+        Ensure consistent and correct calculations.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        # set model coeff
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        model._initialize_feature_mask(X, y)
+        # get the rate
+        mean_firing = model.predict(X)
+        # compute the log-likelihood using jax.scipy
+        mean_ll_jax = jax.scipy.stats.poisson.logpmf(y, mean_firing).mean()
+        model_ll = model.score(X, y, score_type="log-likelihood")
+        if not np.allclose(mean_ll_jax, model_ll):
+            raise ValueError(
+                "Log-likelihood of PoissonModel does not match" "that of jax.scipy!"
+            )
+
+    #######################
+    # Test model.predict
+    #######################
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+        ],
+    )
+    def test_predict_x_dimensionality(
+        self, delta_dim, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `predict` method with x input data of different dimensionalities.
+        Ensure correct dimensionality for x.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        model._initialize_feature_mask(X, y)
+        if delta_dim == -1:
+            X = np.zeros((X.shape[0],))
+        elif delta_dim == 1:
+            X = np.zeros((X.shape[0], X.shape[1], 1))
+        with expectation:
+            model.predict(X)
+
+    @pytest.mark.parametrize(
+        "delta_n_features, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+        ],
+    )
+    def test_predict_n_feature_consistency_x(
+        self, delta_n_features, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `predict` method ensuring the number of features in x input data
+        is consistent with the model's `model.coef_`.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        model._initialize_feature_mask(X, y)
+        if delta_n_features == 1:
+            X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+        elif delta_n_features == -1:
+            X = X[..., :-1]
+        with expectation:
+            model.predict(X)
+
+    @pytest.mark.parametrize(
+        "is_fit, expectation",
+        [
+            (True, does_not_raise()),
+            (
+                False,
+                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+            ),
+        ],
+    )
+    def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+        """
+        Test the `score` method on models based on their fit status.
+        Ensure scoring is only possible on fitted models.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if is_fit:
+            model.fit(X, y)
+        with expectation:
+            model.predict(X)
+
+    #######################
+    # Test model.simulate
+    #######################
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+        ],
+    )
+    def test_simulate_input_dimensionality(
+        self, delta_dim, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `simulate` method with input data of different dimensionalities.
+        Ensure correct dimensionality for input.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        model._initialize_feature_mask(X, y)
+        if delta_dim == -1:
+            X = np.zeros(X.shape[:-1])
+        elif delta_dim == 1:
+            X = np.zeros(X.shape + (1,))
+        with expectation:
+            model.simulate(
+                random_key=jax.random.key(123),
+                feedforward_input=X,
+            )
+
+    @pytest.mark.parametrize(
+        "is_fit, expectation",
+        [
+            (True, does_not_raise()),
+            (
+                False,
+                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+            ),
+        ],
+    )
+    def test_simulate_is_fit(self, is_fit, expectation, poisson_population_GLM_model):
+        """
+        Test if the model raises a ValueError when trying to simulate before it's fitted.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        if is_fit:
+            model.coef_ = true_params[0]
+            model.intercept_ = true_params[1]
+            model._initialize_feature_mask(X, y)
+        with expectation:
+            model.simulate(
+                random_key=jax.random.key(123),
+                feedforward_input=X,
+            )
+
+    @pytest.mark.parametrize(
+        "delta_features, expectation",
+        [
+            (
+                -1,
+                pytest.raises(
+                    ValueError,
+                    match="Inconsistent number of features. spike basis coefficients has",
+                ),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(
+                    ValueError,
+                    match="Inconsistent number of features. spike basis coefficients has",
+                ),
+            ),
+        ],
+    )
+    def test_simulate_feature_consistency_input(
+        self, delta_features, expectation, poisson_population_GLM_model
+    ):
+        """
+        Test the `simulate` method ensuring the number of features in `feedforward_input` is
+        consistent with the model's expected number of features.
+
+        Notes
+        -----
+        The total feature number `model.coef_.shape[1]` must be equal to
+        `feedforward_input.shape[2] + coupling_basis.shape[1]*n_neurons`
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        model._initialize_feature_mask(X, y)
+        feedforward_input = jnp.zeros(
+            (
+                X.shape[0],
+                X.shape[1] + delta_features,
+            )
+        )
+        with expectation:
+            model.simulate(
+                random_key=jax.random.key(123),
+                feedforward_input=feedforward_input,
+            )
+
 #     def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
 #         """Test that simulate goes through"""
 #         X, y, model, params, rate = poissonGLM_model_instantiation

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1843,26 +1843,26 @@ class TestPopulationGLM:
         with expectation:
             model.simulate(jax.random.key(123), X)
 
-#     #######################################
-#     # Compare with standard implementation
-#     #######################################
-#     def test_deviance_against_statsmodels(self, poissonGLM_model_instantiation):
-#         """
-#         Compare fitted parameters to statsmodels.
-#         Assesses if the model estimates are close to statsmodels' results.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         # set model coeff
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         # get the rate
-#         dev = sm.families.Poisson().deviance(y, firing_rate)
-#         dev_model = model.observation_model.deviance(firing_rate, y).sum()
-#         if not np.allclose(dev, dev_model):
-#             raise ValueError("Deviance doesn't match statsmodels!")
-#
-#     def test_compatibility_with_sklearn_cv(self, poissonGLM_model_instantiation):
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
-#         GridSearchCV(model, param_grid).fit(X, y)
+    #######################################
+    # Compare with standard implementation
+    #######################################
+    def test_deviance_against_statsmodels(self, poisson_population_GLM_model):
+        """
+        Compare fitted parameters to statsmodels.
+        Assesses if the model estimates are close to statsmodels' results.
+        """
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        # set model coeff
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        # get the rate
+        dev = sm.families.Poisson().deviance(y, firing_rate)
+        dev_model = model.observation_model.deviance(firing_rate, y).sum()
+        if not np.allclose(dev, dev_model):
+            raise ValueError("Deviance doesn't match statsmodels!")
+
+    def test_compatibility_with_sklearn_cv(self, poisson_population_GLM_model):
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
+        GridSearchCV(model, param_grid).fit(X, y)
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1896,11 +1896,17 @@ class TestPopulationGLM:
              pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
         ]
     )
-    def test_feature_mask_compatibility_fit(self, mask, expectation, poisson_population_GLM_model):
+    @pytest.mark.parametrize("attr_name", ["fit", "predict", "score"])
+    def test_feature_mask_compatibility_fit(self, mask, expectation, attr_name, poisson_population_GLM_model):
         X, y, model, true_params, firing_rate = poisson_population_GLM_model
         model.feature_mask = mask
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
         with expectation:
-            model.fit(X, y)
+            if attr_name == "predict":
+                getattr(model, attr_name)(X)
+            else:
+                getattr(model, attr_name)(X, y)
 
     @pytest.mark.parametrize(
         "mask, expectation",
@@ -1920,105 +1926,17 @@ class TestPopulationGLM:
              pytest.raises(TypeError, match="feature_mask and X must have the same structure"))
         ]
     )
-    def test_feature_mask_compatibility_fit_tree(self, mask, expectation, poisson_population_GLM_model_pytree):
+    @pytest.mark.parametrize("attr_name", ["fit", "predict", "score"])
+    def test_feature_mask_compatibility_fit_tree(self, mask, expectation, attr_name, poisson_population_GLM_model_pytree):
         X, y, model, true_params, firing_rate = poisson_population_GLM_model_pytree
         model.feature_mask = mask
-        with expectation:
-            model.fit(X, y)
-
-    @pytest.mark.parametrize(
-        "mask, expectation",
-        [
-            (np.array([0, 1, 1] * 5).reshape(5, 3), does_not_raise()),
-            (np.array([0, 1, 1] * 4).reshape(4, 3), pytest.raises(ValueError, match="Inconsistent number of features")),
-            (np.array([0, 1, 1, 1] * 5).reshape(5, 4),
-             pytest.raises(ValueError, match="Inconsistent number of neurons")),
-            ({"input_1": np.array([0, 1, 0]), "input_2": np.array([1, 0, 1])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            ({"input_1": np.array([0, 1, 0, 1]), "input_2": np.array([1, 0, 1, 0])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-        ]
-    )
-    def test_feature_mask_compatibility_predict(self, mask, expectation, poisson_population_GLM_model):
-        X, y, model, true_params, firing_rate = poisson_population_GLM_model
         model.coef_ = true_params[0]
         model.intercept_ = true_params[1]
-        model._feature_mask = mask
         with expectation:
-            model.predict(X)
-
-    @pytest.mark.parametrize(
-        "mask, expectation",
-        [
-            (np.array([0, 1, 1] * 5).reshape(5, 3),
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            (np.array([0, 1, 1] * 4).reshape(4, 3),
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            (np.array([0, 1, 1, 1] * 5).reshape(5, 4),
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            ({"input_1": np.array([0, 1, 0]), "input_2": np.array([1, 0, 1])}, does_not_raise()),
-            ({"input_1": np.array([0, 1, 0, 1]), "input_2": np.array([1, 0, 1, 0])},
-             pytest.raises(ValueError, match="Inconsistent number of neurons")),
-            ({"input_1": np.array([0, 1, 0])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            ({"input_1": np.array([0, 1, 0, 1])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure"))
-        ]
-    )
-    def test_feature_mask_compatibility_fit_tree(self, mask, expectation, poisson_population_GLM_model_pytree):
-        X, y, model, true_params, firing_rate = poisson_population_GLM_model_pytree
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        model._feature_mask = mask
-        with expectation:
-            model.predict(X)
-
-    @pytest.mark.parametrize(
-        "mask, expectation",
-        [
-            (np.array([0, 1, 1] * 5).reshape(5, 3), does_not_raise()),
-            (np.array([0, 1, 1] * 4).reshape(4, 3), pytest.raises(ValueError, match="Inconsistent number of features")),
-            (np.array([0, 1, 1, 1] * 5).reshape(5, 4),
-             pytest.raises(ValueError, match="Inconsistent number of neurons")),
-            ({"input_1": np.array([0, 1, 0]), "input_2": np.array([1, 0, 1])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            ({"input_1": np.array([0, 1, 0, 1]), "input_2": np.array([1, 0, 1, 0])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-        ]
-    )
-    def test_feature_mask_compatibility_score(self, mask, expectation, poisson_population_GLM_model):
-        X, y, model, true_params, firing_rate = poisson_population_GLM_model
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        model._feature_mask = mask
-        with expectation:
-            model.score(X, y)
-
-    @pytest.mark.parametrize(
-        "mask, expectation",
-        [
-            (np.array([0, 1, 1] * 5).reshape(5, 3),
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            (np.array([0, 1, 1] * 4).reshape(4, 3),
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            (np.array([0, 1, 1, 1] * 5).reshape(5, 4),
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            ({"input_1": np.array([0, 1, 0]), "input_2": np.array([1, 0, 1])}, does_not_raise()),
-            ({"input_1": np.array([0, 1, 0, 1]), "input_2": np.array([1, 0, 1, 0])},
-             pytest.raises(ValueError, match="Inconsistent number of neurons")),
-            ({"input_1": np.array([0, 1, 0])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure")),
-            ({"input_1": np.array([0, 1, 0, 1])},
-             pytest.raises(TypeError, match="feature_mask and X must have the same structure"))
-        ]
-    )
-    def test_feature_mask_compatibility_score_tree(self, mask, expectation, poisson_population_GLM_model_pytree):
-        X, y, model, true_params, firing_rate = poisson_population_GLM_model_pytree
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        model._feature_mask = mask
-        with expectation:
-            model.score(X, y)
+            if attr_name == "predict":
+                getattr(model, attr_name)(X)
+            else:
+                getattr(model, attr_name)(X, y)
 
     @pytest.mark.parametrize(
         "regularizer",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -439,15 +439,15 @@ class TestGLM:
         with expectation:
             model.fit(X, y, init_params=true_params)
 
-#     def test_fit_mask_grouplasso(self, group_sparse_poisson_glm_model_instantiation):
-#         """Test that the group lasso fit goes through"""
-#         X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
-#         model.set_params(
-#             regularizer=nmo.regularizer.GroupLasso(
-#                 solver_name="ProximalGradient", mask=mask
-#             )
-#         )
-#         model.fit(X, y)
+    def test_fit_mask_grouplasso(self, group_sparse_poisson_glm_model_instantiation):
+        """Test that the group lasso fit goes through"""
+        X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
+        model.set_params(
+            regularizer=nmo.regularizer.GroupLasso(
+                solver_name="ProximalGradient", mask=mask
+            )
+        )
+        model.fit(X, y)
 #
 #     def test_fit_pytree_equivalence(
 #         self, poissonGLM_model_instantiation, poissonGLM_model_instantiation_pytree

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -61,6 +61,923 @@ class TestGLM:
             ),
         ],
     )
+    def test_solver_type(self, regularizer, expectation, glm_class):
+        """
+        Test that an error is raised if a non-compatible solver is passed.
+        """
+        with expectation:
+            glm_class(regularizer=regularizer)
+
+    @pytest.mark.parametrize(
+        "observation, expectation",
+        [
+            (nmo.observation_models.PoissonObservations(), does_not_raise()),
+            (
+                nmo.regularizer.Regularizer,
+                pytest.raises(
+                    AttributeError,
+                    match="The provided object does not have the required",
+                ),
+            ),
+            (
+                1,
+                pytest.raises(
+                    AttributeError,
+                    match="The provided object does not have the required",
+                ),
+            ),
+        ],
+    )
+    def test_init_observation_type(
+        self, observation, expectation, glm_class, ridge_regularizer
+    ):
+        """
+        Test initialization with different regularizer names. Check if an appropriate exception is raised
+        when the regularizer name is not present in jaxopt.
+        """
+        with expectation:
+            glm_class(regularizer=ridge_regularizer, observation_model=observation)
+
+    @pytest.mark.parametrize(
+        "X, y",
+        [
+            (jnp.zeros((2, 4)), jnp.zeros((2,))),
+            (jnp.zeros((2, 4)), jnp.zeros((2,))),
+        ],
+    )
+    def test_parameter_initialization(self, X, y, poissonGLM_model_instantiation):
+        _, _, model, _, _ = poissonGLM_model_instantiation
+        coef, inter = model._initialize_parameters(X, y)
+        assert coef.shape == (X.shape[1],)
+        assert inter.shape == (1,)
+
+    #######################
+    # Test model.fit
+    #######################
+    @pytest.mark.parametrize(
+        "n_params, expectation",
+        [
+            (0, pytest.raises(ValueError, match="Params must have length two.")),
+            (1, pytest.raises(ValueError, match="Params must have length two.")),
+            (2, does_not_raise()),
+            (3, pytest.raises(ValueError, match="Params must have length two.")),
+        ],
+    )
+    def test_fit_param_length(
+        self, n_params, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method with different numbers of initial parameters.
+        Check for correct number of parameters.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if n_params == 0:
+            init_params = tuple()
+        elif n_params == 1:
+            init_params = (true_params[0],)
+        else:
+            init_params = true_params + (true_params[0],) * (n_params - 2)
+        with expectation:
+            model.fit(X, y, init_params=init_params)
+
+    @pytest.mark.parametrize(
+        "add_entry, add_to, expectation",
+        [
+            (0, "X", does_not_raise()),
+            (
+                np.nan,
+                "X",
+                pytest.warns(UserWarning, match="The provided trees contain"),
+            ),
+            (
+                np.inf,
+                "X",
+                pytest.warns(UserWarning, match="The provided trees contain"),
+            ),
+            (0, "y", does_not_raise()),
+            (
+                np.nan,
+                "y",
+                pytest.warns(UserWarning, match="The provided trees contain"),
+            ),
+            (
+                np.inf,
+                "y",
+                pytest.warns(UserWarning, match="The provided trees contain"),
+            ),
+        ],
+    )
+    def test_fit_param_values(
+        self, add_entry, add_to, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method with altered X or y values. Ensure the method raises exceptions for NaN or Inf values.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if add_to == "X":
+            # get an index to be edited
+            idx = np.unravel_index(np.random.choice(X.size), X.shape)
+            X[idx] = add_entry
+        elif add_to == "y":
+            idx = np.unravel_index(np.random.choice(y.size), y.shape)
+            y = np.asarray(y, dtype=np.float32)
+            y[idx] = add_entry
+        with expectation:
+            model.fit(X, y, init_params=true_params)
+
+    @pytest.mark.parametrize(
+        "dim_weights, expectation",
+        [
+            (
+                0,
+                pytest.raises(
+                    ValueError,
+                    match=r"Inconsistent number of features",
+                ),
+            ),
+            (
+                1,
+                does_not_raise(),
+            ),
+            (
+                2,
+                pytest.raises(
+                    ValueError,
+                    match=r"params\[0\] must be an array or .* of shape \(n_features",
+                ),
+            ),
+            (
+                3,
+                pytest.raises(
+                    ValueError,
+                    match=r"params\[0\] must be an array or .* of shape \(n_features",
+                ),
+            ),
+        ],
+    )
+    def test_fit_weights_dimensionality(
+        self, dim_weights, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method with weight matrices of different dimensionalities.
+        Check for correct dimensionality.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        n_samples, n_features = X.shape
+        n_neurons = 4
+        if dim_weights == 0:
+            init_w = jnp.array([])
+        elif dim_weights == 1:
+            init_w = jnp.zeros((n_features,))
+        elif dim_weights == 2:
+            init_w = jnp.zeros((n_features, n_neurons))
+        else:
+            init_w = jnp.zeros((n_features, n_neurons) + (1,) * (dim_weights - 2))
+        with expectation:
+            model.fit(X, y, init_params=(init_w, true_params[1]))
+
+    @pytest.mark.parametrize(
+        "dim_intercepts, expectation",
+        [
+            (0, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
+            (1, does_not_raise()),
+            (2, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
+            (3, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
+        ],
+    )
+    def test_fit_intercepts_dimensionality(
+        self, dim_intercepts, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method with intercepts of different dimensionalities. Check for correct dimensionality.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        n_samples, n_features = X.shape
+        init_b = jnp.zeros((1,) * dim_intercepts)
+        init_w = jnp.zeros((n_features,))
+        with expectation:
+            model.fit(X, y, init_params=(init_w, init_b))
+
+    @pytest.mark.parametrize(
+        "init_params, expectation",
+        [
+            ([jnp.zeros((5,)), jnp.zeros((1,))], does_not_raise()),
+            (
+                [[jnp.zeros((1, 5)), jnp.zeros((1,))]],
+                pytest.raises(ValueError, match="Params must have length two."),
+            ),
+            (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), pytest.raises(KeyError)),
+            (
+                (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), jnp.zeros((1,))),
+                pytest.raises(
+                    TypeError, match=r"X and params\[0\] must be the same type"
+                ),
+            ),
+            (
+                (
+                    FeaturePytree(p1=jnp.zeros((5,)), p2=jnp.zeros((5,))),
+                    jnp.zeros((1,)),
+                ),
+                pytest.raises(
+                    TypeError, match=r"X and params\[0\] must be the same type"
+                ),
+            ),
+            (0, pytest.raises(ValueError, match="Params must have length two.")),
+            (
+                {0, 1},
+                pytest.raises(TypeError, match="Initial parameters must be array-like"),
+            ),
+            (
+                [jnp.zeros((1, 5)), ""],
+                pytest.raises(TypeError, match="Initial parameters must be array-like"),
+            ),
+            (
+                ["", jnp.zeros((1,))],
+                pytest.raises(TypeError, match="Initial parameters must be array-like"),
+            ),
+        ],
+    )
+    def test_fit_init_params_type(
+        self, init_params, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method with various types of initial parameters. Ensure that the provided initial parameters
+        are array-like.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        with expectation:
+            model.fit(X, y, init_params=init_params)
+
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+        ],
+    )
+    def test_fit_x_dimensionality(
+        self, delta_dim, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if delta_dim == -1:
+            X = np.zeros((X.shape[0],))
+        elif delta_dim == 1:
+            X = np.zeros((X.shape[0], 1, X.shape[1]))
+        with expectation:
+            model.fit(X, y, init_params=true_params)
+
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="y must be one-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="y must be one-dimensional")),
+        ],
+    )
+    def test_fit_y_dimensionality(
+        self, delta_dim, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method with y target data of different dimensionalities. Ensure correct dimensionality for y.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if delta_dim == -1:
+            y = np.zeros([])
+        elif delta_dim == 1:
+            y = np.zeros((y.shape[0], 1))
+        with expectation:
+            model.fit(X, y, init_params=true_params)
+
+    @pytest.mark.parametrize(
+        "delta_n_features, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+        ],
+    )
+    def test_fit_n_feature_consistency_weights(
+        self, delta_n_features, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method for inconsistencies between data features and initial weights provided.
+        Ensure the number of features align.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        init_w = jnp.zeros((X.shape[1] + delta_n_features))
+        init_b = jnp.zeros(
+            1,
+        )
+        with expectation:
+            model.fit(X, y, init_params=(init_w, init_b))
+
+    @pytest.mark.parametrize(
+        "delta_n_features, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+        ],
+    )
+    def test_fit_n_feature_consistency_x(
+        self, delta_n_features, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method for inconsistencies between data features and model's expectations.
+        Ensure the number of features in X aligns.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if delta_n_features == 1:
+            X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+        elif delta_n_features == -1:
+            X = X[..., :-1]
+        with expectation:
+            model.fit(X, y, init_params=true_params)
+
+    @pytest.mark.parametrize(
+        "delta_tp, expectation",
+        [
+            (
+                -1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+        ],
+    )
+    def test_fit_time_points_x(
+        self, delta_tp, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method for inconsistencies in time-points in data X. Ensure the correct number of time-points.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
+        with expectation:
+            model.fit(X, y, init_params=true_params)
+
+    @pytest.mark.parametrize(
+        "delta_tp, expectation",
+        [
+            (
+                -1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+        ],
+    )
+    def test_fit_time_points_y(
+        self, delta_tp, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `fit` method for inconsistencies in time-points in y. Ensure the correct number of time-points.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
+        with expectation:
+            model.fit(X, y, init_params=true_params)
+
+    def test_fit_mask_grouplasso(self, group_sparse_poisson_glm_model_instantiation):
+        """Test that the group lasso fit goes through"""
+        X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
+        model.set_params(
+            regularizer=nmo.regularizer.GroupLasso(
+                solver_name="ProximalGradient", mask=mask
+            )
+        )
+        model.fit(X, y)
+
+    def test_fit_pytree_equivalence(
+        self, poissonGLM_model_instantiation, poissonGLM_model_instantiation_pytree
+    ):
+        """Check that the glm fit with pytree learns the same parameters."""
+        # required for numerical precision of coeffs
+        jax.config.update("jax_enable_x64", True)
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X_tree, _, model_tree, true_params_tree, _ = (
+            poissonGLM_model_instantiation_pytree
+        )
+        # fit both models
+        model.fit(X, y, init_params=true_params)
+        model_tree.fit(X_tree, y, init_params=true_params_tree)
+
+        # get the flat parameters
+        flat_coef = np.concatenate(
+            jax.tree_util.tree_flatten(model_tree.coef_)[0], axis=-1
+        )
+
+        # assert equivalence of solutions
+        assert np.allclose(model.coef_, flat_coef)
+        assert np.allclose(model.intercept_, model_tree.intercept_)
+        assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
+        assert np.allclose(model.predict(X), model_tree.predict(X_tree))
+
+    @pytest.mark.parametrize(
+        "fill_val, expectation",
+        [
+            (0, does_not_raise()),
+            (
+                jnp.inf,
+                pytest.raises(
+                    ValueError, match="At least a NaN or an Inf at all sample points"
+                ),
+            ),
+            (
+                jnp.nan,
+                pytest.raises(
+                    ValueError, match="At least a NaN or an Inf at all sample points"
+                ),
+            ),
+        ],
+    )
+    def test_fit_all_invalid_X(
+        self, fill_val, expectation, poissonGLM_model_instantiation
+    ):
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        X.fill(fill_val)
+        with expectation:
+            model.fit(X, y)
+
+    #######################
+    # Test model.score
+    #######################
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+        ],
+    )
+    def test_score_x_dimensionality(
+        self, delta_dim, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `score` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_dim == -1:
+            X = np.zeros((X.shape[0],))
+        elif delta_dim == 1:
+            X = np.zeros((X.shape[0], X.shape[1], 1))
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (
+                -1,
+                pytest.raises(
+                    ValueError, match="y must be one-dimensional, with shape"
+                ),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(
+                    ValueError, match="y must be one-dimensional, with shape"
+                ),
+            ),
+        ],
+    )
+    def test_score_y_dimensionality(
+        self, delta_dim, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `score` method with y of different dimensionalities.
+        Ensure correct dimensionality for y.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_dim == -1:
+            y = np.zeros([])
+        elif delta_dim == 1:
+            y = np.zeros((X.shape[0], X.shape[1]))
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "delta_n_features, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+        ],
+    )
+    def test_score_n_feature_consistency_x(
+        self, delta_n_features, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `score` method for inconsistencies in features of X.
+        Ensure the number of features in X aligns with the model params.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_n_features == 1:
+            X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+        elif delta_n_features == -1:
+            X = X[..., :-1]
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "is_fit, expectation",
+        [
+            (True, does_not_raise()),
+            (
+                False,
+                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+            ),
+        ],
+    )
+    def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+        """
+        Test the `score` method on models based on their fit status.
+        Ensure scoring is only possible on fitted models.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if is_fit:
+            model.fit(X, y)
+        with expectation:
+            model.predict(X)
+
+    @pytest.mark.parametrize(
+        "delta_tp, expectation",
+        [
+            (
+                -1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+        ],
+    )
+    def test_score_time_points_x(
+        self, delta_tp, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `score` method for inconsistencies in time-points in X.
+        Ensure that the number of time-points in X and y matches.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "delta_tp, expectation",
+        [
+            (
+                -1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(ValueError, match="The number of time-points in X and y"),
+            ),
+        ],
+    )
+    def test_score_time_points_y(
+        self, delta_tp, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `score` method for inconsistencies in time-points in y.
+        Ensure that the number of time-points in X and y matches.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
+        with expectation:
+            model.score(X, y)
+
+    @pytest.mark.parametrize(
+        "score_type, expectation",
+        [
+            ("pseudo-r2-McFadden", does_not_raise()),
+            ("pseudo-r2-Cohen", does_not_raise()),
+            ("log-likelihood", does_not_raise()),
+            (
+                "not-implemented",
+                pytest.raises(
+                    NotImplementedError,
+                    match="Scoring method not-implemented not implemented",
+                ),
+            ),
+        ],
+    )
+    def test_score_type_r2(
+        self, score_type, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `score` method for unsupported scoring types.
+        Ensure only valid score types are used.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        with expectation:
+            model.score(X, y, score_type=score_type)
+
+    def test_loglikelihood_against_scipy_stats(self, poissonGLM_model_instantiation):
+        """
+        Compare the model's log-likelihood computation against `jax.scipy`.
+        Ensure consistent and correct calculations.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        # set model coeff
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        # get the rate
+        mean_firing = model.predict(X)
+        # compute the log-likelihood using jax.scipy
+        mean_ll_jax = jax.scipy.stats.poisson.logpmf(y, mean_firing).mean()
+        model_ll = model.score(X, y, score_type="log-likelihood")
+        if not np.allclose(mean_ll_jax, model_ll):
+            raise ValueError(
+                "Log-likelihood of PoissonModel does not match" "that of jax.scipy!"
+            )
+
+    #######################
+    # Test model.predict
+    #######################
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+        ],
+    )
+    def test_predict_x_dimensionality(
+        self, delta_dim, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `predict` method with x input data of different dimensionalities.
+        Ensure correct dimensionality for x.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_dim == -1:
+            X = np.zeros((X.shape[0],))
+        elif delta_dim == 1:
+            X = np.zeros((X.shape[0], X.shape[1], 1))
+        with expectation:
+            model.predict(X)
+
+    @pytest.mark.parametrize(
+        "delta_n_features, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="Inconsistent number of features")),
+        ],
+    )
+    def test_predict_n_feature_consistency_x(
+        self, delta_n_features, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `predict` method ensuring the number of features in x input data
+        is consistent with the model's `model.coef_`.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_n_features == 1:
+            X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
+        elif delta_n_features == -1:
+            X = X[..., :-1]
+        with expectation:
+            model.predict(X)
+
+    @pytest.mark.parametrize(
+        "is_fit, expectation",
+        [
+            (True, does_not_raise()),
+            (
+                False,
+                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+            ),
+        ],
+    )
+    def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+        """
+        Test the `score` method on models based on their fit status.
+        Ensure scoring is only possible on fitted models.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if is_fit:
+            model.fit(X, y)
+        with expectation:
+            model.predict(X)
+
+    #######################
+    # Test model.simulate
+    #######################
+    @pytest.mark.parametrize(
+        "delta_dim, expectation",
+        [
+            (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
+            (0, does_not_raise()),
+            (1, pytest.raises(ValueError, match="X must be two-dimensional")),
+        ],
+    )
+    def test_simulate_input_dimensionality(
+        self, delta_dim, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `simulate` method with input data of different dimensionalities.
+        Ensure correct dimensionality for input.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        if delta_dim == -1:
+            X = np.zeros(X.shape[:-1])
+        elif delta_dim == 1:
+            X = np.zeros(X.shape + (1,))
+        with expectation:
+            model.simulate(
+                random_key=jax.random.key(123),
+                feedforward_input=X,
+            )
+
+    @pytest.mark.parametrize(
+        "is_fit, expectation",
+        [
+            (True, does_not_raise()),
+            (
+                False,
+                pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
+            ),
+        ],
+    )
+    def test_simulate_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
+        """
+        Test if the model raises a ValueError when trying to simulate before it's fitted.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        if is_fit:
+            model.coef_ = true_params[0]
+            model.intercept_ = true_params[1]
+        with expectation:
+            model.simulate(
+                random_key=jax.random.key(123),
+                feedforward_input=X,
+            )
+
+    @pytest.mark.parametrize(
+        "delta_features, expectation",
+        [
+            (
+                -1,
+                pytest.raises(
+                    ValueError,
+                    match="Inconsistent number of features. spike basis coefficients has",
+                ),
+            ),
+            (0, does_not_raise()),
+            (
+                1,
+                pytest.raises(
+                    ValueError,
+                    match="Inconsistent number of features. spike basis coefficients has",
+                ),
+            ),
+        ],
+    )
+    def test_simulate_feature_consistency_input(
+        self, delta_features, expectation, poissonGLM_model_instantiation
+    ):
+        """
+        Test the `simulate` method ensuring the number of features in `feedforward_input` is
+        consistent with the model's expected number of features.
+
+        Notes
+        -----
+        The total feature number `model.coef_.shape[1]` must be equal to
+        `feedforward_input.shape[2] + coupling_basis.shape[1]*n_neurons`
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        feedforward_input = jnp.zeros(
+            (
+                X.shape[0],
+                X.shape[1] + delta_features,
+            )
+        )
+        with expectation:
+            model.simulate(
+                random_key=jax.random.key(123),
+                feedforward_input=feedforward_input,
+            )
+
+    def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
+        """Test that simulate goes through"""
+        X, y, model, params, rate = poissonGLM_model_instantiation
+        model.coef_ = params[0]
+        model.intercept_ = params[1]
+        ysim, ratesim = model.simulate(jax.random.key(123), X)
+        # check that the expected dimensionality is returned
+        assert ysim.ndim == 1
+        assert ratesim.ndim == 1
+        # check that the rates and spikes has the same shape
+        assert ratesim.shape[0] == ysim.shape[0]
+        # check the time point number is that expected (same as the input)
+        assert ysim.shape[0] == X.shape[0]
+
+    @pytest.mark.parametrize(
+        "insert, expectation",
+        [
+            (0, does_not_raise()),
+            (np.nan, pytest.warns(UserWarning, match=r"The provided trees contain")),
+            (np.inf, pytest.warns(UserWarning, match=r"The provided trees contain")),
+        ],
+    )
+    def test_simulate_invalid_feedforward(
+        self, insert, expectation, poissonGLM_model_instantiation
+    ):
+        X, y, model, params, rate = poissonGLM_model_instantiation
+        model.coef_ = params[0]
+        model.intercept_ = params[1]
+        X[0] = insert
+        with expectation:
+            model.simulate(jax.random.key(123), X)
+
+    #######################################
+    # Compare with standard implementation
+    #######################################
+    def test_deviance_against_statsmodels(self, poissonGLM_model_instantiation):
+        """
+        Compare fitted parameters to statsmodels.
+        Assesses if the model estimates are close to statsmodels' results.
+        """
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        # set model coeff
+        model.coef_ = true_params[0]
+        model.intercept_ = true_params[1]
+        # get the rate
+        dev = sm.families.Poisson().deviance(y, firing_rate)
+        dev_model = model.observation_model.deviance(firing_rate, y).sum()
+        if not np.allclose(dev, dev_model):
+            raise ValueError("Deviance doesn't match statsmodels!")
+
+    def test_compatibility_with_sklearn_cv(self, poissonGLM_model_instantiation):
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
+        param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
+        GridSearchCV(model, param_grid).fit(X, y)
+
+
+class TestPopulationGLM:
+    """
+    Unit tests for the PoissonGLM class.
+    """
+
+    #######################
+    # Test model.__init__
+    #######################
+    @pytest.mark.parametrize(
+        "regularizer, expectation",
+        [
+            (nmo.regularizer.Ridge("BFGS"), does_not_raise()),
+            (
+                None,
+                pytest.raises(
+                    AttributeError, match="The provided `solver` doesn't implement "
+                ),
+            ),
+            (
+                nmo.regularizer.Ridge,
+                pytest.raises(
+                    TypeError, match="The provided `solver` cannot be instantiated"
+                ),
+            ),
+        ],
+    )
     def test_solver_type(self, regularizer, expectation, population_glm_class):
         """
         Test that an error is raised if a non-compatible solver is passed.
@@ -948,920 +1865,4 @@ class TestGLM:
 #         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
 #         param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
 #         GridSearchCV(model, param_grid).fit(X, y)
-#
-#
-# class TestPopulationGLM:
-#     """
-#     Unit tests for the PoissonGLM class.
-#     """
-#
-#     #######################
-#     # Test model.__init__
-#     #######################
-#     @pytest.mark.parametrize(
-#         "regularizer, expectation",
-#         [
-#             (nmo.regularizer.Ridge("BFGS"), does_not_raise()),
-#             (
-#                 None,
-#                 pytest.raises(
-#                     AttributeError, match="The provided `solver` doesn't implement "
-#                 ),
-#             ),
-#             (
-#                 nmo.regularizer.Ridge,
-#                 pytest.raises(
-#                     TypeError, match="The provided `solver` cannot be instantiated"
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_solver_type(self, regularizer, expectation, glm_class):
-#         """
-#         Test that an error is raised if a non-compatible solver is passed.
-#         """
-#         with expectation:
-#             glm_class(regularizer=regularizer)
-#
-#     @pytest.mark.parametrize(
-#         "observation, expectation",
-#         [
-#             (nmo.observation_models.PoissonObservations(), does_not_raise()),
-#             (
-#                 nmo.regularizer.Regularizer,
-#                 pytest.raises(
-#                     AttributeError,
-#                     match="The provided object does not have the required",
-#                 ),
-#             ),
-#             (
-#                 1,
-#                 pytest.raises(
-#                     AttributeError,
-#                     match="The provided object does not have the required",
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_init_observation_type(
-#         self, observation, expectation, glm_class, ridge_regularizer
-#     ):
-#         """
-#         Test initialization with different regularizer names. Check if an appropriate exception is raised
-#         when the regularizer name is not present in jaxopt.
-#         """
-#         with expectation:
-#             glm_class(regularizer=ridge_regularizer, observation_model=observation)
-#
-#     @pytest.mark.parametrize(
-#         "X, y",
-#         [
-#             (jnp.zeros((2, 4)), jnp.zeros((2,))),
-#             (jnp.zeros((2, 4)), jnp.zeros((2,))),
-#         ],
-#     )
-#     def test_parameter_initialization(self, X, y, poissonGLM_model_instantiation):
-#         _, _, model, _, _ = poissonGLM_model_instantiation
-#         coef, inter = model._initialize_parameters(X, y)
-#         assert coef.shape == (X.shape[1],)
-#         assert inter.shape == (1,)
-#
-#     #######################
-#     # Test model.fit
-#     #######################
-#     @pytest.mark.parametrize(
-#         "n_params, expectation",
-#         [
-#             (0, pytest.raises(ValueError, match="Params must have length two.")),
-#             (1, pytest.raises(ValueError, match="Params must have length two.")),
-#             (2, does_not_raise()),
-#             (3, pytest.raises(ValueError, match="Params must have length two.")),
-#         ],
-#     )
-#     def test_fit_param_length(
-#         self, n_params, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method with different numbers of initial parameters.
-#         Check for correct number of parameters.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if n_params == 0:
-#             init_params = tuple()
-#         elif n_params == 1:
-#             init_params = (true_params[0],)
-#         else:
-#             init_params = true_params + (true_params[0],) * (n_params - 2)
-#         with expectation:
-#             model.fit(X, y, init_params=init_params)
-#
-#     @pytest.mark.parametrize(
-#         "add_entry, add_to, expectation",
-#         [
-#             (0, "X", does_not_raise()),
-#             (
-#                 np.nan,
-#                 "X",
-#                 pytest.warns(UserWarning, match="The provided trees contain"),
-#             ),
-#             (
-#                 np.inf,
-#                 "X",
-#                 pytest.warns(UserWarning, match="The provided trees contain"),
-#             ),
-#             (0, "y", does_not_raise()),
-#             (
-#                 np.nan,
-#                 "y",
-#                 pytest.warns(UserWarning, match="The provided trees contain"),
-#             ),
-#             (
-#                 np.inf,
-#                 "y",
-#                 pytest.warns(UserWarning, match="The provided trees contain"),
-#             ),
-#         ],
-#     )
-#     def test_fit_param_values(
-#         self, add_entry, add_to, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method with altered X or y values. Ensure the method raises exceptions for NaN or Inf values.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if add_to == "X":
-#             # get an index to be edited
-#             idx = np.unravel_index(np.random.choice(X.size), X.shape)
-#             X[idx] = add_entry
-#         elif add_to == "y":
-#             idx = np.unravel_index(np.random.choice(y.size), y.shape)
-#             y = np.asarray(y, dtype=np.float32)
-#             y[idx] = add_entry
-#         with expectation:
-#             model.fit(X, y, init_params=true_params)
-#
-#     @pytest.mark.parametrize(
-#         "dim_weights, expectation",
-#         [
-#             (
-#                 0,
-#                 pytest.raises(
-#                     ValueError,
-#                     match=r"Inconsistent number of features",
-#                 ),
-#             ),
-#             (
-#                 1,
-#                 does_not_raise(),
-#             ),
-#             (
-#                 2,
-#                 pytest.raises(
-#                     ValueError,
-#                     match=r"params\[0\] must be an array or .* of shape \(n_features",
-#                 ),
-#             ),
-#             (
-#                 3,
-#                 pytest.raises(
-#                     ValueError,
-#                     match=r"params\[0\] must be an array or .* of shape \(n_features",
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_fit_weights_dimensionality(
-#         self, dim_weights, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method with weight matrices of different dimensionalities.
-#         Check for correct dimensionality.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         n_samples, n_features = X.shape
-#         n_neurons = 4
-#         if dim_weights == 0:
-#             init_w = jnp.array([])
-#         elif dim_weights == 1:
-#             init_w = jnp.zeros((n_features,))
-#         elif dim_weights == 2:
-#             init_w = jnp.zeros((n_features, n_neurons))
-#         else:
-#             init_w = jnp.zeros((n_features, n_neurons) + (1,) * (dim_weights - 2))
-#         with expectation:
-#             model.fit(X, y, init_params=(init_w, true_params[1]))
-#
-#     @pytest.mark.parametrize(
-#         "dim_intercepts, expectation",
-#         [
-#             (0, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
-#             (1, does_not_raise()),
-#             (2, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
-#             (3, pytest.raises(ValueError, match=r"params\[1\] must be of shape")),
-#         ],
-#     )
-#     def test_fit_intercepts_dimensionality(
-#         self, dim_intercepts, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method with intercepts of different dimensionalities. Check for correct dimensionality.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         n_samples, n_features = X.shape
-#         init_b = jnp.zeros((1,) * dim_intercepts)
-#         init_w = jnp.zeros((n_features,))
-#         with expectation:
-#             model.fit(X, y, init_params=(init_w, init_b))
-#
-#     @pytest.mark.parametrize(
-#         "init_params, expectation",
-#         [
-#             ([jnp.zeros((5,)), jnp.zeros((1,))], does_not_raise()),
-#             (
-#                 [[jnp.zeros((1, 5)), jnp.zeros((1,))]],
-#                 pytest.raises(ValueError, match="Params must have length two."),
-#             ),
-#             (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), pytest.raises(KeyError)),
-#             (
-#                 (dict(p1=jnp.zeros((5,)), p2=jnp.zeros((1,))), jnp.zeros((1,))),
-#                 pytest.raises(
-#                     TypeError, match=r"X and params\[0\] must be the same type"
-#                 ),
-#             ),
-#             (
-#                 (
-#                     FeaturePytree(p1=jnp.zeros((5,)), p2=jnp.zeros((5,))),
-#                     jnp.zeros((1,)),
-#                 ),
-#                 pytest.raises(
-#                     TypeError, match=r"X and params\[0\] must be the same type"
-#                 ),
-#             ),
-#             (0, pytest.raises(ValueError, match="Params must have length two.")),
-#             (
-#                 {0, 1},
-#                 pytest.raises(TypeError, match="Initial parameters must be array-like"),
-#             ),
-#             (
-#                 [jnp.zeros((1, 5)), ""],
-#                 pytest.raises(TypeError, match="Initial parameters must be array-like"),
-#             ),
-#             (
-#                 ["", jnp.zeros((1,))],
-#                 pytest.raises(TypeError, match="Initial parameters must be array-like"),
-#             ),
-#         ],
-#     )
-#     def test_fit_init_params_type(
-#         self, init_params, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method with various types of initial parameters. Ensure that the provided initial parameters
-#         are array-like.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         with expectation:
-#             model.fit(X, y, init_params=init_params)
-#
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#         ],
-#     )
-#     def test_fit_x_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if delta_dim == -1:
-#             X = np.zeros((X.shape[0],))
-#         elif delta_dim == 1:
-#             X = np.zeros((X.shape[0], 1, X.shape[1]))
-#         with expectation:
-#             model.fit(X, y, init_params=true_params)
-#
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="y must be one-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="y must be one-dimensional")),
-#         ],
-#     )
-#     def test_fit_y_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method with y target data of different dimensionalities. Ensure correct dimensionality for y.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if delta_dim == -1:
-#             y = np.zeros([])
-#         elif delta_dim == 1:
-#             y = np.zeros((y.shape[0], 1))
-#         with expectation:
-#             model.fit(X, y, init_params=true_params)
-#
-#     @pytest.mark.parametrize(
-#         "delta_n_features, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#         ],
-#     )
-#     def test_fit_n_feature_consistency_weights(
-#         self, delta_n_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method for inconsistencies between data features and initial weights provided.
-#         Ensure the number of features align.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         init_w = jnp.zeros((X.shape[1] + delta_n_features))
-#         init_b = jnp.zeros(
-#             1,
-#         )
-#         with expectation:
-#             model.fit(X, y, init_params=(init_w, init_b))
-#
-#     @pytest.mark.parametrize(
-#         "delta_n_features, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#         ],
-#     )
-#     def test_fit_n_feature_consistency_x(
-#         self, delta_n_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method for inconsistencies between data features and model's expectations.
-#         Ensure the number of features in X aligns.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if delta_n_features == 1:
-#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
-#         elif delta_n_features == -1:
-#             X = X[..., :-1]
-#         with expectation:
-#             model.fit(X, y, init_params=true_params)
-#
-#     @pytest.mark.parametrize(
-#         "delta_tp, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#         ],
-#     )
-#     def test_fit_time_points_x(
-#         self, delta_tp, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method for inconsistencies in time-points in data X. Ensure the correct number of time-points.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
-#         with expectation:
-#             model.fit(X, y, init_params=true_params)
-#
-#     @pytest.mark.parametrize(
-#         "delta_tp, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#         ],
-#     )
-#     def test_fit_time_points_y(
-#         self, delta_tp, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `fit` method for inconsistencies in time-points in y. Ensure the correct number of time-points.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
-#         with expectation:
-#             model.fit(X, y, init_params=true_params)
-#
-#     def test_fit_mask_grouplasso(self, group_sparse_poisson_glm_model_instantiation):
-#         """Test that the group lasso fit goes through"""
-#         X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
-#         model.set_params(
-#             regularizer=nmo.regularizer.GroupLasso(
-#                 solver_name="ProximalGradient", mask=mask
-#             )
-#         )
-#         model.fit(X, y)
-#
-#     def test_fit_pytree_equivalence(
-#         self, poissonGLM_model_instantiation, poissonGLM_model_instantiation_pytree
-#     ):
-#         """Check that the glm fit with pytree learns the same parameters."""
-#         # required for numerical precision of coeffs
-#         jax.config.update("jax_enable_x64", True)
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         X_tree, _, model_tree, true_params_tree, _ = (
-#             poissonGLM_model_instantiation_pytree
-#         )
-#         # fit both models
-#         model.fit(X, y, init_params=true_params)
-#         model_tree.fit(X_tree, y, init_params=true_params_tree)
-#
-#         # get the flat parameters
-#         flat_coef = np.concatenate(
-#             jax.tree_util.tree_flatten(model_tree.coef_)[0], axis=-1
-#         )
-#
-#         # assert equivalence of solutions
-#         assert np.allclose(model.coef_, flat_coef)
-#         assert np.allclose(model.intercept_, model_tree.intercept_)
-#         assert np.allclose(model.score(X, y), model_tree.score(X_tree, y))
-#         assert np.allclose(model.predict(X), model_tree.predict(X_tree))
-#
-#     @pytest.mark.parametrize(
-#         "fill_val, expectation",
-#         [
-#             (0, does_not_raise()),
-#             (
-#                 jnp.inf,
-#                 pytest.raises(
-#                     ValueError, match="At least a NaN or an Inf at all sample points"
-#                 ),
-#             ),
-#             (
-#                 jnp.nan,
-#                 pytest.raises(
-#                     ValueError, match="At least a NaN or an Inf at all sample points"
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_fit_all_invalid_X(
-#         self, fill_val, expectation, poissonGLM_model_instantiation
-#     ):
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         X.fill(fill_val)
-#         with expectation:
-#             model.fit(X, y)
-#
-#     #######################
-#     # Test model.score
-#     #######################
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#         ],
-#     )
-#     def test_score_x_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method with X input data of different dimensionalities. Ensure correct dimensionality for X.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             X = np.zeros((X.shape[0],))
-#         elif delta_dim == 1:
-#             X = np.zeros((X.shape[0], X.shape[1], 1))
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(
-#                     ValueError, match="y must be one-dimensional, with shape"
-#                 ),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(
-#                     ValueError, match="y must be one-dimensional, with shape"
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_score_y_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method with y of different dimensionalities.
-#         Ensure correct dimensionality for y.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             y = np.zeros([])
-#         elif delta_dim == 1:
-#             y = np.zeros((X.shape[0], X.shape[1]))
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "delta_n_features, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#         ],
-#     )
-#     def test_score_n_feature_consistency_x(
-#         self, delta_n_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for inconsistencies in features of X.
-#         Ensure the number of features in X aligns with the model params.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_n_features == 1:
-#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
-#         elif delta_n_features == -1:
-#             X = X[..., :-1]
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "is_fit, expectation",
-#         [
-#             (True, does_not_raise()),
-#             (
-#                 False,
-#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-#             ),
-#         ],
-#     )
-#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-#         """
-#         Test the `score` method on models based on their fit status.
-#         Ensure scoring is only possible on fitted models.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if is_fit:
-#             model.fit(X, y)
-#         with expectation:
-#             model.predict(X)
-#
-#     @pytest.mark.parametrize(
-#         "delta_tp, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#         ],
-#     )
-#     def test_score_time_points_x(
-#         self, delta_tp, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for inconsistencies in time-points in X.
-#         Ensure that the number of time-points in X and y matches.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         X = jnp.zeros((X.shape[0] + delta_tp,) + X.shape[1:])
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "delta_tp, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(ValueError, match="The number of time-points in X and y"),
-#             ),
-#         ],
-#     )
-#     def test_score_time_points_y(
-#         self, delta_tp, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for inconsistencies in time-points in y.
-#         Ensure that the number of time-points in X and y matches.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         y = jnp.zeros((y.shape[0] + delta_tp,) + y.shape[1:])
-#         with expectation:
-#             model.score(X, y)
-#
-#     @pytest.mark.parametrize(
-#         "score_type, expectation",
-#         [
-#             ("pseudo-r2-McFadden", does_not_raise()),
-#             ("pseudo-r2-Cohen", does_not_raise()),
-#             ("log-likelihood", does_not_raise()),
-#             (
-#                 "not-implemented",
-#                 pytest.raises(
-#                     NotImplementedError,
-#                     match="Scoring method not-implemented not implemented",
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_score_type_r2(
-#         self, score_type, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `score` method for unsupported scoring types.
-#         Ensure only valid score types are used.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         with expectation:
-#             model.score(X, y, score_type=score_type)
-#
-#     def test_loglikelihood_against_scipy_stats(self, poissonGLM_model_instantiation):
-#         """
-#         Compare the model's log-likelihood computation against `jax.scipy`.
-#         Ensure consistent and correct calculations.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         # set model coeff
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         # get the rate
-#         mean_firing = model.predict(X)
-#         # compute the log-likelihood using jax.scipy
-#         mean_ll_jax = jax.scipy.stats.poisson.logpmf(y, mean_firing).mean()
-#         model_ll = model.score(X, y, score_type="log-likelihood")
-#         if not np.allclose(mean_ll_jax, model_ll):
-#             raise ValueError(
-#                 "Log-likelihood of PoissonModel does not match" "that of jax.scipy!"
-#             )
-#
-#     #######################
-#     # Test model.predict
-#     #######################
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#         ],
-#     )
-#     def test_predict_x_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `predict` method with x input data of different dimensionalities.
-#         Ensure correct dimensionality for x.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             X = np.zeros((X.shape[0],))
-#         elif delta_dim == 1:
-#             X = np.zeros((X.shape[0], X.shape[1], 1))
-#         with expectation:
-#             model.predict(X)
-#
-#     @pytest.mark.parametrize(
-#         "delta_n_features, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="Inconsistent number of features")),
-#         ],
-#     )
-#     def test_predict_n_feature_consistency_x(
-#         self, delta_n_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `predict` method ensuring the number of features in x input data
-#         is consistent with the model's `model.coef_`.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_n_features == 1:
-#             X = jnp.concatenate((X, jnp.zeros((X.shape[0], 1))), axis=1)
-#         elif delta_n_features == -1:
-#             X = X[..., :-1]
-#         with expectation:
-#             model.predict(X)
-#
-#     @pytest.mark.parametrize(
-#         "is_fit, expectation",
-#         [
-#             (True, does_not_raise()),
-#             (
-#                 False,
-#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-#             ),
-#         ],
-#     )
-#     def test_predict_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-#         """
-#         Test the `score` method on models based on their fit status.
-#         Ensure scoring is only possible on fitted models.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if is_fit:
-#             model.fit(X, y)
-#         with expectation:
-#             model.predict(X)
-#
-#     #######################
-#     # Test model.simulate
-#     #######################
-#     @pytest.mark.parametrize(
-#         "delta_dim, expectation",
-#         [
-#             (-1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#             (0, does_not_raise()),
-#             (1, pytest.raises(ValueError, match="X must be two-dimensional")),
-#         ],
-#     )
-#     def test_simulate_input_dimensionality(
-#         self, delta_dim, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `simulate` method with input data of different dimensionalities.
-#         Ensure correct dimensionality for input.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         if delta_dim == -1:
-#             X = np.zeros(X.shape[:-1])
-#         elif delta_dim == 1:
-#             X = np.zeros(X.shape + (1,))
-#         with expectation:
-#             model.simulate(
-#                 random_key=jax.random.key(123),
-#                 feedforward_input=X,
-#             )
-#
-#     @pytest.mark.parametrize(
-#         "is_fit, expectation",
-#         [
-#             (True, does_not_raise()),
-#             (
-#                 False,
-#                 pytest.raises(ValueError, match="This GLM instance is not fitted yet"),
-#             ),
-#         ],
-#     )
-#     def test_simulate_is_fit(self, is_fit, expectation, poissonGLM_model_instantiation):
-#         """
-#         Test if the model raises a ValueError when trying to simulate before it's fitted.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         if is_fit:
-#             model.coef_ = true_params[0]
-#             model.intercept_ = true_params[1]
-#         with expectation:
-#             model.simulate(
-#                 random_key=jax.random.key(123),
-#                 feedforward_input=X,
-#             )
-#
-#     @pytest.mark.parametrize(
-#         "delta_features, expectation",
-#         [
-#             (
-#                 -1,
-#                 pytest.raises(
-#                     ValueError,
-#                     match="Inconsistent number of features. spike basis coefficients has",
-#                 ),
-#             ),
-#             (0, does_not_raise()),
-#             (
-#                 1,
-#                 pytest.raises(
-#                     ValueError,
-#                     match="Inconsistent number of features. spike basis coefficients has",
-#                 ),
-#             ),
-#         ],
-#     )
-#     def test_simulate_feature_consistency_input(
-#         self, delta_features, expectation, poissonGLM_model_instantiation
-#     ):
-#         """
-#         Test the `simulate` method ensuring the number of features in `feedforward_input` is
-#         consistent with the model's expected number of features.
-#
-#         Notes
-#         -----
-#         The total feature number `model.coef_.shape[1]` must be equal to
-#         `feedforward_input.shape[2] + coupling_basis.shape[1]*n_neurons`
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         feedforward_input = jnp.zeros(
-#             (
-#                 X.shape[0],
-#                 X.shape[1] + delta_features,
-#             )
-#         )
-#         with expectation:
-#             model.simulate(
-#                 random_key=jax.random.key(123),
-#                 feedforward_input=feedforward_input,
-#             )
-#
-#     def test_simulate_feedforward_glm(self, poissonGLM_model_instantiation):
-#         """Test that simulate goes through"""
-#         X, y, model, params, rate = poissonGLM_model_instantiation
-#         model.coef_ = params[0]
-#         model.intercept_ = params[1]
-#         ysim, ratesim = model.simulate(jax.random.key(123), X)
-#         # check that the expected dimensionality is returned
-#         assert ysim.ndim == 1
-#         assert ratesim.ndim == 1
-#         # check that the rates and spikes has the same shape
-#         assert ratesim.shape[0] == ysim.shape[0]
-#         # check the time point number is that expected (same as the input)
-#         assert ysim.shape[0] == X.shape[0]
-#
-#     @pytest.mark.parametrize(
-#         "insert, expectation",
-#         [
-#             (0, does_not_raise()),
-#             (np.nan, pytest.warns(UserWarning, match=r"The provided trees contain")),
-#             (np.inf, pytest.warns(UserWarning, match=r"The provided trees contain")),
-#         ],
-#     )
-#     def test_simulate_invalid_feedforward(
-#         self, insert, expectation, poissonGLM_model_instantiation
-#     ):
-#         X, y, model, params, rate = poissonGLM_model_instantiation
-#         model.coef_ = params[0]
-#         model.intercept_ = params[1]
-#         X[0] = insert
-#         with expectation:
-#             model.simulate(jax.random.key(123), X)
-#
-#     #######################################
-#     # Compare with standard implementation
-#     #######################################
-#     def test_deviance_against_statsmodels(self, poissonGLM_model_instantiation):
-#         """
-#         Compare fitted parameters to statsmodels.
-#         Assesses if the model estimates are close to statsmodels' results.
-#         """
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         # set model coeff
-#         model.coef_ = true_params[0]
-#         model.intercept_ = true_params[1]
-#         # get the rate
-#         dev = sm.families.Poisson().deviance(y, firing_rate)
-#         dev_model = model.observation_model.deviance(firing_rate, y).sum()
-#         if not np.allclose(dev, dev_model):
-#             raise ValueError("Deviance doesn't match statsmodels!")
-#
-#     def test_compatibility_with_sklearn_cv(self, poissonGLM_model_instantiation):
-#         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-#         param_grid = {"regularizer__solver_name": ["BFGS", "GradientDescent"]}
-#         GridSearchCV(model, param_grid).fit(X, y)
+

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2007,6 +2007,6 @@ class TestPopulationGLM:
             idx, coef = map_neu(k, model_single_neu.coef_)
             coef_loop[idx, k] = coef
             intercept_loop[k] = np.array(model_single_neu.intercept_)[0]
-        assert np.allclose(coef_loop, coef_vectorized, atol=10**-4, rtol=0)
+        assert np.allclose(coef_loop, coef_vectorized, atol=10**-6, rtol=0)
 
 

--- a/tests/test_proximal_operator.py
+++ b/tests/test_proximal_operator.py
@@ -1,12 +1,19 @@
 import jax
 import jax.numpy as jnp
 
-from nemos.proximal_operator import _vmap_norm2_masked, prox_group_lasso
+from nemos.proximal_operator import _vmap_norm2_masked_2, prox_group_lasso
 
 
 def test_prox_group_lasso_returns_tuple(example_data_prox_operator):
     """Test whether prox_group_lasso returns a tuple."""
     params, alpha, mask, scaling = example_data_prox_operator
+    updated_params = prox_group_lasso(params, alpha, mask, scaling)
+    assert isinstance(updated_params, tuple)
+
+
+def test_prox_group_lasso_returns_tuple_multineuron(example_data_prox_operator_multineuron):
+    """Test whether the tuple returned by prox_group_lasso has a length of 2."""
+    params, alpha, mask, scaling = example_data_prox_operator_multineuron
     updated_params = prox_group_lasso(params, alpha, mask, scaling)
     assert isinstance(updated_params, tuple)
 
@@ -18,9 +25,23 @@ def test_prox_group_lasso_tuple_length(example_data_prox_operator):
     assert len(updated_params) == 2
 
 
+def test_prox_group_lasso_tuple_length_multineuron(example_data_prox_operator_multineuron):
+    """Test whether the tuple returned by prox_group_lasso has a length of 2."""
+    params, alpha, mask, scaling = example_data_prox_operator_multineuron
+    updated_params = prox_group_lasso(params, alpha, mask, scaling)
+    assert len(updated_params) == 2
+
+
 def test_prox_group_lasso_weights_shape(example_data_prox_operator):
     """Test whether the shape of the weights in prox_group_lasso is correct."""
     params, alpha, mask, scaling = example_data_prox_operator
+    updated_params = prox_group_lasso(params, alpha, mask, scaling)
+    assert updated_params[0].shape == params[0].shape
+
+
+def test_prox_group_lasso_weights_shape_multineuron(example_data_prox_operator_multineuron):
+    """Test whether the shape of the weights in prox_group_lasso is correct."""
+    params, alpha, mask, scaling = example_data_prox_operator_multineuron
     updated_params = prox_group_lasso(params, alpha, mask, scaling)
     assert updated_params[0].shape == params[0].shape
 
@@ -32,24 +53,44 @@ def test_prox_group_lasso_intercepts_shape(example_data_prox_operator):
     assert updated_params[1].shape == params[1].shape
 
 
+def test_prox_group_lasso_intercepts_shape_multineuron(example_data_prox_operator_multineuron):
+    """Test whether the shape of the intercepts in prox_group_lasso is correct."""
+    params, alpha, mask, scaling = example_data_prox_operator_multineuron
+    updated_params = prox_group_lasso(params, alpha, mask, scaling)
+    assert updated_params[1].shape == params[1].shape
+
 def test_vmap_norm2_masked_2_returns_array(example_data_prox_operator):
     """Test whether _vmap_norm2_masked_2 returns a NumPy array."""
     params, _, mask, _ = example_data_prox_operator
-    l2_norm = _vmap_norm2_masked(params[0], mask)
+    l2_norm = _vmap_norm2_masked_2(params[0], mask)
     assert isinstance(l2_norm, jnp.ndarray)
 
 
 def test_vmap_norm2_masked_2_shape(example_data_prox_operator):
     """Test whether the shape of the result from _vmap_norm2_masked_2 is correct."""
     params, _, mask, _ = example_data_prox_operator
-    l2_norm = _vmap_norm2_masked(params[0], mask)
-    assert l2_norm.shape == (mask.shape[0],)
+    l2_norm = _vmap_norm2_masked_2(params[0], mask)
+    assert l2_norm.shape == (params[0].shape[0], mask.shape[0])
+
+
+def test_vmap_norm2_masked_2_shape_multineuron(example_data_prox_operator_multineuron):
+    """Test whether the shape of the result from _vmap_norm2_masked_2 is correct."""
+    params, _, mask, _ = example_data_prox_operator_multineuron
+    l2_norm = _vmap_norm2_masked_2(params[0].T, mask)
+    assert l2_norm.shape == (params[0].shape[1], mask.shape[0])
 
 
 def test_vmap_norm2_masked_2_non_negative(example_data_prox_operator):
     """Test whether all elements of the result from _vmap_norm2_masked_2 are non-negative."""
     params, _, mask, _ = example_data_prox_operator
-    l2_norm = _vmap_norm2_masked(params[0], mask)
+    l2_norm = _vmap_norm2_masked_2(params[0], mask)
+    assert jnp.all(l2_norm >= 0)
+
+
+def test_vmap_norm2_masked_2_non_negative_multineuron(example_data_prox_operator_multineuron):
+    """Test whether all elements of the result from _vmap_norm2_masked_2 are non-negative."""
+    params, _, mask, _ = example_data_prox_operator_multineuron
+    l2_norm = _vmap_norm2_masked_2(params[0].T, mask)
     assert jnp.all(l2_norm >= 0)
 
 
@@ -59,3 +100,11 @@ def test_prox_operator_shrinks_only_masked(example_data_prox_operator):
     params_new = prox_group_lasso(params, 0.05, mask)
     assert params_new[0][1] == params[0][1]
     assert all(params_new[0][i] < params[0][i] for i in [0, 2, 3])
+
+
+def test_prox_operator_shrinks_only_masked_multineuron(example_data_prox_operator_multineuron):
+    params, _, mask, _ = example_data_prox_operator_multineuron
+    mask = mask.at[:, 1].set(jnp.zeros(2))
+    params_new = prox_group_lasso(params, 0.05, mask)
+    assert jnp.all(params_new[0][1] == params[0][1])
+    assert all(jnp.all(params_new[0][i] < params[0][i]) for i in [0, 2, 3])

--- a/tests/test_pytrees.py
+++ b/tests/test_pytrees.py
@@ -61,22 +61,22 @@ class TestFeaturePytree:
         assert len(tree) == 100
 
     def test_treemap(self):
-        """Test the application of jax.tree_map function on FeaturePytree."""
+        """Test the application of jax.tree_util.tree_map function on FeaturePytree."""
         tree = FeaturePytree(test=np.random.rand(100, 1), test2=np.random.rand(100, 2))
-        mapped = jax.tree_map(lambda x: jnp.mean(x, axis=-1), tree)
+        mapped = jax.tree_util.tree_map(lambda x: jnp.mean(x, axis=-1), tree)
         assert len(tree) == len(mapped)
         assert list(tree.keys()) == list(mapped.keys())
         assert isinstance(mapped, FeaturePytree)
 
     def test_treemap_npts(self):
-        """Check if jax.tree_map correctly modifies the number of points in FeaturePytree."""
+        """Check if jax.tree_util.tree_map correctly modifies the number of points in FeaturePytree."""
         tree = FeaturePytree(test=np.random.rand(100, 1), test2=np.random.rand(100, 2))
-        mapped = jax.tree_map(lambda x: x[::10], tree)
+        mapped = jax.tree_util.tree_map(lambda x: x[::10], tree)
         assert len(mapped) == 10
         assert list(tree.keys()) == list(mapped.keys())
 
     def test_treemap_to_dict(self):
-        """Ensure jax.tree_map transforms FeaturePytree to a dictionary with mean values."""
+        """Ensure jax.tree_util.tree_map transforms FeaturePytree to a dictionary with mean values."""
         tree = FeaturePytree(
             test=np.random.rand(
                 100,
@@ -84,7 +84,7 @@ class TestFeaturePytree:
             test2=np.random.rand(100, 2),
         )
 
-        mapped = jax.tree_map(jnp.mean, tree)
+        mapped = jax.tree_util.tree_map(jnp.mean, tree)
         assert isinstance(mapped, dict)
         assert list(tree.keys()) == list(mapped.keys())
 

--- a/tests/test_pytrees.py
+++ b/tests/test_pytrees.py
@@ -83,10 +83,8 @@ class TestFeaturePytree:
             ),
             test2=np.random.rand(100, 2),
         )
-        with pytest.warns(
-            UserWarning, match=r"Output is not a FeaturePytree \(e\.g\.\, because at"
-        ):
-            mapped = jax.tree_map(jnp.mean, tree)
+
+        mapped = jax.tree_map(jnp.mean, tree)
         assert isinstance(mapped, dict)
         assert list(tree.keys()) == list(mapped.keys())
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,10 @@ package_cache = .tox/cache
 # while black, isort and flake8 are also i
 commands =
     black --check src
-    isort src
-    isort docs/neural_modeling
-    isort docs/background
-    isort docs/neural_modeling
+    isort src --profile=black
+    isort docs/neural_modeling --profile=black
+    isort docs/background --profile=black
+    isort docs/neural_modeling --profile=black
     flake8 --config={toxinidir}/tox.ini src
     pytest --cov=nemos --cov-report=xml
 


### PR DESCRIPTION
## PopulationGLM

This PR includes a new class for fitting a `PopulationGLM`. 

The API is very similar to the single neuron GLM:
-  A single predictor `X`, either an array of shape `(n_samples, n_features)` or a `FeaturePytree`, with entries of the same shape and apply a mask of 0s and 1s.
- A single output `y` of shape `(n_samples, n_neurons)`.
- An optional `feature_mask` of 0s and 1s (default is all 1s, including all features for all neurons). 
    - If `X` is in array form, the mask is either a matrix of shape `(n_features, n_neurons)`
    - If `X` is a `FeaturePytree`, the mask is dictionary with the same structure as `X` of arrays of shape `(n_neurons,)`
- The model `coef_` are
    -  If `X` is in array form, an array of shape `(n_features, n_neurons)`
    - If `X` is a `FeaturePytree`, a dictionary with the same structure as `X` containing arrsys of shape `(n_features, n_neurons)`
- The model `intercept_` is an array of shape `(n_neurons, )`