### PR TITLE
add tests for checking get_params()

### DIFF
--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -160,8 +160,8 @@ class TestGLM:
             model.solver_name,
         }
 
-        assert list(model.get_params().keys()) == expected_keys
-        assert list(model.get_params().values()) == expected_values
+        assert set(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().values()) == expected_values
 
         # changing regularizer
         model.regularizer = "Ridge"

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -181,14 +181,14 @@ class TestGLM:
         # changing solver
         model.solver_name = "ProximalGradient"
 
-        expected_values = [
+        expected_values = {
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        ]
+        }
 
         assert list(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -166,14 +166,14 @@ class TestGLM:
         # changing regularizer
         model.regularizer = "Ridge"
 
-        expected_values = [
+        expected_values = {
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        ]
+        }
 
         assert list(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -136,62 +136,62 @@ class TestGLM:
 
         model = nmo.glm.GLM()
 
-        expected_values = {
+        expected_values = [
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        }
+        ]
 
         assert set(model.get_params().keys()) == expected_keys
-        assert set(model.get_params().values()) == expected_values
+        assert list(model.get_params().values()) == expected_values
 
         # passing params
         model = nmo.glm.GLM(solver_name="LBFGS", regularizer="UnRegularized")
 
-        expected_values = {
+        expected_values = [
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        }
+        ]
 
         assert set(model.get_params().keys()) == expected_keys
-        assert set(model.get_params().values()) == expected_values
+        assert list(model.get_params().values()) == expected_values
 
         # changing regularizer
         model.regularizer = "Ridge"
 
-        expected_values = {
+        expected_values = [
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        }
+        ]
 
-        assert list(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values
 
         # changing solver
         model.solver_name = "ProximalGradient"
 
-        expected_values = {
+        expected_values = [
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        }
+        ]
 
         assert set(model.get_params().keys()) == expected_keys
-        assert set(model.get_params().values()) == expected_values
+        assert list(model.get_params().values()) == expected_values
 
     #######################
     # Test model.fit
@@ -1532,7 +1532,7 @@ class TestPopulationGLM:
         """
         Test that get_params() contains expected values.
         """
-        expected_keys = [
+        expected_keys = {
             "feature_mask",
             "observation_model__inverse_link_function",
             "observation_model",
@@ -1540,7 +1540,7 @@ class TestPopulationGLM:
             "regularizer_strength",
             "solver_kwargs",
             "solver_name",
-        ]
+        }
 
         model = nmo.glm.PopulationGLM()
 
@@ -1554,7 +1554,7 @@ class TestPopulationGLM:
             model.solver_name,
         ]
 
-        assert list(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values
 
         # passing params
@@ -1570,7 +1570,7 @@ class TestPopulationGLM:
             model.solver_name,
         ]
 
-        assert list(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values
 
         # changing regularizer
@@ -1586,7 +1586,7 @@ class TestPopulationGLM:
             model.solver_name,
         ]
 
-        assert list(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values
 
         # changing solver
@@ -1602,7 +1602,7 @@ class TestPopulationGLM:
             model.solver_name,
         ]
 
-        assert list(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values
 
     @pytest.mark.parametrize(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -121,6 +121,78 @@ class TestGLM:
         assert coef.shape == (X.shape[1],)
         assert inter.shape == (1,)
 
+    def test_get_params(self):
+        """
+        Test that get_params() contains expected values.
+        """
+        expected_keys = [
+            "observation_model__inverse_link_function",
+            "observation_model",
+            "regularizer",
+            "regularizer_strength",
+            "solver_kwargs",
+            "solver_name",
+        ]
+
+        model = nmo.glm.GLM()
+
+        expected_values = [
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
+
+        # passing params
+        model = nmo.glm.GLM(solver_name="LBFGS", regularizer="UnRegularized")
+
+        expected_values = [
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
+
+        # changing regularizer
+        model.regularizer = "Ridge"
+
+        expected_values = [
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
+
+        # changing solver
+        model.solver_name = "ProximalGradient"
+
+        expected_values = [
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
+
     #######################
     # Test model.fit
     #######################
@@ -1455,6 +1527,83 @@ class TestPopulationGLM:
         """
         with expectation:
             population_glm_class(regularizer=regularizer)
+
+    def test_get_params(self):
+        """
+        Test that get_params() contains expected values.
+        """
+        expected_keys = [
+            "feature_mask",
+            "observation_model__inverse_link_function",
+            "observation_model",
+            "regularizer",
+            "regularizer_strength",
+            "solver_kwargs",
+            "solver_name",
+        ]
+
+        model = nmo.glm.PopulationGLM()
+
+        expected_values = [
+            model.feature_mask,
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
+
+        # passing params
+        model = nmo.glm.PopulationGLM(solver_name="LBFGS", regularizer="UnRegularized")
+
+        expected_values = [
+            model.feature_mask,
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
+
+        # changing regularizer
+        model.regularizer = "Ridge"
+
+        expected_values = [
+            model.feature_mask,
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
+
+        # changing solver
+        model.solver_name = "ProximalGradient"
+
+        expected_values = [
+            model.feature_mask,
+            model.observation_model.inverse_link_function,
+            model.observation_model,
+            model.regularizer,
+            model.regularizer_strength,
+            model.solver_kwargs,
+            model.solver_name,
+        ]
+
+        assert list(model.get_params().keys()) == expected_keys
+        assert list(model.get_params().values()) == expected_values
 
     @pytest.mark.parametrize(
         "observation, expectation",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -190,8 +190,8 @@ class TestGLM:
             model.solver_name,
         }
 
-        assert list(model.get_params().keys()) == expected_keys
-        assert list(model.get_params().values()) == expected_values
+        assert set(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().values()) == expected_values
 
     #######################
     # Test model.fit

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -145,8 +145,8 @@ class TestGLM:
             model.solver_name,
         }
 
-        assert list(model.get_params().keys()) == expected_keys
-        assert list(model.get_params().values()) == expected_values
+        assert set(model.get_params().keys()) == expected_keys
+        assert set(model.get_params().values()) == expected_values
 
         # passing params
         model = nmo.glm.GLM(solver_name="LBFGS", regularizer="UnRegularized")

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -125,14 +125,14 @@ class TestGLM:
         """
         Test that get_params() contains expected values.
         """
-        expected_keys = [
+        expected_keys = {
             "observation_model__inverse_link_function",
             "observation_model",
             "regularizer",
             "regularizer_strength",
             "solver_kwargs",
             "solver_name",
-        ]
+        }
 
         model = nmo.glm.GLM()
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -136,14 +136,14 @@ class TestGLM:
 
         model = nmo.glm.GLM()
 
-        expected_values = [
+        expected_values = {
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        ]
+        }
 
         assert list(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -151,14 +151,14 @@ class TestGLM:
         # passing params
         model = nmo.glm.GLM(solver_name="LBFGS", regularizer="UnRegularized")
 
-        expected_values = [
+        expected_values = {
             model.observation_model.inverse_link_function,
             model.observation_model,
             model.regularizer,
             model.regularizer_strength,
             model.solver_kwargs,
             model.solver_name,
-        ]
+        }
 
         assert list(model.get_params().keys()) == expected_keys
         assert list(model.get_params().values()) == expected_values

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -110,6 +110,14 @@ class TestPoissonObservations:
         else:
             observation_model.set_params(inverse_link_function=link_function)
 
+    def test_get_params(self, poisson_observations):
+        """Test get_params() returns expected values."""
+        observation_model = poisson_observations()
+
+        assert observation_model.get_params() == {
+            "inverse_link_function": observation_model.inverse_link_function
+        }
+
     def test_deviance_against_statsmodels(self, poissonGLM_model_instantiation):
         """
         Compare fitted parameters to statsmodels.
@@ -379,6 +387,14 @@ class TestGammaObservations:
                 observation_model.set_params(inverse_link_function=link_function)
         else:
             observation_model.set_params(inverse_link_function=link_function)
+
+    def test_get_params(self, gamma_observations):
+        """Test get_params() returns expected values."""
+        observation_model = gamma_observations()
+
+        assert observation_model.get_params() == {
+            "inverse_link_function": observation_model.inverse_link_function
+        }
 
     def test_deviance_against_statsmodels(self, gammaGLM_model_instantiation):
         """

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -205,6 +205,12 @@ class TestUnRegularized:
         model.regularizer = regularizer
         assert model.regularizer_strength is None
 
+    def test_get_params(self):
+        """Test get_params() returns expected values."""
+        regularizer = self.cls()
+
+        assert regularizer.get_params() == {}
+
     @pytest.mark.parametrize("solver_name", ["GradientDescent", "BFGS"])
     @pytest.mark.parametrize("solver_kwargs", [{"tol": 10**-10}, {"tols": 10**-10}])
     def test_init_solver_kwargs(self, solver_name, solver_kwargs):
@@ -487,6 +493,12 @@ class TestRidge:
 
         assert model.regularizer_strength == 1.0
 
+    def test_get_params(self):
+        """Test get_params() returns expected values."""
+        regularizer = self.cls()
+
+        assert regularizer.get_params() == {}
+
     @pytest.mark.parametrize("loss", [lambda a, b, c: 0, 1, None, {}])
     def test_loss_is_callable(self, loss):
         """Test Ridge callable loss."""
@@ -702,6 +714,12 @@ class TestLasso:
 
         assert model.regularizer_strength == 1.0
 
+    def test_get_params(self):
+        """Test get_params() returns expected values."""
+        regularizer = self.cls()
+
+        assert regularizer.get_params() == {}
+
     @pytest.mark.parametrize("loss", [lambda a, b, c: 0, 1, None, {}])
     def test_loss_callable(self, loss):
         """Test that the loss function is a callable"""
@@ -904,6 +922,12 @@ class TestGroupLasso:
             model.regularizer = regularizer
 
         assert model.regularizer_strength == 1.0
+
+    def test_get_params(self):
+        """Test get_params() returns expected values."""
+        regularizer = self.cls()
+
+        assert regularizer.get_params() == {"mask": None}
 
     @pytest.mark.parametrize("loss", [lambda a, b, c: 0, 1, None, {}])
     def test_loss_callable(self, loss):
@@ -1281,5 +1305,6 @@ class TestGroupLasso:
 
 def test_available_regularizer_match():
     """Test matching of the two regularizer lists."""
-    assert set(nmo._regularizer_builder.AVAILABLE_REGULARIZERS) == set(nmo.regularizer.__dir__())
-
+    assert set(nmo._regularizer_builder.AVAILABLE_REGULARIZERS) == set(
+        nmo.regularizer.__dir__()
+    )


### PR DESCRIPTION
closes #185

This PR adds tests to check that classes inheriting from the `Base` class contain the correct parameters when making calls to `get_params()`. In summary:

**Model**
- observation model
- observation model link function
- regularizer
- regularizer strength
- solver name
- solver kwargs

**Regularizer**
- will be an empty dict unless using `GroupLasso`, in which case will contain the `mask` param

 > **Note:** Because we moved `regularizer_strength` to `BaseRegressor` it is technically no longer associated with the regularizer and is only passed to the `penalized_loss` and `get_proximal_operator` methods as needed 

**Observation Model**
- inverse link function only 