### PR TITLE
Initialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ profile = "black"
 # Configure pytest
 [tool.pytest.ini_options]
 testpaths = ["tests"]             # Specify the directory where test files are located
-addopts = "-n auto"
 
 [tool.coverage.run]
 omit = [

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -17,11 +17,11 @@ from . import observation_models as obs
 from . import tree_utils, validation
 from .base_regressor import BaseRegressor
 from .exceptions import NotFittedError
+from .initialize_regressor import initialize_intercept_matching_mean_rate
 from .pytrees import FeaturePytree
 from .regularizer import GroupLasso, Lasso, Regularizer, Ridge
 from .type_casting import jnp_asarray_if, support_pynapple
 from .typing import DESIGN_INPUT_TYPE
-from .initialize_regressor import initialize_intercept_matching_mean_rate
 
 ModelParams = Tuple[jnp.ndarray, jnp.ndarray]
 
@@ -535,7 +535,9 @@ class GLM(BaseRegressor):
         else:
             data = X
 
-        initial_intercept= initialize_intercept_matching_mean_rate(self.observation_model.inverse_link_function, y)
+        initial_intercept = initialize_intercept_matching_mean_rate(
+            self.observation_model.inverse_link_function, y
+        )
 
         # Initialize parameters
         init_params = (

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -11,7 +11,6 @@ import jax
 import jax.numpy as jnp
 import jaxopt
 from numpy.typing import ArrayLike
-from scipy.optimize import root
 
 from . import observation_models as obs
 from . import tree_utils, validation

--- a/src/nemos/initialize_regressor.py
+++ b/src/nemos/initialize_regressor.py
@@ -1,18 +1,20 @@
-import jax.numpy as jnp
-import jax
-from scipy.optimize import root_scalar
 from typing import Callable
-from numpy.typing import ArrayLike
 
+import jax
+import jax.numpy as jnp
+from numpy.typing import ArrayLike
+from scipy.optimize import root_scalar
 
 # dictionary of known inverse link functions.
 INVERSE_FUNCS = {
     jnp.exp: jnp.log,
-    jax.nn.softplus: lambda x: jnp.log(jnp.exp(x) - 1.),
+    jax.nn.softplus: lambda x: jnp.log(jnp.exp(x) - 1.0),
 }
 
 
-def scalar_root_find_elementwise(func: Callable, args: ArrayLike, x0: ArrayLike) -> jnp.ndarray:
+def scalar_root_find_elementwise(
+    func: Callable, args: ArrayLike, x0: ArrayLike
+) -> jnp.ndarray:
     """
     Find roots of a scalar function.
 
@@ -40,17 +42,19 @@ def scalar_root_find_elementwise(func: Callable, args: ArrayLike, x0: ArrayLike)
     """
     opts = [root_scalar(func, arg, x0=x, method="secant") for arg, x in zip(args, x0)]
 
-    if not all(jnp.abs(func(opt.root, args[i])) < 10 ** -4 for i, opt in enumerate(opts)):
+    if not all(jnp.abs(func(opt.root, args[i])) < 10**-4 for i, opt in enumerate(opts)):
         raise ValueError(
-                "Could not set the initial intercept as the inverse of the firing rate for "
-                "the provided link function. "
-                "Please, provide initial parameters instead!"
-            )
+            "Could not set the initial intercept as the inverse of the firing rate for "
+            "the provided link function. "
+            "Please, provide initial parameters instead!"
+        )
 
     return jnp.array([opt.root for opt in opts])
 
 
-def initialize_intercept_matching_mean_rate(inverse_link_function: Callable, y: jnp.ndarray) -> jnp.ndarray:
+def initialize_intercept_matching_mean_rate(
+    inverse_link_function: Callable, y: jnp.ndarray
+) -> jnp.ndarray:
     """
     Compute the initial intercept term for a regression models.
 
@@ -81,8 +85,10 @@ def initialize_intercept_matching_mean_rate(inverse_link_function: Callable, y: 
     if analytical_inv:
         out = analytical_inv(means)
         if jnp.any(jnp.isnan(out)):
-            raise ValueError("Could not set the initial intercept as the inverse of the firing rate for "
-                             "the provided link funciton. The mean firing rate assumes negative values.")
+            raise ValueError(
+                "Could not set the initial intercept as the inverse of the firing rate for "
+                "the provided link funciton. The mean firing rate assumes negative values."
+            )
         return out
 
     def func(x, mean_x):

--- a/src/nemos/initialize_regressor.py
+++ b/src/nemos/initialize_regressor.py
@@ -1,0 +1,87 @@
+import jax.numpy as jnp
+import jax
+from scipy.optimize import root_scalar
+from typing import Callable
+from numpy.typing import ArrayLike
+
+
+# dictionary of known inverse link functions.
+INVERSE_FUNCS = {
+    jnp.exp: jnp.log,
+    jax.nn.softplus: lambda x: jnp.log(jnp.exp(x) - 1.),
+}
+
+
+def scalar_root_find_elementwise(func: Callable, args: ArrayLike, x0: ArrayLike) -> jnp.ndarray:
+    """
+    Find roots of a scalar function.
+
+    This can be used as an attempt to find a numerical inverse of an unknown link function of a GLM; typically,
+    this numerical inverse, is used to set the initial intercept to match the mean firing rate of the model.
+
+    Parameters
+    ----------
+    func:
+        A callable, which typically will be `inv_link_func(x) - jnp.mean(spikes)`.
+    args:
+        List of additional arguments passed to the function.
+    x0:
+        Initial values for the root-finding algorithm.
+
+    Returns
+    -------
+    :
+        An array containing the roots of each f(x) = func(x, args[k]), for k in 1,..., len(args).
+
+    Raises
+    ------
+    ValueError:
+        If any of the optimization is not successful.
+    """
+    opts = [root_scalar(func, arg, x0=x, method="secant") for arg, x in zip(args, x0)]
+
+    if any(func(opt.root, args[i]) > 10 ** -4 for i, opt in enumerate(opts)):
+        raise ValueError(
+                "Could not set the initial intercept as the inverse of the firing rate for "
+                "the provided link function. "
+                "Please, provide initial parameters instead!"
+            )
+
+    return jnp.array([opt.root for opt in opts])
+
+
+def initialize_intercept_matching_mean_rate(inverse_link_function: Callable, y: jnp.ndarray) -> jnp.ndarray:
+    """
+    Compute the initial intercept term for a regression models.
+
+    This method compute an initial intercept term for a regression models such that the baseline activity
+    matches the mean activity of each neuron, assuming that the model coefficients are initialized to zero.
+
+
+    Parameters
+    ----------
+    inverse_link_function:
+        The inverse link function of the model, linking the mean to the linear combination of the covariates in
+        a GLM.
+    y:
+        The neural activity, shape either (num_sample,) for single variable regressors as `GLM`
+         or (n_sample, n_neurons) for multi-variable regressors, such as `PopulaitonGLM`.
+
+    Returns
+    -------
+    :
+        The initial intercept term, shape (n_neurons,).
+
+    """
+
+    # return inverse if analytical solution is available
+    analytical_inv = INVERSE_FUNCS.get(inverse_link_function, None)
+
+    means = jnp.atleast_1d(jnp.mean(y, axis=0))
+    if analytical_inv:
+        return analytical_inv(means)
+
+    def func(x, mean_x):
+        return inverse_link_function(x) - mean_x
+
+    return scalar_root_find_elementwise(func, means, means)

--- a/src/nemos/initialize_regressor.py
+++ b/src/nemos/initialize_regressor.py
@@ -87,7 +87,7 @@ def initialize_intercept_matching_mean_rate(
         if jnp.any(jnp.isnan(out)):
             raise ValueError(
                 "Could not set the initial intercept as the inverse of the firing rate for "
-                "the provided link funciton. The mean firing rate assumes negative values."
+                "the provided link function. The mean firing rate has some negative values."
             )
         return out
 

--- a/src/nemos/initialize_regressor.py
+++ b/src/nemos/initialize_regressor.py
@@ -86,12 +86,19 @@ def initialize_intercept_matching_mean_rate(
         out = analytical_inv(means)
         if jnp.any(jnp.isnan(out)):
             raise ValueError(
-                "Could not set the initial intercept as the inverse of the firing rate for "
-                "the provided link function. The mean firing rate has some negative values."
+                "Failed to initialize the model intercept as the inverse of the firing rate for "
+                "the provided link function. The mean firing rate has some non-positive values."
             )
         return out
 
     def func(x, mean_x):
         return inverse_link_function(x) - mean_x
 
-    return scalar_root_find_elementwise(func, means, means)
+    try:
+        out = scalar_root_find_elementwise(func, means, means)
+    except ValueError:
+        raise ValueError(
+            "Failed to initialize the model intercept as the inverse of the firing rate for the"
+            " provided link function. Please, provide initial parameters instead!"
+        )
+    return out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -626,3 +626,25 @@ def ridge_regression_tree(ridge_regression):
         return jnp.power(yy - pred, 2).sum() + norm
 
     return X_tree, y, coef_tree, ridge_tree, loss_tree
+
+
+@pytest.fixture()
+def example_X_y_high_firing_rates():
+    """Example that used failed with NeMoS original initialization."""
+    np.random.seed(123)
+
+    n_features = 18
+    n_neurons = 60
+    n_samples = 500
+
+    # random design array. Shape (n_time_points, n_features).
+    X = 0.5 * np.random.normal(size=(n_samples, n_features))
+
+    # log-rates & weights
+    b_true = np.random.uniform(size=(n_neurons,)) * 3  # baseline rates
+    w_true = np.random.uniform(size=(n_features, n_neurons)) * 0.1  # real weights:
+
+    # generate counts (spikes will be (n_samples, n_features)
+    rate = jnp.exp(jnp.dot(X, w_true) + b_true)
+    spikes = np.random.poisson(rate)
+    return X, spikes

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -891,7 +891,7 @@ class TestGLM:
             model.initialize_state(X, y, params)
 
     @pytest.mark.parametrize(
-        "inv_link", [jnp.exp, lambda x: jnp.exp(x), jax.nn.softplus, jax.nn.sigmoid]
+        "inv_link", [jnp.exp, lambda x: jnp.exp(x), jax.nn.softplus, jax.nn.relu]
     )
     def test_high_firing_rate_initialization(
         self, inv_link, example_X_y_high_firing_rates
@@ -1932,7 +1932,7 @@ class TestPopulationGLM:
             )
 
     @pytest.mark.parametrize(
-        "inv_link", [jnp.exp, lambda x: jnp.exp(x), jax.nn.softplus, jax.nn.sigmoid]
+        "inv_link", [jnp.exp, lambda x: jnp.exp(x), jax.nn.softplus, jax.nn.relu]
     )
     def test_high_firing_rate_initialization(
         self, inv_link, example_X_y_high_firing_rates

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -73,7 +73,9 @@ class TestGLM:
         Test that an error is raised if a non-compatible solver is passed.
         """
         with expectation:
-            glm_class(regularizer=regularizer, solver_name=solver_name, regularizer_strength=1)
+            glm_class(
+                regularizer=regularizer, solver_name=solver_name, regularizer_strength=1
+            )
 
     @pytest.mark.parametrize(
         "observation, expectation",
@@ -166,7 +168,7 @@ class TestGLM:
         assert list(model.get_params().values()) == expected_values
 
         # changing regularizer
-        model.set_params(regularizer="Ridge", regularizer_strength=1.)
+        model.set_params(regularizer="Ridge", regularizer_strength=1.0)
 
         expected_values = [
             model.observation_model.inverse_link_function,
@@ -491,7 +493,7 @@ class TestGLM:
         """Test that the group lasso fit goes through"""
         X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
         model.set_params(
-            regularizer_strength=1.,
+            regularizer_strength=1.0,
             regularizer=nmo.regularizer.GroupLasso(mask=mask),
             solver_name="ProximalGradient",
         )
@@ -889,6 +891,20 @@ class TestGLM:
             model.initialize_state(X, y, params)
 
     @pytest.mark.parametrize(
+        "inv_link", [jnp.exp, lambda x: jnp.exp(x), jax.nn.softplus, jax.nn.sigmoid]
+    )
+    def test_high_firing_rate_initialization(
+        self, inv_link, example_X_y_high_firing_rates
+    ):
+        model = nmo.glm.GLM(
+            observation_model=nmo.observation_models.PoissonObservations(
+                inverse_link_function=inv_link
+            )
+        )
+        X, y = example_X_y_high_firing_rates
+        model.initialize_params(X, y[:, 0])
+
+    @pytest.mark.parametrize(
         "dim_weights, expectation",
         [
             (
@@ -1177,7 +1193,7 @@ class TestGLM:
         model.set_params(
             regularizer=nmo.regularizer.GroupLasso(mask=mask),
             solver_name="ProximalGradient",
-            regularizer_strength=1.,
+            regularizer_strength=1.0,
         )
         params = model.initialize_params(X, y)
         model.initialize_state(X, y, params)
@@ -1448,9 +1464,7 @@ class TestGLM:
             ("poisson_population_GLM_model_pytree", nmo.glm.PopulationGLM),
         ],
     )
-    @pytest.mark.parametrize(
-        "key", [jax.random.key(0), jax.random.key(19)]
-    )
+    @pytest.mark.parametrize("key", [jax.random.key(0), jax.random.key(19)])
     @pytest.mark.parametrize(
         "regularizer_class, solver_name",
         [
@@ -1458,10 +1472,11 @@ class TestGLM:
             (nmo.regularizer.Ridge, "SVRG"),
             (nmo.regularizer.Lasso, "ProxSVRG"),
             # (nmo.regularizer.GroupLasso, "ProxSVRG"),
-        ]
+        ],
     )
-    def test_glm_update_consistent_with_fit_with_svrg(self, request, regr_setup, glm_class, key, regularizer_class,
-                                                      solver_name):
+    def test_glm_update_consistent_with_fit_with_svrg(
+        self, request, regr_setup, glm_class, key, regularizer_class, solver_name
+    ):
         """
         Make sure that calling GLM.update with the rest of the algorithm implemented outside in a naive loop
         is consistent with running the compiled GLM.fit on the same data with the same parameters
@@ -1481,10 +1496,12 @@ class TestGLM:
         regularizer_kwargs = {}
         if regularizer_class.__name__ == "GroupLasso":
             n_features = sum(x.shape[1] for x in jax.tree.leaves(X))
-            regularizer_kwargs["mask"] = (np.random.randn(n_features) > 0).reshape(1, -1).astype(float)
+            regularizer_kwargs["mask"] = (
+                (np.random.randn(n_features) > 0).reshape(1, -1).astype(float)
+            )
 
         reg = regularizer_class(**regularizer_kwargs)
-        strength = None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.
+        strength = None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.0
         glm = glm_class(
             regularizer=reg,
             regularizer_strength=strength,
@@ -1543,7 +1560,9 @@ class TestGLM:
 
             iter_num += 1
 
-            _error = tree_l2_norm(tree_sub(params, prev_params)) / tree_l2_norm(prev_params)
+            _error = tree_l2_norm(tree_sub(params, prev_params)) / tree_l2_norm(
+                prev_params
+            )
             if _error < tol:
                 break
 
@@ -1557,7 +1576,9 @@ class TestGLM:
         )
 
     @pytest.mark.parametrize("solver_name", ["GradientDescent", "SVRG"])
-    def test_glm_fit_matches_sklearn_poisson(self, solver_name, poissonGLM_model_instantiation):
+    def test_glm_fit_matches_sklearn_poisson(
+        self, solver_name, poissonGLM_model_instantiation
+    ):
         """Test that different solvers converge to the same solution."""
         jax.config.update("jax_enable_x64", True)
         X, y, _, true_params, firing_rate = poissonGLM_model_instantiation
@@ -1566,7 +1587,7 @@ class TestGLM:
             regularizer=nmo.regularizer.UnRegularized(),
             observation_model=nmo.observation_models.PoissonObservations(),
             solver_name=solver_name,
-            solver_kwargs={"tol": 10**-12}
+            solver_kwargs={"tol": 10**-12},
         )
         # set precision to float64 for accurate matching of the results
         model.data_type = jnp.float64
@@ -1575,20 +1596,26 @@ class TestGLM:
         model_skl = PoissonRegressor(fit_intercept=True, tol=10**-12, alpha=0.0)
         model_skl.fit(X, y)
 
-        match_weights = jnp.allclose(model_skl.coef_, model.coef_, atol=1e-5, rtol=0.)
-        match_intercepts = jnp.allclose(model_skl.intercept_, model.intercept_, atol=1e-5, rtol=0.)
+        match_weights = jnp.allclose(model_skl.coef_, model.coef_, atol=1e-5, rtol=0.0)
+        match_intercepts = jnp.allclose(
+            model_skl.intercept_, model.intercept_, atol=1e-5, rtol=0.0
+        )
         if (not match_weights) or (not match_intercepts):
             raise ValueError("GLM.fit estimate does not match sklearn!")
 
     @pytest.mark.parametrize("solver_name", ["GradientDescent", "SVRG"])
-    def test_glm_fit_matches_sklearn_gamma(self, solver_name, gammaGLM_model_instantiation):
+    def test_glm_fit_matches_sklearn_gamma(
+        self, solver_name, gammaGLM_model_instantiation
+    ):
         """Test that different solvers converge to the same solution."""
         jax.config.update("jax_enable_x64", True)
         X, y, _, true_params, firing_rate = gammaGLM_model_instantiation
 
         model = nmo.glm.GLM(
             regularizer=nmo.regularizer.UnRegularized(),
-            observation_model=nmo.observation_models.GammaObservations(inverse_link_function=jnp.exp),
+            observation_model=nmo.observation_models.GammaObservations(
+                inverse_link_function=jnp.exp
+            ),
             solver_name=solver_name,
             solver_kwargs={"tol": 10**-12},
         )
@@ -1599,8 +1626,10 @@ class TestGLM:
         model_skl = GammaRegressor(fit_intercept=True, tol=10**-12, alpha=0.0)
         model_skl.fit(X, y)
 
-        match_weights = jnp.allclose(model_skl.coef_, model.coef_, atol=1e-5, rtol=0.)
-        match_intercepts = jnp.allclose(model_skl.intercept_, model.intercept_, atol=1e-5, rtol=0.)
+        match_weights = jnp.allclose(model_skl.coef_, model.coef_, atol=1e-5, rtol=0.0)
+        match_intercepts = jnp.allclose(
+            model_skl.intercept_, model.intercept_, atol=1e-5, rtol=0.0
+        )
 
         if (not match_weights) or (not match_intercepts):
             raise ValueError("GLM.fit estimate does not match sklearn!")
@@ -1625,7 +1654,7 @@ class TestGLM:
         Test that the dof is an integer.
         """
         X, y, model, true_params, firing_rate = poissonGLM_model_instantiation
-        strength = None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.
+        strength = None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.0
         model.set_params(regularizer=reg, regularizer_strength=strength)
         model.solver_name = model.regularizer.default_solver
         model.fit(X, y)
@@ -1645,48 +1674,93 @@ class TestGLM:
             model = nmo.glm.GLM(regularizer=reg, regularizer_strength=1.0)
 
         # reset to unregularized
-        model.set_params(regularizer = "UnRegularized", regularizer_strength=None)
+        model.set_params(regularizer="UnRegularized", regularizer_strength=None)
         with pytest.warns(UserWarning):
             nmo.glm.GLM(regularizer=reg)
 
     @pytest.mark.parametrize("reg", ["Ridge", "Lasso", "GroupLasso"])
     def test_reg_strength_reset(self, reg):
         model = nmo.glm.GLM(regularizer=reg, regularizer_strength=1.0)
-        with pytest.warns(UserWarning, match="Unused parameter `regularizer_strength` for UnRegularized GLM"):
+        with pytest.warns(
+            UserWarning,
+            match="Unused parameter `regularizer_strength` for UnRegularized GLM",
+        ):
             model.regularizer = "UnRegularized"
         model.regularizer_strength = None
-        with pytest.warns(UserWarning, match="Caution: regularizer strength has not been set"):
+        with pytest.warns(
+            UserWarning, match="Caution: regularizer strength has not been set"
+        ):
             model.regularizer = "Ridge"
 
     @pytest.mark.parametrize(
         "params, warns",
         [
             # set regularizer
-            ({"regularizer": "Ridge"},
-             pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-            ({"regularizer": "Lasso"},
-             pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-            ({"regularizer": "GroupLasso"},
-             pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
+            (
+                {"regularizer": "Ridge"},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            (
+                {"regularizer": "Lasso"},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            (
+                {"regularizer": "GroupLasso"},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
             ({"regularizer": "UnRegularized"}, does_not_raise()),
             # set both None or number
-            ({"regularizer": "Ridge", "regularizer_strength": None},
-             pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-            ({"regularizer": "Ridge", "regularizer_strength": 1.}, does_not_raise()),
-            ({"regularizer": "Lasso", "regularizer_strength": None},
-             pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-            ({"regularizer": "Lasso", "regularizer_strength": 1.}, does_not_raise()),
-            ({"regularizer": "GroupLasso", "regularizer_strength": None},
-             pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-            ({"regularizer": "GroupLasso", "regularizer_strength": 1.}, does_not_raise()),
-            ({"regularizer": "UnRegularized", "regularizer_strength": None}, does_not_raise()),
-            ({"regularizer": "UnRegularized", "regularizer_strength": 1.},
-             pytest.warns(UserWarning, match="Unused parameter `regularizer_strength` for UnRegularized GLM")),
+            (
+                {"regularizer": "Ridge", "regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            ({"regularizer": "Ridge", "regularizer_strength": 1.0}, does_not_raise()),
+            (
+                {"regularizer": "Lasso", "regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            ({"regularizer": "Lasso", "regularizer_strength": 1.0}, does_not_raise()),
+            (
+                {"regularizer": "GroupLasso", "regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            (
+                {"regularizer": "GroupLasso", "regularizer_strength": 1.0},
+                does_not_raise(),
+            ),
+            (
+                {"regularizer": "UnRegularized", "regularizer_strength": None},
+                does_not_raise(),
+            ),
+            (
+                {"regularizer": "UnRegularized", "regularizer_strength": 1.0},
+                pytest.warns(
+                    UserWarning,
+                    match="Unused parameter `regularizer_strength` for UnRegularized GLM",
+                ),
+            ),
             # set regularizer str only
-            ({"regularizer_strength": 1.},
-             pytest.warns(UserWarning, match="Unused parameter `regularizer_strength` for UnRegularized GLM")),
+            (
+                {"regularizer_strength": 1.0},
+                pytest.warns(
+                    UserWarning,
+                    match="Unused parameter `regularizer_strength` for UnRegularized GLM",
+                ),
+            ),
             ({"regularizer_strength": None}, does_not_raise()),
-        ]
+        ],
     )
     def test_reg_set_params(self, params, warns):
         model = nmo.glm.GLM()
@@ -1697,10 +1771,14 @@ class TestGLM:
         "params, warns",
         [
             # set regularizer str only
-            ({"regularizer_strength": 1.}, does_not_raise()),
-            ({"regularizer_strength": None},
-             pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ]
+            ({"regularizer_strength": 1.0}, does_not_raise()),
+            (
+                {"regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+        ],
     )
     @pytest.mark.parametrize("reg", ["Ridge", "Lasso", "GroupLasso"])
     def test_reg_set_params_reg_str_only(self, params, warns, reg):
@@ -1740,7 +1818,7 @@ class TestPopulationGLM:
         Test that an error is raised if a non-compatible solver is passed.
         """
         with expectation:
-            population_glm_class(regularizer=regularizer, regularizer_strength=1.)
+            population_glm_class(regularizer=regularizer, regularizer_strength=1.0)
 
     def test_get_params(self):
         """
@@ -1788,7 +1866,7 @@ class TestPopulationGLM:
         assert list(model.get_params().values()) == expected_values
 
         # changing regularizer
-        model.set_params(regularizer="Ridge", regularizer_strength=1.)
+        model.set_params(regularizer="Ridge", regularizer_strength=1.0)
 
         expected_values = [
             model.feature_mask,
@@ -1848,8 +1926,25 @@ class TestPopulationGLM:
         """
         with expectation:
             population_glm_class(
-                regularizer=ridge_regularizer, observation_model=observation, regularizer_strength=1.
+                regularizer=ridge_regularizer,
+                observation_model=observation,
+                regularizer_strength=1.0,
             )
+
+    @pytest.mark.parametrize(
+        "inv_link", [jnp.exp, lambda x: jnp.exp(x), jax.nn.softplus, jax.nn.sigmoid]
+    )
+    def test_high_firing_rate_initialization(
+        self, inv_link, example_X_y_high_firing_rates
+    ):
+        """Test firing rate regime that would not be initialized correctly in the original implementation."""
+        model = nmo.glm.PopulationGLM(
+            observation_model=nmo.observation_models.PoissonObservations(
+                inverse_link_function=inv_link
+            )
+        )
+        X, y = example_X_y_high_firing_rates
+        model.initialize_params(X, y)
 
     @pytest.mark.parametrize(
         "X, y",
@@ -1913,7 +2008,7 @@ class TestPopulationGLM:
         Test that the dof is an integer.
         """
         X, y, model, true_params, firing_rate = poisson_population_GLM_model
-        strength = None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.
+        strength = None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.0
         model.set_params(regularizer=reg, regularizer_strength=strength)
         model.solver_name = model.regularizer.default_solver
         model.fit(X, y)
@@ -2180,7 +2275,7 @@ class TestPopulationGLM:
         model.set_params(
             regularizer=nmo.regularizer.GroupLasso(mask=mask),
             solver_name="ProximalGradient",
-            regularizer_strength=1.,
+            regularizer_strength=1.0,
         )
         model.fit(X, y)
 
@@ -2585,7 +2680,7 @@ class TestPopulationGLM:
         """Test that the group lasso initialize_solver goes through"""
         X, y, model, params, rate, mask = group_sparse_poisson_glm_model_instantiation
         model.set_params(
-            regularizer_strength=1.,
+            regularizer_strength=1.0,
             regularizer=nmo.regularizer.GroupLasso(mask=mask),
             solver_name="ProximalGradient",
         )
@@ -2756,7 +2851,9 @@ class TestPopulationGLM:
             ),
         ],
     )
-    def test_predict_is_fit_population(self, is_fit, expectation, poisson_population_GLM_model):
+    def test_predict_is_fit_population(
+        self, is_fit, expectation, poisson_population_GLM_model
+    ):
         """
         Test the `score` method on models based on their fit status.
         Ensure scoring is only possible on fitted models.
@@ -3400,33 +3497,86 @@ class TestPopulationGLM:
     @pytest.mark.parametrize("reg", ["Ridge", "Lasso", "GroupLasso"])
     def test_reg_strength_reset(self, reg):
         model = nmo.glm.PopulationGLM(regularizer=reg, regularizer_strength=1.0)
-        with pytest.warns(UserWarning, match="Unused parameter `regularizer_strength` for UnRegularized GLM"):
+        with pytest.warns(
+            UserWarning,
+            match="Unused parameter `regularizer_strength` for UnRegularized GLM",
+        ):
             model.regularizer = "UnRegularized"
         model.regularizer_strength = None
-        with pytest.warns(UserWarning, match="Caution: regularizer strength has not been set"):
+        with pytest.warns(
+            UserWarning, match="Caution: regularizer strength has not been set"
+        ):
             model.regularizer = "Ridge"
 
     @pytest.mark.parametrize(
         "params, warns",
-    [
-        # set regularizer
-        ({"regularizer": "Ridge"},  pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ({"regularizer": "Lasso"}, pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ({"regularizer": "GroupLasso"}, pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ({"regularizer": "UnRegularized"}, does_not_raise()),
-        # set both None or number
-        ({"regularizer": "Ridge", "regularizer_strength": None}, pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ({"regularizer": "Ridge", "regularizer_strength": 1.}, does_not_raise()),
-        ({"regularizer": "Lasso", "regularizer_strength": None}, pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ({"regularizer": "Lasso", "regularizer_strength": 1.}, does_not_raise()),
-        ({"regularizer": "GroupLasso", "regularizer_strength": None}, pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ({"regularizer": "GroupLasso", "regularizer_strength": 1.}, does_not_raise()),
-        ({"regularizer": "UnRegularized", "regularizer_strength": None}, does_not_raise()),
-        ({"regularizer": "UnRegularized", "regularizer_strength": 1.}, pytest.warns(UserWarning, match="Unused parameter `regularizer_strength` for UnRegularized GLM")),
-        # set regularizer str only
-        ({"regularizer_strength": 1.}, pytest.warns(UserWarning, match="Unused parameter `regularizer_strength` for UnRegularized GLM")),
-        ({"regularizer_strength": None},does_not_raise()),
-    ]
+        [
+            # set regularizer
+            (
+                {"regularizer": "Ridge"},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            (
+                {"regularizer": "Lasso"},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            (
+                {"regularizer": "GroupLasso"},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            ({"regularizer": "UnRegularized"}, does_not_raise()),
+            # set both None or number
+            (
+                {"regularizer": "Ridge", "regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            ({"regularizer": "Ridge", "regularizer_strength": 1.0}, does_not_raise()),
+            (
+                {"regularizer": "Lasso", "regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            ({"regularizer": "Lasso", "regularizer_strength": 1.0}, does_not_raise()),
+            (
+                {"regularizer": "GroupLasso", "regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+            (
+                {"regularizer": "GroupLasso", "regularizer_strength": 1.0},
+                does_not_raise(),
+            ),
+            (
+                {"regularizer": "UnRegularized", "regularizer_strength": None},
+                does_not_raise(),
+            ),
+            (
+                {"regularizer": "UnRegularized", "regularizer_strength": 1.0},
+                pytest.warns(
+                    UserWarning,
+                    match="Unused parameter `regularizer_strength` for UnRegularized GLM",
+                ),
+            ),
+            # set regularizer str only
+            (
+                {"regularizer_strength": 1.0},
+                pytest.warns(
+                    UserWarning,
+                    match="Unused parameter `regularizer_strength` for UnRegularized GLM",
+                ),
+            ),
+            ({"regularizer_strength": None}, does_not_raise()),
+        ],
     )
     def test_reg_set_params(self, params, warns):
         model = nmo.glm.PopulationGLM()
@@ -3437,9 +3587,14 @@ class TestPopulationGLM:
         "params, warns",
         [
             # set regularizer str only
-            ({"regularizer_strength": 1.}, does_not_raise()),
-            ({"regularizer_strength": None},pytest.warns(UserWarning, match="Caution: regularizer strength has not been set")),
-        ]
+            ({"regularizer_strength": 1.0}, does_not_raise()),
+            (
+                {"regularizer_strength": None},
+                pytest.warns(
+                    UserWarning, match="Caution: regularizer strength has not been set"
+                ),
+            ),
+        ],
     )
     @pytest.mark.parametrize("reg", ["Ridge", "Lasso", "GroupLasso"])
     def test_reg_set_params_reg_str_only(self, params, warns, reg):

--- a/tests/test_glm_initialization.py
+++ b/tests/test_glm_initialization.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import nemos as nmo
-
+import warnings
 
 @pytest.mark.parametrize(
     "non_linearity",
@@ -48,10 +48,22 @@ def test_invert_non_linearity(non_linearity, output_y):
         ),
     ],
 )
-def test_initialization_error(non_linearity, expectation):
+def test_initialization_error_nan_input(non_linearity, expectation):
     """Initialize invalid."""
     output_y = np.full((10, 2), np.nan)
     with expectation:
         nmo.initialize_regressor.initialize_intercept_matching_mean_rate(
             inverse_link_function=non_linearity, y=output_y
         )
+
+def test_initialization_error_non_invertible():
+    """Initialize invalid."""
+    output_y = np.random.uniform(size=100)
+    inv_link = lambda x: jax.nn.softplus(x) + 10
+    with pytest.raises(ValueError, match="Failed to initialize the model intercept.+Please, provide"):
+        with warnings.catch_warnings():
+            # ignore the warning raised by the root-finder (there is no root)
+            warnings.filterwarnings("ignore", category=RuntimeWarning, message="Tolerance of")
+            nmo.initialize_regressor.initialize_intercept_matching_mean_rate(
+                inverse_link_function=inv_link, y=output_y
+            )

--- a/tests/test_glm_initialization.py
+++ b/tests/test_glm_initialization.py
@@ -29,10 +29,10 @@ def test_invert_non_linearity(non_linearity, output_y):
 @pytest.mark.parametrize(
     "non_linearity, expectation",
     [
-        (jnp.exp, pytest.raises(ValueError, match=".+The mean firing rate assumes")),
+        (jnp.exp, pytest.raises(ValueError, match=".+The mean firing rate has")),
         (
             jax.nn.softplus,
-            pytest.raises(ValueError, match=".+The mean firing rate assumes"),
+            pytest.raises(ValueError, match=".+The mean firing rate has"),
         ),
         (
             lambda x: jnp.exp(x),

--- a/tests/test_glm_initialization.py
+++ b/tests/test_glm_initialization.py
@@ -1,0 +1,57 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import nemos as nmo
+
+
+@pytest.mark.parametrize(
+    "non_linearity",
+    [
+        jnp.exp,
+        jax.nn.softplus,
+        lambda x: jnp.exp(x),
+        jax.nn.sigmoid,
+    ],
+)
+@pytest.mark.parametrize(
+    "output_y",
+    [np.random.uniform(0, 1, size=(10,)), np.random.uniform(0, 1, size=(10, 2))],
+)
+def test_invert_non_linearity(non_linearity, output_y):
+    inv_y = nmo.initialize_regressor.initialize_intercept_matching_mean_rate(
+        inverse_link_function=non_linearity, y=output_y
+    )
+    assert jnp.allclose(non_linearity(inv_y), jnp.mean(output_y, axis=0), rtol=10**-5)
+
+
+@pytest.mark.parametrize(
+    "non_linearity, expectation",
+    [
+        (jnp.exp, pytest.raises(ValueError, match=".+The mean firing rate assumes")),
+        (
+            jax.nn.softplus,
+            pytest.raises(ValueError, match=".+The mean firing rate assumes"),
+        ),
+        (
+            lambda x: jnp.exp(x),
+            pytest.raises(
+                ValueError, match=".+Please, provide initial parameters instead"
+            ),
+        ),
+        (
+            jax.nn.sigmoid,
+            pytest.raises(
+                ValueError, match=".+Please, provide initial parameters instead"
+            ),
+        ),
+    ],
+)
+def test_initialization_error(non_linearity, expectation):
+    """Initialize invalid."""
+    output_y = np.full((10, 2), np.nan)
+    with expectation:
+        nmo.initialize_regressor.initialize_intercept_matching_mean_rate(
+            inverse_link_function=non_linearity, y=output_y
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ package_cache = .tox/cache
 
 # Run both pytest and coverage since pytest was initialized with the --cov option in the pyproject.toml
 commands =
-    pytest --doctest-modules src/nemos/
-    pytest --cov=nemos --cov-config=pyproject.toml --cov-report=xml
+    pytest -n auto --doctest-modules src/nemos/
+    pytest -n auto --cov=nemos --cov-config=pyproject.toml --cov-report=xml
 
 [testenv:fix]
 commands=


### PR DESCRIPTION
In this PR I fix the initialization issue in #243; 

Additionally, I removed the parallel testing from the default configuration of pytest, but added the parallelization it in the tox.ini call instead.

The reason for this is that debugging tests is much easier without parallelization; Additionally, when debugging, one often needs to run a single test function or a few of them, and the overhead of starting workers makes it slower the single core option.
