### PR TITLE
set up javascript animation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,9 +11,6 @@ build:
   tools:
     python: "3.10"
 
-  apt_packages:
-    - ffmpeg
-
 mkdocs:
   configuration: mkdocs.yml
 

--- a/docs/tutorials/plot_02_head_direction.py
+++ b/docs/tutorials/plot_02_head_direction.py
@@ -20,9 +20,6 @@ import nemos as nmo
 # some helper plotting functions
 from nemos import _documentation_utils as doc_plots
 
-# set the output format for animations in Jupyter notebooks to use JavaScript
-plt.rcParams['animation.html'] = 'jshtml'
-
 # configure pynapple to ignore conversion warning
 nap.nap_config.suppress_conversion_warnings = True
 
@@ -182,7 +179,7 @@ doc_plots.plot_history_window(neuron_count, epoch_one_spk, window_size_sec)
 # the figure).
 
 
-doc_plots.run_animation(neuron_count, epoch_one_spk.start[0])
+anim = doc_plots.run_animation(neuron_count, epoch_one_spk.start[0])
 
 # %%
 # If $t$ is smaller than the window size, we won't have a full window of spike history for estimating the rate.

--- a/docs/tutorials/plot_02_head_direction.py
+++ b/docs/tutorials/plot_02_head_direction.py
@@ -179,7 +179,7 @@ doc_plots.plot_history_window(neuron_count, epoch_one_spk, window_size_sec)
 # the figure).
 
 
-anim = doc_plots.run_animation(neuron_count, epoch_one_spk.start[0])
+doc_plots.run_animation(neuron_count, epoch_one_spk.start[0])
 
 # %%
 # If $t$ is smaller than the window size, we won't have a full window of spike history for estimating the rate.

--- a/docs/tutorials/plot_02_head_direction.py
+++ b/docs/tutorials/plot_02_head_direction.py
@@ -20,6 +20,9 @@ import nemos as nmo
 # some helper plotting functions
 from nemos import _documentation_utils as doc_plots
 
+# set the output format for animations in Jupyter notebooks to use JavaScript
+plt.rcParams['animation.html'] = 'jshtml'
+
 # configure pynapple to ignore conversion warning
 nap.nap_config.suppress_conversion_warnings = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ docs = [
     "mkdocs-autorefs>=0.5",
     "scikit-learn",
     "dandi",
-    "ipython",
     "matplotlib>=3.7",
     "seaborn",
     "pooch",
@@ -70,7 +69,6 @@ docs = [
 examples = [
     "scikit-learn",
     "dandi",
-    "ipython",
     "matplotlib>=3.7",
     "seaborn",
     "pooch",

--- a/src/nemos/_documentation_utils/plotting.py
+++ b/src/nemos/_documentation_utils/plotting.py
@@ -22,14 +22,6 @@ except ImportError:
         "conda to install 'seaborn'."
     )
 
-try:
-    from IPython.display import HTML
-except ImportError:
-    raise ImportError(
-        "Missing optional dependency 'ipython'."
-        " Please use pip or "
-        "conda to install 'ipython'."
-    )
 
 import warnings
 

--- a/src/nemos/_documentation_utils/plotting.py
+++ b/src/nemos/_documentation_utils/plotting.py
@@ -502,8 +502,7 @@ class PlotSlidingWindow:
 
 
 def run_animation(counts: nap.Tsd, start: float):
-    anim = PlotSlidingWindow(counts, start).run()
-    return HTML(anim.to_html5_video())
+    return PlotSlidingWindow(counts, start).run()
 
 
 def plot_coupling(

--- a/src/nemos/styles/nemos.mplstyle
+++ b/src/nemos/styles/nemos.mplstyle
@@ -3,3 +3,4 @@ xtick.labelsize : small
 axes.labelsize : small
 axes.spines.right : False
 axes.spines.top : False
+animation.html: 'jshtml'

--- a/src/nemos/styles/nemos.mplstyle
+++ b/src/nemos/styles/nemos.mplstyle
@@ -3,4 +3,4 @@ xtick.labelsize : small
 axes.labelsize : small
 axes.spines.right : False
 axes.spines.top : False
-animation.html: 'jshtml'
+animation.html : jshtml


### PR DESCRIPTION
This solves #229 by setting up jshtml for the animation output, which will not require ffmpeg to run nor Pillow as an example dependency.

