### PR TITLE
Splits tox into multiple jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
        - main
 
 jobs:
-  tox:
+  tests:
     if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
@@ -38,7 +38,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .
           pip install tox
 
       - name: Run tox
@@ -48,6 +47,27 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  check:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4 # Use v4 for compatibility with pyproject.toml
+        with:
+          python-version: 3.12
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run tox
+        run: tox -e check
 
   prevent_docs_absolute_links:
     runs-on: ubuntu-latest
@@ -63,7 +83,10 @@ jobs:
 
   check:
     if: ${{ !github.event.pull_request.draft }}
-    needs: tox
+    needs:
+      - tests
+      - prevent_docs_absolute_links
+      - check
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether all tests and notebooks succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
        - main
 
 jobs:
-  tests:
+  tox_tests:
     if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
@@ -48,7 +48,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  check:
+  tox_check:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
@@ -84,9 +84,9 @@ jobs:
   check:
     if: ${{ !github.event.pull_request.draft }}
     needs:
-      - tests
+      - tox_tests
       - prevent_docs_absolute_links
-      - check
+      - tox_check
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether all tests and notebooks succeeded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,19 @@ See below for details on how to [add tests](#adding-tests) and properly [documen
 
 Lastly, you should make sure that the existing tests all run successfully and that the codebase is formatted properly:
 
+> [!TIP]
+> The [NeMoS GitHub action](.github/workflows/ci.yml) runs tests and some additional style checks in an isolated environment using [`tox`](https://tox.wiki/en/). `tox` is not included in our optional dependencies, so if you want to replicate the action workflow locally, you need to install `tox` via pip and then run it. From the package directory:
+> ```sh
+> pip install tox
+> tox -e check,py
+> ```
+> This will execute `tox` with a Python version that matches your local environment. If the above passes, then the Github action will pass and your PR is mergeable
+>
+> You can also use `tox` to use `black` and `isort` to try and fix your code if either of those are failing. To do so, run `tox -e fix`
+> 
+> `tox` configurations can be found in the [`tox.ini`](tox.ini) file.
+
+
 ```bash
 # run tests and make sure they all pass
 pytest tests/
@@ -105,7 +118,10 @@ pytest --doctest-modules src/nemos/
 
 # format the code base
 black src/
-isort src
+isort src --profile=black
+isort docs/how_to_guide --profile=black
+isort docs/background --profile=black
+isort docs/tutorials --profile=black
 flake8 --config=tox.ini src
 ```
 
@@ -128,14 +144,6 @@ you will probably need to respond to our comments, making changes as appropriate
 changes. 
 
 Additionally, every PR to `main` or `development` will automatically run linters and tests through a [GitHub action](https://docs.github.com/en/actions). Merges can happen only when all check passes.
-
-> [!NOTE]
-> The [NeMoS GitHub action](.github/workflows/ci.yml) runs tests in an isolated environment using [`tox`](https://tox.wiki/en/). `tox` is not included in our optional dependencies, so if you want to replicate the action workflow locally, you need to install `tox` via pip and then run it. From the package directory:
-> ```sh
-> pip install tox
-> tox -e py
-> ```
-> This will execute `tox` with a Python version that matches your local environment. `tox` configurations can be found in the [`tox.ini`](tox.ini) file.
 
 Once your changes are integrated, you will be added as a GitHub contributor and as one of the authors of the package. Thank you for being part of `nemos`!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "isort",                        # Import sorter
     "pip-tools",                    # Dependency management
     "pytest",                       # Testing framework
+    "pytest-xdist",                 # Parallelize pytest
     "flake8",                       # Code linter
     "coverage",                     # Test coverage measurement
     "pytest-cov",                   # Test coverage plugin for pytest
@@ -112,6 +113,7 @@ profile = "black"
 # Configure pytest
 [tool.pytest.ini_options]
 testpaths = ["tests"]             # Specify the directory where test files are located
+addopts = "-n auto"
 
 [tool.coverage.run]
 omit = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py310, py311, py312
+envlist = py,fix
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -12,17 +12,26 @@ extras = dev
 package_cache = .tox/cache
 
 # Run both pytest and coverage since pytest was initialized with the --cov option in the pyproject.toml
-# while black, isort and flake8 are also i
 commands =
-    black --check src
+    pytest --doctest-modules src/nemos/
+    pytest --cov=nemos --cov-config=pyproject.toml --cov-report=xml
+
+[testenv:fix]
+commands=
+    black src
     isort src --profile=black
     isort docs/how_to_guide --profile=black
     isort docs/background --profile=black
     isort docs/tutorials --profile=black
-    flake8 --config={toxinidir}/tox.ini src
-    pytest --doctest-modules src/nemos/
-    pytest --cov=nemos --cov-config=pyproject.toml --cov-report=xml
 
+[testenv:check]
+commands=
+    black --check src
+    isort --check src --profile=black
+    isort --check docs/how_to_guide --profile=black
+    isort --check docs/background --profile=black
+    isort --check docs/tutorials --profile=black
+    flake8 --config={toxinidir}/tox.ini src
 
 [gh-actions]
 python =


### PR DESCRIPTION
With this PR, we now have three possible tox environments: the default (run pytest), `fix` (runs black and isort commands that edit `src/` and some of `docs`), and `check` (just check those directories and raise error).

Then additionally made changes to `ci.yml`:
- adds new `check` job, which just runs the `check` tox environment.
- remove `pip install -e .[dev]` during set up of tox (because tox will install all requirements into its own 
- final `check` job now requires all of `tests`, `prevent_docs_absolute_links`, and `check`environments)

Thus our CI should be slightly faster (as we're no longer installing unnecessary packages and only running black+isort+flake8 with one OS / python version, instead of all)

I think that by editing `envlist` at the top of the `tox.ini`, we can make it so the default tox action is to run the test with a single python version and also run `fix`, do we want that?

Finally, CONTRIBUTING still needs to be updated. if this all looks good to you, I can go ahead and update it to reflect these changes.