### PR TITLE
Fix sklearn test

### DIFF
--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -434,7 +434,7 @@ class GroupLasso(Regularizer):
     def _penalization(
         self, params: Tuple[DESIGN_INPUT_TYPE, jnp.ndarray], regularizer_strength: float
     ) -> jnp.ndarray:
-        """
+        r"""
         Calculate the penalization.
 
         Note: the penalty is being calculated according to the following formula:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ Note:
     This module primarily serves as a utility for test configurations, setting up initial conditions,
     and loading predefined parameters for testing various functionalities of the NeMoS library.
 """
+import multiprocessing as mp
+
 
 import jax
 import jax.numpy as jnp
@@ -17,6 +19,16 @@ import pytest
 import nemos as nmo
 import pynapple as nap
 
+
+@pytest.fixture(scope="session", autouse=True)
+def set_multiprocessing_method():
+    try:
+        mp.set_start_method('spawn', force=True)
+    except RuntimeError:
+        # Context has already been set, so ignore this error.
+        pass
+
+# shut-off conversion warnings
 nap.nap_config.suppress_conversion_warnings = True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@ import numpy as np
 import pytest
 
 import nemos as nmo
+import pynapple as nap
+
+nap.nap_config.suppress_conversion_warnings = True
 
 
 # Sample subclass to test instantiation and methods

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,24 +8,14 @@ Note:
     This module primarily serves as a utility for test configurations, setting up initial conditions,
     and loading predefined parameters for testing various functionalities of the NeMoS library.
 """
-import multiprocessing as mp
-
-try:
-    mp.set_start_method('spawn')
-except RuntimeError:
-    # Context has already been set, so ignore this error.
-    pass
-
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pynapple as nap
 import pytest
 
 import nemos as nmo
