### PR TITLE
Fix warns test convolution

### DIFF
--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -170,19 +170,16 @@ class BaseRegressor(Base, abc.ABC):
 
     @regularizer_strength.setter
     def regularizer_strength(self, strength: Union[float, None]):
-        # if using unregularized, strength will be None no matter what
-        if isinstance(self._regularizer, UnRegularized):
-            self._regularizer_strength = None
         # check regularizer strength
-        elif strength is None:
+        if strength is None and not isinstance(self._regularizer, UnRegularized):
             warnings.warn(
                 UserWarning(
                     "Caution: regularizer strength has not been set. Defaulting to 1.0. Please see "
                     "the documentation for best practices in setting regularization strength."
                 )
             )
-            self._regularizer_strength = 1.0
-        else:
+            strength = 1.0
+        elif strength is not None:
             try:
                 # force conversion to float to prevent weird GPU issues
                 strength = float(strength)
@@ -191,7 +188,16 @@ class BaseRegressor(Base, abc.ABC):
                 raise ValueError(
                     f"Could not convert the regularizer strength: {strength} to a float."
                 )
-            self._regularizer_strength = strength
+            if isinstance(self._regularizer, UnRegularized):
+                warnings.warn(
+                    UserWarning(
+                        "Unused parameter `regularizer_strength` for UnRegularized GLM. "
+                        "The regularizer strength parameter is not required and won't be used when the regularizer "
+                        "is set to UnRegularized."
+                    )
+                )
+
+        self._regularizer_strength = strength
 
     @property
     def solver_name(self) -> str:

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -146,9 +146,12 @@ class BaseRegressor(Base, abc.ABC):
         if "regularizer" in params and "regularizer_strength" in params:
             reg = params.pop("regularizer")
             with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=UserWarning,
