### PR TITLE
Identifiability

### DIFF
--- a/docs/api_guide/plot_05_batch_glm.py
+++ b/docs/api_guide/plot_05_batch_glm.py
@@ -99,7 +99,7 @@ params, state = glm.initialize_solver(*batcher())
 #
 # Let's do a few iterations of gradient descent calling the `batcher` function at every step.
 # At each step, we store the log-likelihood of the model for each neuron evaluated on the batch
-n_step = 5000
+n_step = 500
 logl = np.zeros(n_step)
 
 for i in range(n_step):	

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -246,6 +246,10 @@ class Basis(abc.ABC):
 
     @identifiability_constraints.setter
     def identifiability_constraints(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(
+                f"`identifiability_constraints` must be a boolean. {type(value)} provided instead!"
+            )
         self._ident_constraints = value
 
     @staticmethod
@@ -271,19 +275,19 @@ class Basis(abc.ABC):
         :
             The adjusted design matrix with redundant columns dropped and columns mean-centered.
         """
+
         def add_constant(x):
             return np.hstack((np.ones((x.shape[0], 1)), x))
 
         rank = np.linalg.matrix_rank(add_constant(X))
         # mean center
-        X -= np.nanmean(X)
+        X -= np.nanmean(X, axis=0)
         while rank < X.shape[1] + 1:
             # drop a column
             X = X[:, :-1]
             # recompute rank
             rank = np.linalg.matrix_rank(add_constant(X))
         return X
-
 
     @check_transform_input
     def _compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
@@ -740,7 +744,6 @@ class AdditiveBasis(Basis):
         if self.identifiability_constraints:
             X = self._apply_identifiability_constraints(X)
         return X
-
 
     @check_transform_input
     def _compute_features(self, *xi: ArrayLike) -> FeatureMatrix:

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -7,6 +7,7 @@ import numpy as np
 import pynapple as nap
 import pytest
 import sklearn.pipeline as pipeline
+import statsmodels.api as sm
 import utils_testing
 
 import nemos.basis as basis
@@ -498,6 +499,20 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         assert np.all(conv[valid] == conv_2[valid])
         assert np.all(np.isnan(conv_2[~valid]))
 
+    def test_identifiability_constraint_setter(self):
+        bas = self.cls(5, mode="conv", window_size=10)
+        bas.identifiability_constraints = True
+        assert bas.identifiability_constraints
+        with pytest.raises(TypeError, match="`identifiability_constraints` must be"):
+            bas.identifiability_constraints = "True"
+
+    def test_identifiability_constraint_apply(self):
+        bas = self.cls(5, mode="conv", window_size=10)
+        bas.identifiability_constraints = True
+        # identifiability constraint should mean center only for this basis
+        X = bas(np.linspace(0, 1, 20))
+        assert np.allclose(X.mean(axis=0), np.zeros(X.shape[1]))
+        assert X.shape[1] == bas.n_basis_funcs
 
 class TestRaisedCosineLinearBasis(BasisFuncsTesting):
     cls = basis.RaisedCosineBasisLinear
@@ -876,6 +891,20 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
         assert np.all(conv[valid] == conv_2[valid])
         assert np.all(np.isnan(conv_2[~valid]))
 
+    def test_identifiability_constraint_setter(self):
+        bas = self.cls(5, mode="conv", window_size=10)
+        bas.identifiability_constraints = True
+        assert bas.identifiability_constraints
+        with pytest.raises(TypeError, match="`identifiability_constraints` must be"):
+            bas.identifiability_constraints = "True"
+
+    def test_identifiability_constraint_apply(self):
+        bas = self.cls(5)
+        bas.identifiability_constraints = True
+        X = bas(np.linspace(0, 1, 20))
+        assert np.allclose(X.mean(axis=0), np.zeros(X.shape[1]))
+        assert X.shape[1] == bas.n_basis_funcs - 1
+
 
 class TestMSplineBasis(BasisFuncsTesting):
     cls = basis.MSplineBasis
@@ -1237,6 +1266,20 @@ class TestMSplineBasis(BasisFuncsTesting):
         valid = ~np.isnan(conv)
         assert np.all(conv[valid] == conv_2[valid])
         assert np.all(np.isnan(conv_2[~valid]))
+
+    def test_identifiability_constraint_setter(self):
+        bas = self.cls(5, mode="conv", window_size=10)
+        bas.identifiability_constraints = True
+        assert bas.identifiability_constraints
+        with pytest.raises(TypeError, match="`identifiability_constraints` must be"):
+            bas.identifiability_constraints = "True"
+
+    def test_identifiability_constraint_apply(self):
+        bas = self.cls(5)
+        bas.identifiability_constraints = True
+        X = bas(np.linspace(0, 1, 20))
+        assert np.allclose(X.mean(axis=0), np.zeros(X.shape[1]))
+        assert X.shape[1] == bas.n_basis_funcs - 1
 
 
 class TestOrthExponentialBasis(BasisFuncsTesting):
@@ -1680,6 +1723,20 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         assert np.all(conv[valid] == conv_2[valid])
         assert np.all(np.isnan(conv_2[~valid]))
 
+    def test_identifiability_constraint_setter(self):
+        bas = self.cls(5, decay_rates=[1,2,3,4,5])
+        bas.identifiability_constraints = True
+        assert bas.identifiability_constraints
+        with pytest.raises(TypeError, match="`identifiability_constraints` must be"):
+            bas.identifiability_constraints = "True"
+
+    def test_identifiability_constraint_apply(self):
+        bas = self.cls(5, decay_rates=[1,2,3,4,5])
+        bas.identifiability_constraints = True
+        X = bas(np.linspace(0, 1, 20))
+        assert np.allclose(X.mean(axis=0), np.zeros(X.shape[1]))
+        assert X.shape[1] == bas.n_basis_funcs
+
 
 class TestBSplineBasis(BasisFuncsTesting):
     cls = basis.BSplineBasis
@@ -2063,6 +2120,20 @@ class TestBSplineBasis(BasisFuncsTesting):
         valid = ~np.isnan(conv)
         assert np.all(conv[valid] == conv_2[valid])
         assert np.all(np.isnan(conv_2[~valid]))
+
+    def test_identifiability_constraint_setter(self):
+        bas = self.cls(5, mode="conv", window_size=10)
+        bas.identifiability_constraints = True
+        assert bas.identifiability_constraints
+        with pytest.raises(TypeError, match="`identifiability_constraints` must be"):
+            bas.identifiability_constraints = "True"
+
+    def test_identifiability_constraint_apply(self):
+        bas = self.cls(5)
+        bas.identifiability_constraints = True
+        X = bas(np.linspace(0, 1, 20))
+        assert np.allclose(X.mean(axis=0), np.zeros(X.shape[1]))
+        assert X.shape[1] == bas.n_basis_funcs - 1
 
 
 class TestCyclicBSplineBasis(BasisFuncsTesting):
@@ -2465,6 +2536,20 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
         valid = ~np.isnan(conv)
         assert np.all(conv[valid] == conv_2[valid])
         assert np.all(np.isnan(conv_2[~valid]))
+
+    def test_identifiability_constraint_setter(self):
+        bas = self.cls(5, mode="conv", window_size=10)
+        bas.identifiability_constraints = True
+        assert bas.identifiability_constraints
+        with pytest.raises(TypeError, match="`identifiability_constraints` must be"):
+            bas.identifiability_constraints = "True"
+
+    def test_identifiability_constraint_apply(self):
+        bas = self.cls(5)
+        bas.identifiability_constraints = True
+        X = bas(np.linspace(0, 1, 20))
+        assert np.allclose(X.mean(axis=0), np.zeros(X.shape[1]))
+        assert X.shape[1] == bas.n_basis_funcs - 1
 
 
 class CombinedBasis(BasisFuncsTesting):

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -1,5 +1,6 @@
 import warnings
 from contextlib import nullcontext as does_not_raise
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -7,7 +8,6 @@ import numpy as np
 import pytest
 import statsmodels.api as sm
 from sklearn.linear_model import GammaRegressor, PoissonRegressor
-from typing import NamedTuple
 
 import nemos as nmo
 


### PR DESCRIPTION
## Take care of model identifiability

Added a flag to basis that, if True, checks that the design matrix including the intercept, is full rank; if not, it drops a column and mean center the data.

This will take care of BSplines, and CyclicBslplines, which sum to 1, and may result in a family of equivalent parameters all maximizing the likelihood. 

