### PR TITLE
fixed warns in test_convergence.py

### DIFF
--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -76,11 +76,12 @@ def test_ridge_convergence(solver_names):
     y = np.random.poisson(rate)
 
     # instantiate and fit ridge GLM with GradientDescent
-    model_GD = nmo.glm.GLM(regularizer="Ridge", solver_kwargs=dict(tol=10**-12))
+    model_GD = nmo.glm.GLM(regularizer_strength=1., regularizer="Ridge", solver_kwargs=dict(tol=10**-12))
     model_GD.fit(X, y)
 
     # instantiate and fit ridge GLM with ProximalGradient
     model_PG = nmo.glm.GLM(
+        regularizer_strength=1.,
         regularizer="Ridge",
         solver_name="ProximalGradient",
         solver_kwargs=dict(tol=10**-12),
@@ -108,6 +109,7 @@ def test_lasso_convergence(solver_name):
     # instantiate and fit GLM with ProximalGradient
     model_PG = nmo.glm.GLM(
         regularizer="Lasso",
+        regularizer_strength=1.,
         solver_name="ProximalGradient",
         solver_kwargs=dict(tol=10**-12),
     )


### PR DESCRIPTION
Added reg strength explicitly as parameter to silence the warning message.