-                                        message="Caution: regularizer strength.*"
-                                                "|Unused parameter `regularizer_strength`.*")
+                warnings.filterwarnings(
+                    "ignore",
+                    category=UserWarning,
+                    message="Caution: regularizer strength.*"
+                    "|Unused parameter `regularizer_strength`.*",
+                )
                 super().set_params(regularizer=reg)
 
         return super().set_params(**params)

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -139,6 +139,18 @@ class BaseRegressor(Base, abc.ABC):
         """
         return self._solver_run
 
+    def set_params(self, **params: Any):
+        """Manage warnings in case of multiple parameter settings."""
+        # if both regularizer and regularizer_strength are set, then only
+        # warn in case the strength is not expected for the regularizer type
+        if "regularizer" in params and "regularizer_strength" in params:
+            reg = params.pop("regularizer")
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning, message="Caution: regularizer strength.*")
+                super().set_params(regularizer=reg)
+
+        return super().set_params(**params)
+
     @property
     def regularizer(self) -> Union[None, Regularizer]:
         """Getter for the regularizer attribute."""

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -146,7 +146,9 @@ class BaseRegressor(Base, abc.ABC):
         if "regularizer" in params and "regularizer_strength" in params:
             reg = params.pop("regularizer")
             with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=UserWarning, message="Caution: regularizer strength.*")
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        message="Caution: regularizer strength.*"
+                                                "|Unused parameter `regularizer_strength`.*")
                 super().set_params(regularizer=reg)
 
         return super().set_params(**params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,7 +398,7 @@ def example_data_prox_operator():
         ),
     )
     regularizer_strength = 0.1
-    mask = jnp.array([[1, 0, 1, 0], [0, 1, 0, 1]], dtype=jnp.float32)
+    mask = jnp.array([[1, 0, 1, 0], [0, 1, 0, 1]]).astype(float)
     scaling = 0.5
 
     return params, regularizer_strength, mask, scaling

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -329,7 +329,7 @@ class TestCreateConvolutionalPredictor:
         conv = convolve.create_convolutional_predictor(
             basis_matrix, trial_counts, axis=axis
         )
-        assert jax.tree_util.tree_structure(trial_counts) == jax.tree_structure(conv)
+        assert jax.tree_util.tree_structure(trial_counts) == jax.tree_util.tree_structure(conv)
 
     @pytest.mark.parametrize("axis", [0, 1, 2])
     @pytest.mark.parametrize(
@@ -346,7 +346,6 @@ class TestCreateConvolutionalPredictor:
             (2, False, "anti-causal", [29]),
             (2, None, "anti-causal", [29, 28]),
             (3, False, "acausal", [29, 0]),
-            (2, False, "acausal", [29]),
         ],
     )
     def test_expected_nan(self, axis, window_size, shift, predictor_causality, nan_idx):
@@ -394,7 +393,6 @@ class TestCreateConvolutionalPredictor:
             (2, False, "anti-causal", [20, 75]),
             (2, None, "anti-causal", [20, 19, 75, 74]),
             (3, False, "acausal", [0, 20, 50, 75]),
-            (2, False, "acausal", [20, 75]),
         ],
     )
     def test_multi_epoch_pynapple(

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import nullcontext as does_not_raise
 
 import jax
@@ -501,7 +502,9 @@ class TestGammaObservations:
         X, y, model, _, firing_rate = gammaGLM_model_instantiation
 
         # statsmodels mcfadden
-        mdl = sm.GLM(y, sm.add_constant(X), family=sm.families.Gamma()).fit()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="The InversePower link function does")
+            mdl = sm.GLM(y, sm.add_constant(X), family=sm.families.Gamma()).fit()
         pr2_sms = mdl.pseudo_rsquared("mcf")
 
         # set params

--- a/tests/test_proximal_operator.py
+++ b/tests/test_proximal_operator.py
@@ -121,6 +121,7 @@ def test_prox_operator_shrinks_only_masked(example_data_prox_operator):
 
 def test_prox_operator_shrinks_only_masked_multineuron(example_data_prox_operator_multineuron):
     params, _, mask, _ = example_data_prox_operator_multineuron
+    mask = mask.astype(float)
     mask = mask.at[:, 1].set(jnp.zeros(2))
     params_new = prox_group_lasso(params, 0.05, mask)
     assert jnp.all(params_new[0][1] == params[0][1])

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import jax
 import jax.numpy as jnp
@@ -6,8 +7,6 @@ import numpy as np
 import pytest
 import statsmodels.api as sm
 from sklearn.linear_model import GammaRegressor, PoissonRegressor
-import warnings
-
 from statsmodels.tools.sm_exceptions import DomainWarning
 
 import nemos as nmo

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -728,9 +728,9 @@ class TestLasso:
             with pytest.raises(
                 ValueError, match=f"The solver: {solver_name} is not allowed for "
             ):
-                nmo.glm.GLM(regularizer=self.cls(), solver_name=solver_name)
+                nmo.glm.GLM(regularizer=self.cls(), solver_name=solver_name, regularizer_strength=1)
         else:
-            nmo.glm.GLM(regularizer=self.cls(), solver_name=solver_name)
+            nmo.glm.GLM(regularizer=self.cls(), solver_name=solver_name, regularizer_strength=1)
 
     @pytest.mark.parametrize(
         "solver_name",
@@ -751,7 +751,7 @@ class TestLasso:
             "ProxSVRG",
         ]
         regularizer = self.cls()
-        model = nmo.glm.GLM(regularizer=regularizer)
+        model = nmo.glm.GLM(regularizer=regularizer, regularizer_strength=1)
         raise_exception = solver_name not in acceptable_solvers
         if raise_exception:
             with pytest.raises(
@@ -775,12 +775,14 @@ class TestLasso:
                     regularizer=regularizer,
                     solver_name=solver_name,
                     solver_kwargs=solver_kwargs,
+                    regularizer_strength=1.
                 )
         else:
             nmo.glm.GLM(
                 regularizer=regularizer,
                 solver_name=solver_name,
                 solver_kwargs=solver_kwargs,
+                regularizer_strength=1.
             )
 
     def test_regularizer_strength_none(self):
@@ -793,7 +795,7 @@ class TestLasso:
         assert model.regularizer_strength == 1.0
 
         # if changed to regularized, should go to None
-        model.regularizer = "UnRegularized"
+        model.set_params(regularizer="UnRegularized", regularizer_strength=None)
         assert model.regularizer_strength is None
 
         # if changed back, should warn and set to 1.0
@@ -813,7 +815,7 @@ class TestLasso:
         """Test that the loss function is a callable"""
         raise_exception = not callable(loss)
         regularizer = self.cls()
-        model = nmo.glm.GLM(regularizer=regularizer)
+        model = nmo.glm.GLM(regularizer=regularizer, regularizer_strength=1)
         model._predict_and_compute_loss = loss
         if raise_exception:
             with pytest.raises(TypeError, match="The `loss` must be a Callable"):
@@ -827,7 +829,7 @@ class TestLasso:
 
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
 
-        model.regularizer = self.cls()
+        model.set_params(regularizer=self.cls(), regularizer_strength=1)
         model.solver_name = solver_name
         runner = model.instantiate_solver().solver_run
         runner((true_params[0] * 0.0, true_params[1]), X, y)
@@ -839,7 +841,7 @@ class TestLasso:
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation_pytree
 
         # set regularizer and solver name
-        model.regularizer = self.cls()
+        model.set_params(regularizer=self.cls(), regularizer_strength=1)
         model.solver_name = solver_name
         runner = model.instantiate_solver().solver_run
         runner(
@@ -857,7 +859,7 @@ class TestLasso:
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
         # set precision to float64 for accurate matching of the results
         model.data_type = jnp.float64
-        model.regularizer = self.cls()
+        model.set_params(regularizer=self.cls(), regularizer_strength=1)
         model.solver_name = solver_name
         model.solver_kwargs = {"tol": 10**-12}
 
@@ -885,7 +887,7 @@ class TestLasso:
     def test_lasso_pytree(self, poissonGLM_model_instantiation_pytree):
         """Check pytree X can be fit."""
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation_pytree
-        model.regularizer = nmo.regularizer.Lasso()
+        model.set_params(regularizer=nmo.regularizer.Lasso(), regularizer_strength=1.)
         model.solver_name = "ProximalGradient"
         model.fit(X, y)
 
@@ -903,10 +905,9 @@ class TestLasso:
         X, _, model, _, _ = poissonGLM_model_instantiation_pytree
         X_array, y, model_array, _, _ = poissonGLM_model_instantiation
 
-        model.regularizer_strength = reg_str
-        model_array.regularizer_strength = reg_str
-        model.regularizer = nmo.regularizer.Lasso()
-        model_array.regularizer = nmo.regularizer.Lasso()
+
+        model.set_params(regularizer=nmo.regularizer.Lasso(), regularizer_strength=reg_str)
+        model_array.set_params(regularizer=nmo.regularizer.Lasso(), regularizer_strength=reg_str)
         model.solver_name = solver_name
         model_array.solver_name = solver_name
         model.fit(X, y)
@@ -918,7 +919,7 @@ class TestLasso:
     @pytest.mark.parametrize("solver_name", ["ProximalGradient", "ProxSVRG"])
     def test_solver_combination(self, solver_name, poissonGLM_model_instantiation):
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.regularizer = self.cls()
+        model.set_params(regularizer=self.cls(), regularizer_strength=1.)
         model.solver_name = solver_name
         model.fit(X, y)
 
@@ -956,9 +957,9 @@ class TestGroupLasso:
             with pytest.raises(
                 ValueError, match=f"The solver: {solver_name} is not allowed for "
             ):
-                nmo.glm.GLM(regularizer=self.cls(mask=mask), solver_name=solver_name)
+                nmo.glm.GLM(regularizer=self.cls(mask=mask), solver_name=solver_name, regularizer_strength=1)
         else:
-            nmo.glm.GLM(regularizer=self.cls(mask=mask), solver_name=solver_name)
+            nmo.glm.GLM(regularizer=self.cls(mask=mask), solver_name=solver_name, regularizer_strength=1)
 
     @pytest.mark.parametrize(
         "solver_name",
@@ -985,7 +986,7 @@ class TestGroupLasso:
         mask = jnp.asarray(mask)
         regularizer = self.cls(mask=mask)
         raise_exception = solver_name not in acceptable_solvers
-        model = nmo.glm.GLM(regularizer=regularizer)
+        model = nmo.glm.GLM(regularizer=regularizer, regularizer_strength=1)
         if raise_exception:
             with pytest.raises(
                 ValueError, match=f"The solver: {solver_name} is not allowed for "
@@ -1016,12 +1017,14 @@ class TestGroupLasso:
                     regularizer=regularizer,
                     solver_name=solver_name,
                     solver_kwargs=solver_kwargs,
+                    regularizer_strength=1.
                 )
         else:
             nmo.glm.GLM(
                 regularizer=regularizer,
                 solver_name=solver_name,
                 solver_kwargs=solver_kwargs,
+                regularizer_strength=1.
             )
 
     def test_regularizer_strength_none(self):
@@ -1034,8 +1037,7 @@ class TestGroupLasso:
         assert model.regularizer_strength == 1.0
 
         # if changed to regularized, should go to None
-        model.regularizer = "UnRegularized"
-        assert model.regularizer_strength is None
+        model.set_params(regularizer="UnRegularized", regularizer_strength=None)
 
         # if changed back, should warn and set to 1.0
         with pytest.warns(UserWarning):
@@ -1061,7 +1063,7 @@ class TestGroupLasso:
         mask = jnp.asarray(mask)
 
         regularizer = self.cls(mask=mask)
-        model = nmo.glm.GLM(regularizer=regularizer)
+        model = nmo.glm.GLM(regularizer=regularizer, regularizer_strength=1.)
         model._predict_and_compute_loss = loss
 
         if raise_exception:
@@ -1082,7 +1084,7 @@ class TestGroupLasso:
         mask[1, 2:] = 1
         mask = jnp.asarray(mask)
 
-        model.regularizer = self.cls(mask=mask)
+        model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
         model.solver_name = solver_name
 
         model.instantiate_solver()
@@ -1100,7 +1102,7 @@ class TestGroupLasso:
         mask[1, 2:] = 1
         mask = jnp.asarray(mask)
 
-        model.regularizer = self.cls(mask=mask)
+        model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
         model.solver_name = solver_name
 
         model.instantiate_solver()
@@ -1126,7 +1128,7 @@ class TestGroupLasso:
         mask[1, 2:] = 1
         mask = jnp.asarray(mask)
 
-        model.regularizer = self.cls(mask=mask)
+        model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
         model.solver_name = solver_name
 
         model.instantiate_solver()
@@ -1186,9 +1188,9 @@ class TestGroupLasso:
             with pytest.raises(
                 ValueError, match="Incorrect group assignment. " "Some of the features"
             ):
-                model.regularizer = self.cls(mask=mask)
+                model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
         else:
-            model.regularizer = self.cls(mask=mask)
+            model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
 
     @pytest.mark.parametrize("set_entry", [0, 1, -1, 2, 2.5])
     def test_mask_validity_entries(self, set_entry, poissonGLM_model_instantiation):
@@ -1206,9 +1208,9 @@ class TestGroupLasso:
 
         if raise_exception:
             with pytest.raises(ValueError, match="Mask elements be 0s and 1s"):
-                model.regularizer = self.cls(mask=mask)
+                model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
         else:
-            model.regularizer = self.cls(mask=mask)
+            model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
 
     @pytest.mark.parametrize("n_dim", [0, 1, 2, 3])
     def test_mask_dimension_1(self, n_dim, poissonGLM_model_instantiation):
@@ -1235,9 +1237,9 @@ class TestGroupLasso:
 
         if raise_exception:
             with pytest.raises(ValueError, match="`mask` must be 2-dimensional"):
-                model.regularizer = self.cls(mask=mask)
+                model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
         else:
-            model.regularizer = self.cls(mask=mask)
+            model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
 
     @pytest.mark.parametrize("n_groups", [0, 1, 2])
     def test_mask_n_groups(self, n_groups, poissonGLM_model_instantiation):
@@ -1256,9 +1258,9 @@ class TestGroupLasso:
 
         if raise_exception:
             with pytest.raises(ValueError, match=r"Empty mask provided! Mask has "):
-                model.regularizer = self.cls(mask=mask)
+                model.set_params(regularizer = self.cls(mask=mask), regularizer_strength=1.)
         else:
-            model.regularizer = self.cls(mask=mask)
+            model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
 
     def test_group_sparsity_enforcement(
         self, group_sparse_poisson_glm_model_instantiation
@@ -1278,7 +1280,7 @@ class TestGroupLasso:
         mask[1, ~zeros_true] = 1
         mask = jnp.asarray(mask, dtype=jnp.float32)
 
-        model.regularizer = self.cls(mask=mask)
+        model.set_params(regularizer=self.cls(mask=mask), regularizer_strength=1.)
         model.solver_name = "ProximalGradient"
 
         runner = model.instantiate_solver().solver_run
@@ -1415,14 +1417,15 @@ class TestGroupLasso:
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
 
         with pytest.warns(UserWarning):
-            model.regularizer = self.cls()
+            model.regularizer = self.cls(mask=np.ones((1, X.shape[1])).astype(float))
             model.solver_name = "ProximalGradient"
             model.fit(X, y)
 
     @pytest.mark.parametrize("solver_name", ["ProximalGradient", "ProxSVRG"])
     def test_solver_combination(self, solver_name, poissonGLM_model_instantiation):
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        model.regularizer = self.cls()
+        model.set_params(regularizer=self.cls(mask=np.ones((1, X.shape[1])).astype(float)),
+                         regularizer_strength=None if self.cls==nmo.regularizer.UnRegularized else 1.)
         model.solver_name = solver_name
         model.fit(X, y)
 

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -218,9 +218,8 @@ class TestUnRegularized:
 
         assert model.regularizer_strength == 1.0
 
-        # assert change back to unregularized is none
         model.regularizer = regularizer
-        assert model.regularizer_strength is None
+        assert model.regularizer_strength == 1.
 
     def test_get_params(self):
         """Test get_params() returns expected values."""
@@ -535,13 +534,13 @@ class TestRidge:
 
         assert model.regularizer_strength == 1.0
 
-        # if changed to regularized, should go to None
-        model.regularizer = "UnRegularized"
-        assert model.regularizer_strength is None
+        with pytest.warns(UserWarning):
+            # if changed to regularized, is kept to 1.
+            model.regularizer = "UnRegularized"
+        assert model.regularizer_strength == 1.0
 
         # if changed back, should warn and set to 1.0
-        with pytest.warns(UserWarning):
-            model.regularizer = "Ridge"
+        model.regularizer = "Ridge"
 
         assert model.regularizer_strength == 1.0
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -128,7 +128,7 @@ def test_svrg_glm_instantiate_solver(regularizer_name, solver_class, mask):
     if mask is not None:
         kwargs["mask"] = mask
 
-    glm = nmo.glm.GLM(regularizer=regularizer_name, solver_name=solver_name)
+    glm = nmo.glm.GLM(regularizer=regularizer_name, solver_name=solver_name, regularizer_strength=None if regularizer_name == "UnRegularized" else 1,)
     glm.instantiate_solver()
 
     solver = inspect.getclosurevars(glm._solver_run).nonlocals["solver"]
@@ -161,6 +161,7 @@ def test_svrg_glm_passes_solver_kwargs(regularizer_name, solver_name, mask, glm_
         regularizer=regularizer_name,
         solver_name=solver_name,
         solver_kwargs=solver_kwargs,
+        regularizer_strength=None if regularizer_name == "UnRegularized" else 1,
         **kwargs,
     )
     glm.instantiate_solver()
@@ -177,9 +178,9 @@ def test_svrg_glm_passes_solver_kwargs(regularizer_name, solver_name, mask, glm_
         (
             "GroupLasso",
             ProxSVRG,
-            np.array([[0], [0], [1]]),
+            np.array([[0.], [0.], [1.]]),
         ),
-        ("GroupLasso", ProxSVRG, None),
+        ("GroupLasso", ProxSVRG, np.array([[1.], [0.], [0.]])),
         ("Ridge", SVRG, None),
         ("UnRegularized", SVRG, None),
     ],
@@ -196,15 +197,22 @@ def test_svrg_glm_initialize_state(
     if glm_class == nmo.glm.PopulationGLM:
         y = np.expand_dims(y, 1)
 
+    reg_cls = getattr(nmo.regularizer, regularizer_name)
+    if regularizer_name == "GroupLasso":
+        reg = reg_cls(mask=mask)
+    else:
+        reg = reg_cls()
+
     # only pass mask if it's not None
     kwargs = {}
     if mask is not None and glm_class == nmo.glm.PopulationGLM:
         kwargs["feature_mask"] = mask
 
     glm = glm_class(
-        regularizer=regularizer_name,
+        regularizer=reg,
         solver_name=solver_class.__name__,
         observation_model=nmo.observation_models.PoissonObservations(jax.nn.softplus),
+        regularizer_strength=None if regularizer_name == "UnRegularized" else 1,
         **kwargs,
     )
 
@@ -225,7 +233,7 @@ def test_svrg_glm_initialize_state(
         (
             "GroupLasso",
             ProxSVRG,
-            np.array([[0], [0], [1]]),
+            np.array([[0.], [0.], [1.]]),
         ),
         ("Ridge", SVRG, None),
         ("UnRegularized", SVRG, None),
@@ -244,13 +252,20 @@ def test_svrg_glm_update(
 
     # only pass mask if it's not None
     kwargs = {}
-    if mask is not None and glm_class == nmo.glm.PopulationGLM:
+    if glm_class == nmo.glm.PopulationGLM:
         kwargs["feature_mask"] = mask
 
+    reg_cls = getattr(nmo.regularizer, regularizer_name)
+    if regularizer_name == "GroupLasso":
+        reg = reg_cls(mask=mask)
+    else:
+        reg = reg_cls()
+
     glm = glm_class(
-        regularizer=regularizer_name,
+        regularizer=reg,
         solver_name=solver_class.__name__,
         observation_model=nmo.observation_models.PoissonObservations(jax.nn.softplus),
+        regularizer_strength=None if regularizer_name == "UnRegularized" else 1,
         **kwargs,
     )
 
@@ -276,15 +291,15 @@ def test_svrg_glm_update(
         (
             "GroupLasso",
             "ProxSVRG",
-            np.array([[0, 1, 0], [0, 0, 1]]).reshape(2, -1).astype(float),
+            np.array([[0, 1, 0, 1, 1], [1, 0, 1, 0, 0]]).astype(float),
         ),
-        ("GroupLasso", "ProxSVRG", None),
+        ("GroupLasso", "ProxSVRG", np.array([[1, 1, 1, 1, 1]]).astype(float)),
         (
             "GroupLasso",
             "ProximalGradient",
-            np.array([[0, 1, 0], [0, 0, 1]]).reshape(2, -1).astype(float),
+            np.array([[0, 1, 0, 1, 1], [1, 0, 1, 0, 0]]).astype(float),
         ),
-        ("GroupLasso", "ProximalGradient", None),
+        ("GroupLasso", "ProximalGradient", np.array([[1, 1, 1, 1, 1]]).astype(float)),
         ("Ridge", "SVRG", None),
         ("UnRegularized", "SVRG", None),
     ],
@@ -314,15 +329,23 @@ def test_svrg_glm_fit(
     }
 
     # only pass mask if it's not None
+    reg_cls = getattr(nmo.regularizer, regularizer_name)
+    if regularizer_name == "GroupLasso":
+        reg = reg_cls(mask=mask)
+    else:
+        reg = reg_cls()
+
     kwargs = {}
-    if mask is not None:
-        kwargs["feature_mask"] = mask
+    if glm_class == nmo.glm.PopulationGLM:
+        kwargs["feature_mask"] = np.ones((X.shape[1], 1))
 
     glm = glm_class(
-        regularizer=regularizer_name,
+        regularizer=reg,
         solver_name=solver_name,
         observation_model=nmo.observation_models.PoissonObservations(jax.nn.softplus),
         solver_kwargs=solver_kwargs,
+        regularizer_strength=None if regularizer_name == "UnRegularized" else 1,
+        **kwargs
     )
 
     if isinstance(glm, nmo.glm.PopulationGLM):
@@ -356,17 +379,20 @@ def test_svrg_glm_update_needs_full_grad_at_reference_point(
         y = np.expand_dims(y, 1)
 
     # only pass mask if it's not None
+    reg_cls = getattr(nmo.regularizer, regularizer_name)
+    if regularizer_name == "GroupLasso":
+        reg = reg_cls(mask=mask)
+    else:
+        reg = reg_cls()
     kwargs = dict(
-        regularizer=regularizer_name,
+        regularizer=reg,
         solver_name=solver_class.__name__,
         observation_model=nmo.observation_models.PoissonObservations(jax.nn.softplus),
+        regularizer_strength=None if regularizer_name == "UnRegularized" else 0.1,
     )
 
     if mask is not None and glm_class == nmo.glm.PopulationGLM:
-        kwargs["feature_mask"] = mask
-
-    if glm_class != nmo.regularizer.UnRegularized:
-        kwargs["regularizer_strength"] = 0.1
+        kwargs["feature_mask"] = np.array([0, 1, 0]).reshape(-1, 1).astype(float)
 
     glm = glm_class(**kwargs)
 

--- a/tests/test_tree_utils.py
+++ b/tests/test_tree_utils.py
@@ -1,5 +1,5 @@
-import numpy as np
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from nemos import tree_utils

--- a/tests/test_type_casting.py
+++ b/tests/test_type_casting.py
@@ -370,7 +370,7 @@ def test_equal_time_axis_nap_types(t1, t2, data, cls, expectation):
         (
             [
                 nap.Tsd(t=np.arange(10), d=np.arange(10)),
-                nap.Tsd(t=np.arange(1), d=np.arange(1)),
+                nap.Tsd(t=np.arange(1), d=np.arange(1), time_support=nap.IntervalSet(0, 10)),
                 nap.Tsd(t=np.arange(10), d=np.arange(10)),
             ],
             pytest.raises(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import nullcontext as does_not_raise
 
 import jax
@@ -6,7 +7,6 @@ import numpy as np
 import pynapple as nap
 import pytest
 from scipy.interpolate import splev
-import warnings
 
 from nemos import utils
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import pynapple as nap
 import pytest
 from scipy.interpolate import splev
+import warnings
 
 from nemos import utils
 
@@ -107,7 +108,10 @@ class TestPadding:
             with pytest.raises(ValueError, match="predictor_causality must be one of"):
                 utils.nan_pad(iterable, 3, predictor_causality)
         else:
-            utils.nan_pad(iterable, 3, predictor_causality)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        message="With acausal filter, pad_size should probably be even")
+                utils.nan_pad(iterable, 3, predictor_causality)
 
     @pytest.mark.parametrize("iterable", [[np.zeros([2, 4, 5]), np.zeros([2, 4, 6])]])
     @pytest.mark.parametrize("pad_size", [0.1, -1, 0, 1, 2, 3, 5, 6])
@@ -159,7 +163,7 @@ class TestPadding:
             ), "Size after padding doesn't match expectation. Should be T + window_size - 1."
 
     @pytest.mark.parametrize("iterable", [[np.zeros([2, 5, 4]), np.zeros([2, 6, 4])]])
-    @pytest.mark.parametrize("pad_size", [-1, 0.2, 0, 1, 2, 3, 5, 6])
+    @pytest.mark.parametrize("pad_size", [-1, 0.2, 0, 1, 3, 5])
     def test_padding_nan_acausal(self, pad_size, iterable):
         raise_exception = (not isinstance(pad_size, int)) or (pad_size <= 0)
         if raise_exception:
@@ -170,7 +174,10 @@ class TestPadding:
 
         else:
             init_nan, end_nan = pad_size // 2, pad_size - pad_size // 2
-            padded = utils.nan_pad(iterable, pad_size, "acausal")
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        message="With acausal filter, pad_size should probably be even")
+                padded = utils.nan_pad(iterable, pad_size, "acausal")
             for trial in padded:
                 print(trial.shape, pad_size)
             assert all(np.isnan(trial[:init_nan]).all() for trial in padded), (
@@ -252,8 +259,11 @@ class TestPadding:
         ],
     )
     def test_axis_compatibility(self, pad_size, array, causality, axis, expectation):
-        with expectation:
-            utils.nan_pad(array, pad_size, causality, axis=axis)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning,
+                                    message="With acausal filter, pad_size should probably be even")
+            with expectation:
+                utils.nan_pad(array, pad_size, causality, axis=axis)
 
     @pytest.mark.parametrize("causality", ["causal", "acausal", "anti-causal"])
     @pytest.mark.parametrize(
@@ -273,8 +283,11 @@ class TestPadding:
     )
     @pytest.mark.parametrize("array", [jnp.zeros((10,)), np.zeros((10, 11))])
     def test_pad_size_type(self, pad_size, array, causality, expectation):
-        with expectation:
-            utils.nan_pad(array, pad_size, causality, axis=0)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning,
+                                    message="With acausal filter, pad_size should probably be even")
+            with expectation:
+                utils.nan_pad(array, pad_size, causality, axis=0)
 
     @pytest.mark.parametrize(
         "causality, pad_size, expectation",


### PR DESCRIPTION
- Fix all warning messages in tests
- Change regularizer strength setter logic; never change user base settings, warn in case of unused params (UnRegularized with not None strength)