### PR TITLE
fix convergence tests

### DIFF
--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -226,7 +226,7 @@ class Ridge(Regularizer):
             term is not regularized.
         """
 
-        def prox_op(params, l2reg, scaling=0.5):
+        def prox_op(params, l2reg, scaling=1.):
             Ws, bs = params
             l2reg /= bs.shape[0]
             return jaxopt.prox.prox_ridge(Ws, l2reg, scaling=scaling), bs
@@ -454,7 +454,7 @@ class GroupLasso(Regularizer):
         # divide regularization strength by number of neurons
         regularizer_strength = regularizer_strength / params[1].shape[0]
 
-        return penalty * regularizer_strength
+        return 0.5 * penalty * regularizer_strength
 
     def penalized_loss(self, loss: Callable, regularizer_strength: float) -> Callable:
         """Returns a function for calculating the penalized loss using Group Lasso regularization."""

--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -226,7 +226,7 @@ class Ridge(Regularizer):
             term is not regularized.
         """
 
-        def prox_op(params, l2reg, scaling=1.):
+        def prox_op(params, l2reg, scaling=1.0):
             Ws, bs = params
             l2reg /= bs.shape[0]
             return jaxopt.prox.prox_ridge(Ws, l2reg, scaling=scaling), bs

--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -447,14 +447,14 @@ class GroupLasso(Regularizer):
         )  # this masks the param, (group, feature, neuron)
 
         penalty = jax.numpy.sum(
-            jax.numpy.linalg.norm(masked_param, axis=1)
+            jax.numpy.linalg.norm(masked_param, axis=1).T
             * jax.numpy.sqrt(self.mask.sum(axis=1))
         )
 
         # divide regularization strength by number of neurons
         regularizer_strength = regularizer_strength / params[1].shape[0]
 
-        return 0.5 * penalty * regularizer_strength
+        return penalty * regularizer_strength
 
     def penalized_loss(self, loss: Callable, regularizer_strength: float) -> Callable:
         """Returns a function for calculating the penalized loss using Group Lasso regularization."""

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -135,19 +135,19 @@ def test_group_lasso_convergence():
     """
     jax.config.update("jax_enable_x64", True)
     # generate toy data
-    num_samples, num_features, num_groups = 1000, 2, 2
+    num_samples, num_features, num_groups = 1000, 3, 2
     X = np.random.normal(size=(num_samples, num_features))  # design matrix
-    w = [-0.5, 0.5]  # define some weights
+    w = [-0.5, 0.25, 0.5]  # define some weights
     y = np.random.poisson(np.exp(X.dot(w)))  # observed counts
 
     mask = np.zeros((num_groups, num_features))
-    mask[0] = [1, 0]  # Group 0 includes features 0 and 3
-    mask[1] = [0, 1]  # Group 1 includes features 1
+    mask[0] = [1, 1, 0]  # Group 0 includes features 0 and 1
+    mask[1] = [0, 0, 1]  # Group 1 includes features 1
 
     # instantiate and fit GLM with ProximalGradient
     model_PG = nmo.glm.GLM(
         regularizer=nmo.regularizer.GroupLasso(mask=mask),
-        solver_kwargs=dict(tol=10**-12),
+        solver_kwargs=dict(tol=10**-14, maxiter=10000),
         regularizer_strength=0.2,
     )
     model_PG.fit(X, y)
@@ -172,7 +172,7 @@ def test_group_lasso_convergence():
         args=(X, y),
         method="Nelder-Mead",
         tol=10**-12,
-        options=dict(maxiter=350),
+        options=dict(maxiter=1000),
     )
 
     # assert weights are the same

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -43,6 +43,7 @@ def test_unregularized_convergence():
 
     # assert weights are the same
     assert np.allclose(model_GD.coef_, model_PG.coef_)
+    assert np.allclose(model_GD.intercept_, model_PG.intercept_)
 
 
 def test_ridge_convergence():
@@ -81,6 +82,7 @@ def test_ridge_convergence():
 
     # assert weights are the same
     assert np.allclose(model_GD.coef_, model_PG.coef_)
+    assert np.allclose(model_GD.intercept_, model_PG.intercept_)
 
 
 def test_lasso_convergence():
@@ -123,6 +125,7 @@ def test_lasso_convergence():
 
     # assert weights are the same
     assert np.allclose(res.x[1:], model_PG.coef_)
+    assert np.allclose(res.x[:1], model_PG.intercept_)
 
 
 def test_group_lasso_convergence():
@@ -174,3 +177,4 @@ def test_group_lasso_convergence():
 
     # assert weights are the same
     assert np.allclose(res.x[1:], model_PG.coef_)
+    assert np.allclose(res.x[:1], model_PG.intercept_)


### PR DESCRIPTION
closes #205 

Update the tests for convergence between proximal gradient method and penalized loss method. Previously, I was asserting that the coefficients were the same using the wrong method. 