-import pynapple as nap
-
-
 
 # shut-off conversion warnings
 nap.nap_config.suppress_conversion_warnings = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ Note:
 """
 import multiprocessing as mp
 
+try:
+    mp.set_start_method('spawn')
+except RuntimeError:
+    # Context has already been set, so ignore this error.
+    pass
+
 
 import jax
 import jax.numpy as jnp
@@ -20,13 +26,6 @@ import nemos as nmo
 import pynapple as nap
 
 
-@pytest.fixture(scope="session", autouse=True)
-def set_multiprocessing_method():
-    try:
-        mp.set_start_method('spawn', force=True)
-    except RuntimeError:
-        # Context has already been set, so ignore this error.
-        pass
 
 # shut-off conversion warnings
 nap.nap_config.suppress_conversion_warnings = True

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -781,12 +781,12 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
         if n_input == 0:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) missing 1 required positional argument",
+                match=r"evaluate_on_grid\(\) missing 1 required positional argument",
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
+                match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
             )
         else:
             expectation = does_not_raise()
@@ -1293,12 +1293,12 @@ class TestMSplineBasis(BasisFuncsTesting):
         if n_input == 0:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) missing 1 required positional argument",
+                match=r"evaluate_on_grid\(\) missing 1 required positional argument",
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
+                match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
             )
         else:
             expectation = does_not_raise()
@@ -1787,12 +1787,12 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         if n_input == 0:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) missing 1 required positional argument",
+                match=r"evaluate_on_grid\(\) missing 1 required positional argument",
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
+                match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
             )
         else:
             expectation = does_not_raise()
@@ -2280,12 +2280,12 @@ class TestBSplineBasis(BasisFuncsTesting):
         if n_input == 0:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) missing 1 required positional argument",
+                match=r"evaluate_on_grid\(\) missing 1 required positional argument",
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
+                match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
             )
         else:
             expectation = does_not_raise()
@@ -2811,12 +2811,12 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
         if n_input == 0:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) missing 1 required positional argument",
+                match=r"evaluate_on_grid\(\) missing 1 required positional argument",
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
                 TypeError,
-                match="evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
+                match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
             )
         else:
             expectation = does_not_raise()
@@ -4602,7 +4602,7 @@ def test_transformerbasis_pickle(tmpdir, basis_cls, n_basis_funcs):
         (2, False, "anti-causal", [20, 75]),
         (2, None, "anti-causal", [20, 19, 75, 74]),
         (3, False, "acausal", [0, 20, 50, 75]),
-        (2, False, "acausal", [20, 75]),
+        (5, False, "acausal", [ 0,  1, 19, 20, 50, 51, 74, 75]),
     ],
 )
 @pytest.mark.parametrize(
@@ -4690,7 +4690,7 @@ def test_multi_epoch_pynapple_basis(
         (2, False, "anti-causal", [20, 75]),
         (2, None, "anti-causal", [20, 19, 75, 74]),
         (3, False, "acausal", [0, 20, 50, 75]),
-        (2, False, "acausal", [20, 75]),
+        (5, False, "acausal", [0,  1, 19, 20, 50, 51, 74, 75]),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -64,7 +64,7 @@ def test_sklearn_transformer_pipeline_cv_multiprocess(
     param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
     gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, n_jobs=3, error_score='raise')
     # use threading instead of fork (this avoids conflicts with jax)
-    with joblib.parallel_backend("threading", n_jobs=3):
+    with joblib.parallel_backend("threading"):
         gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -47,11 +47,11 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
 @pytest.mark.parametrize(
     "bas",
     [
-        basis.MSplineBasis(5),
+        # basis.MSplineBasis(5),
         basis.BSplineBasis(5),
-        basis.CyclicBSplineBasis(5),
-        basis.RaisedCosineBasisLinear(5),
-        basis.RaisedCosineBasisLog(5),
+        # basis.CyclicBSplineBasis(5),
+        # basis.RaisedCosineBasisLinear(5),
+        # basis.RaisedCosineBasisLog(5),
     ],
 )
 def test_sklearn_transformer_pipeline_cv_multiprocess(
@@ -61,7 +61,7 @@ def test_sklearn_transformer_pipeline_cv_multiprocess(
     bas = basis.TransformerBasis(bas)
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
     param_grid = dict(basis__n_basis_funcs=(3, 5, 10))
-    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, n_jobs=3)
+    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, n_jobs=3, error_score='raise')
     gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -39,7 +39,7 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
     X, y, model, _, _ = poissonGLM_model_instantiation
     bas = basis.TransformerBasis(bas)
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
-    param_grid = dict(basis__n_basis_funcs=(3, 5, 10))
+    param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
     gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, error_score='raise')
     gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -60,7 +60,7 @@ def test_sklearn_transformer_pipeline_cv_multiprocess(
     X, y, model, _, _ = poissonGLM_model_instantiation
     bas = basis.TransformerBasis(bas)
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
-    param_grid = dict(basis__n_basis_funcs=(3, 5, 10))
+    param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
     gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, n_jobs=3, error_score='raise')
     gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -47,11 +47,11 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
 @pytest.mark.parametrize(
     "bas",
     [
-        # basis.MSplineBasis(5),
+        basis.MSplineBasis(5),
         basis.BSplineBasis(5),
-        # basis.CyclicBSplineBasis(5),
-        # basis.RaisedCosineBasisLinear(5),
-        # basis.RaisedCosineBasisLog(5),
+        basis.CyclicBSplineBasis(5),
+        basis.RaisedCosineBasisLinear(5),
+        basis.RaisedCosineBasisLog(5),
     ],
 )
 def test_sklearn_transformer_pipeline_cv_multiprocess(
@@ -104,7 +104,7 @@ def test_sklearn_transformer_pipeline_cv_illegal_combination(
     pipe = pipeline.Pipeline([("transformerbasis", bas), ("fit", model)])
     param_grid = dict(
         transformerbasis___basis=(bas_cls(5), bas_cls(10), bas_cls(20)),
-        transformerbasis__n_basis_funcs=(3, 5, 10),
+        transformerbasis__n_basis_funcs=(4, 5, 10),
     )
     gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3)
     with pytest.raises(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,4 @@
+import joblib
 import numpy as np
 import pynapple as nap
 import pytest
@@ -62,7 +63,9 @@ def test_sklearn_transformer_pipeline_cv_multiprocess(
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
     param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
     gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, n_jobs=3, error_score='raise')
-    gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
+    # use threading instead of fork (this avoids conflicts with jax)
+    with joblib.parallel_backend("threading", n_jobs=3):
+        gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -40,7 +40,7 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
     bas = basis.TransformerBasis(bas)
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
     param_grid = dict(basis__n_basis_funcs=(3, 5, 10))
-    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3)
+    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, error_score='raise')
     gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 
 
@@ -82,7 +82,7 @@ def test_sklearn_transformer_pipeline_cv_directly_over_basis(
     bas = basis.TransformerBasis(bas_cls(5))
     pipe = pipeline.Pipeline([("transformerbasis", bas), ("fit", model)])
     param_grid = dict(transformerbasis___basis=(bas_cls(5), bas_cls(10), bas_cls(20)))
-    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3)
+    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, error_score='raise')
     gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 
 
@@ -106,7 +106,7 @@ def test_sklearn_transformer_pipeline_cv_illegal_combination(
         transformerbasis___basis=(bas_cls(5), bas_cls(10), bas_cls(20)),
         transformerbasis__n_basis_funcs=(4, 5, 10),
     )
-    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3)
+    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, error_score='raise')
     with pytest.raises(
         ValueError, match="Set either new _basis object or parameters for existing _basis, not both."
     ):


### PR DESCRIPTION
Fix some warnings in tests:
- basis in  conv `acausal` mode should have odd window size (we were setting even ws in tests sometimes)
- jax needs to start multiprocessing in spawn, not forking.
- shut off conversion error from jax to numpy array for the tests