### PR TITLE
require sample axis to be axis=0

### DIFF
--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -545,7 +545,7 @@ class Basis(Base, abc.ABC):
             if param.default
             # prevent user from passing
             # `basis_matrix` or `time_series` in kwargs.
-            is not inspect.Parameter.empty  
+            is not inspect.Parameter.empty
         }
         if not set(self._conv_kwargs.keys()).issubset(convolve_configs):
             # do not encourage to set axis.

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -529,7 +529,9 @@ class Basis(Base, abc.ABC):
         convolve_configs = convolve_configs.difference({"axis"})
         if not set(kwargs.keys()).issubset(convolve_configs):
             # remove axis in case axis=0, was passed which is allowed.
-            invalid = set(kwargs.keys()).difference(convolve_configs).difference({"axis"})
+            invalid = (
+                set(kwargs.keys()).difference(convolve_configs).difference({"axis"})
+            )
             raise ValueError(
                 f"Unrecognized keyword arguments: {invalid}. "
                 f"Allowed convolution keyword arguments are: {convolve_configs}."

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -531,9 +531,9 @@ class Basis(Base, abc.ABC):
                 f"kwargs should only be set when mode=='conv', but '{self._mode}' provided instead!"
             )
 
-        if "axis" in self._conv_kwargs and self._conv_kwargs["axis"] != 0:
+        if "axis" in self._conv_kwargs:
             raise ValueError(
-                f"Invalid `axis={self._conv_kwargs['axis']}` provided. Basis requires the "
+                f"Setting the `axis` parameter is not allowed. Basis requires the "
                 f"convolution to be applied along the first axis (`axis=0`).\n"
                 "Please transpose your input so that the desired axis for "
                 "convolution is the first dimension (axis=0)."

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -473,7 +473,7 @@ class Basis(Base, abc.ABC):
     **kwargs :
         Only used in "conv" mode. Additional keyword arguments that are passed to
         `nemos.convolve.create_convolutional_predictor`
-    
+
     Raises
     ------
     ValueError:
@@ -521,7 +521,8 @@ class Basis(Base, abc.ABC):
             )
         convolve_params = inspect.signature(create_convolutional_predictor).parameters
         convolve_configs = {
-            key for key, param in convolve_params.items()
+            key
+            for key, param in convolve_params.items()
             if param.default is not inspect.Parameter.empty
         }
         if not set(kwargs.keys()).issubset(convolve_configs):

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -533,8 +533,8 @@ class Basis(Base, abc.ABC):
 
         if "axis" in self._conv_kwargs:
             raise ValueError(
-                f"Setting the `axis` parameter is not allowed. Basis requires the "
-                f"convolution to be applied along the first axis (`axis=0`).\n"
+                "Setting the `axis` parameter is not allowed. Basis requires the "
+                "convolution to be applied along the first axis (`axis=0`).\n"
                 "Please transpose your input so that the desired axis for "
                 "convolution is the first dimension (axis=0)."
             )

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -471,8 +471,11 @@ class Basis(Base, abc.ABC):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs :
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
 
     Raises
     ------
@@ -1471,8 +1474,11 @@ class MSplineBasis(SplineBasis):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs:
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
 
     Examples
     --------
@@ -1629,8 +1635,11 @@ class BSplineBasis(SplineBasis):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs :
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
 
     Attributes
     ----------
@@ -1748,8 +1757,11 @@ class CyclicBSplineBasis(SplineBasis):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs :
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
 
     Attributes
     ----------
@@ -1890,8 +1902,11 @@ class RaisedCosineBasisLinear(Basis):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs :
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
 
     # References
     ------------
@@ -2083,8 +2098,11 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs :
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
 
     # References
     ------------
@@ -2237,8 +2255,11 @@ class OrthExponentialBasis(Basis):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs :
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
     """
 
     def __init__(

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -528,9 +528,9 @@ class Basis(Base, abc.ABC):
             for key, param in convolve_params.items()
             if param.default is not inspect.Parameter.empty
         }
-        # do not encourage to set axis.
-        convolve_configs = convolve_configs.difference({"axis"})
         if not set(kwargs.keys()).issubset(convolve_configs):
+            # do not encourage to set axis.
+            convolve_configs = convolve_configs.difference({"axis"})
             # remove axis in case axis=0, was passed which is allowed.
             invalid = (
                 set(kwargs.keys()).difference(convolve_configs).difference({"axis"})

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -514,7 +514,7 @@ class Basis(Base, abc.ABC):
         # check on convolution kwargs content
         if "axis" in kwargs and kwargs["axis"] != 0:
             raise ValueError(
-                f"Invalid `axis={kwargs['axis']}` provided. This basis requires the "
+                f"Invalid `axis={kwargs['axis']}` provided. Basis requires the "
                 f"convolution to be applied along the first axis (`axis=0`).\n"
                 "Please transpose your input so that the desired axis for "
                 "convolution is the first dimension (axis=0)."

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -525,8 +525,11 @@ class Basis(Base, abc.ABC):
             for key, param in convolve_params.items()
             if param.default is not inspect.Parameter.empty
         }
+        # do not encourage to set axis.
+        convolve_configs = convolve_configs.difference({"axis"})
         if not set(kwargs.keys()).issubset(convolve_configs):
-            invalid = set(kwargs.keys()).difference(convolve_configs)
+            # remove axis in case axis=0, was passed which is allowed.
+            invalid = set(kwargs.keys()).difference(convolve_configs).difference({"axis"})
             raise ValueError(
                 f"Unrecognized keyword arguments: {invalid}. "
                 f"Allowed convolution keyword arguments are: {convolve_configs}."

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -542,15 +542,18 @@ class Basis(Base, abc.ABC):
         convolve_configs = {
             key
             for key, param in convolve_params.items()
-            if param.default is not inspect.Parameter.empty  # prevent user from passing directly
-                                                             # `basis_matrix` or `time_series` in kwargs.
+            if param.default
+            is not inspect.Parameter.empty  # prevent user from passing directly
+            # `basis_matrix` or `time_series` in kwargs.
         }
         if not set(self._conv_kwargs.keys()).issubset(convolve_configs):
             # do not encourage to set axis.
             convolve_configs = convolve_configs.difference({"axis"})
             # remove the parameter in case axis=0 was passed, since it is allowed.
             invalid = (
-                set(self._conv_kwargs.keys()).difference(convolve_configs).difference({"axis"})
+                set(self._conv_kwargs.keys())
+                .difference(convolve_configs)
+                .difference({"axis"})
             )
             raise ValueError(
                 f"Unrecognized keyword arguments: {invalid}. "

--- a/src/nemos/basis.py
+++ b/src/nemos/basis.py
@@ -1323,8 +1323,11 @@ class SplineBasis(Basis, abc.ABC):
         minimum and the maximum of the samples provided when evaluating the basis.
         If a sample is outside the bounds, the basis will return NaN.
     **kwargs :
-        Only used in "conv" mode. Additional keyword arguments that are passed to
-        `nemos.convolve.create_convolutional_predictor`
+        Additional keyword arguments passed to `nemos.convolve.create_convolutional_predictor` when
+        `mode='conv'`; These arguments are used to change the default behavior of the convolution.
+        For example, changing the `predictor_causality`, which by default is set to `"causal"`.
+        Note that one cannot change the default value for the `axis` parameter. Basis assumes
+        that the convolution axis is `axis=0`.
 
     Attributes
     ----------

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -496,6 +496,23 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             self.cls(5, mode=mode, window_size=window_size)
 
     @pytest.mark.parametrize(
+        "conv_kwargs, expectation",
+        [
+            (dict(), does_not_raise()),
+            (dict(axis=0), does_not_raise()),
+            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (dict(shift=True), does_not_raise()),
+            (dict(shift=True, axis=0), does_not_raise()),
+            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, axis=0, time_series=np.arange(10)), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+        ]
+    )
+    def test_init_conv_kwargs(self, conv_kwargs, expectation):
+        with expectation:
+            self.cls(5, mode="conv", window_size=200, **conv_kwargs)
+
+    @pytest.mark.parametrize(
         "mode, ws, expectation",
         [
             ("conv", 2, does_not_raise()),
@@ -1145,6 +1162,24 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
             self.cls(5, mode=mode, window_size=window_size)
 
     @pytest.mark.parametrize(
+        "conv_kwargs, expectation",
+        [
+            (dict(), does_not_raise()),
+            (dict(axis=0), does_not_raise()),
+            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (dict(shift=True), does_not_raise()),
+            (dict(shift=True, axis=0), does_not_raise()),
+            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, axis=0, time_series=np.arange(10)),
+             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+        ]
+    )
+    def test_init_conv_kwargs(self, conv_kwargs, expectation):
+        with expectation:
+            self.cls(5, mode="conv", window_size=200, **conv_kwargs)
+
+    @pytest.mark.parametrize(
         "mode, ws, expectation",
         [
             ("conv", 2, does_not_raise()),
@@ -1777,6 +1812,24 @@ class TestMSplineBasis(BasisFuncsTesting):
         window_size = None if mode == "eval" else 2
         with expectation:
             self.cls(5, mode=mode, window_size=window_size)
+
+    @pytest.mark.parametrize(
+        "conv_kwargs, expectation",
+        [
+            (dict(), does_not_raise()),
+            (dict(axis=0), does_not_raise()),
+            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (dict(shift=True), does_not_raise()),
+            (dict(shift=True, axis=0), does_not_raise()),
+            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, axis=0, time_series=np.arange(10)),
+             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+        ]
+    )
+    def test_init_conv_kwargs(self, conv_kwargs, expectation):
+        with expectation:
+            self.cls(5, mode="conv", window_size=200, **conv_kwargs)
 
     @pytest.mark.parametrize(
         "mode, ws, expectation",
@@ -2491,6 +2544,24 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
             self.cls(5, mode=mode, window_size=window_size, decay_rates=np.arange(1, 6))
 
     @pytest.mark.parametrize(
+        "conv_kwargs, expectation",
+        [
+            (dict(), does_not_raise()),
+            (dict(axis=0), does_not_raise()),
+            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (dict(shift=True), does_not_raise()),
+            (dict(shift=True, axis=0), does_not_raise()),
+            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, axis=0, time_series=np.arange(10)),
+             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+        ]
+    )
+    def test_init_conv_kwargs(self, conv_kwargs, expectation):
+        with expectation:
+            self.cls(5, mode="conv", window_size=200, decay_rates=np.arange(1, 6), **conv_kwargs)
+
+    @pytest.mark.parametrize(
         "mode, ws, expectation",
         [
             ("conv", 2, does_not_raise()),
@@ -3077,6 +3148,24 @@ class TestBSplineBasis(BasisFuncsTesting):
         window_size = None if mode == "eval" else 2
         with expectation:
             self.cls(5, mode=mode, window_size=window_size)
+
+    @pytest.mark.parametrize(
+        "conv_kwargs, expectation",
+        [
+            (dict(), does_not_raise()),
+            (dict(axis=0), does_not_raise()),
+            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (dict(shift=True), does_not_raise()),
+            (dict(shift=True, axis=0), does_not_raise()),
+            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, axis=0, time_series=np.arange(10)),
+             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+        ]
+    )
+    def test_init_conv_kwargs(self, conv_kwargs, expectation):
+        with expectation:
+            self.cls(5, mode="conv", window_size=200, **conv_kwargs)
 
     @pytest.mark.parametrize(
         "mode, ws, expectation",

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -500,13 +500,22 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         [
             (dict(), does_not_raise()),
             (dict(axis=0), does_not_raise()),
-            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (
+                dict(axis=1),
+                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+            ),
             (dict(shift=True), does_not_raise()),
             (dict(shift=True, axis=0), does_not_raise()),
-            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (
+                dict(shifts=True, axis=0),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
             (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
-            (dict(shift=True, axis=0, time_series=np.arange(10)), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
-        ]
+            (
+                dict(shift=True, axis=0, time_series=np.arange(10)),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
+        ],
     )
     def test_init_conv_kwargs(self, conv_kwargs, expectation):
         with expectation:
@@ -584,7 +593,10 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
 
         for i in range(len(pars)):
             for j in range(i + 1, len(pars)):
-                with pytest.raises(AttributeError, match="can't set attribute 'mode'|property 'mode' of "):
+                with pytest.raises(
+                    AttributeError,
+                    match="can't set attribute 'mode'|property 'mode' of ",
+                ):
                     par_set = {
                         keys[i]: pars[keys[i]],
                         keys[j]: pars[keys[j]],
@@ -1166,14 +1178,22 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
         [
             (dict(), does_not_raise()),
             (dict(axis=0), does_not_raise()),
-            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (
+                dict(axis=1),
+                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+            ),
             (dict(shift=True), does_not_raise()),
             (dict(shift=True, axis=0), does_not_raise()),
-            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (
+                dict(shifts=True, axis=0),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
             (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
-            (dict(shift=True, axis=0, time_series=np.arange(10)),
-             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
-        ]
+            (
+                dict(shift=True, axis=0, time_series=np.arange(10)),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
+        ],
     )
     def test_init_conv_kwargs(self, conv_kwargs, expectation):
         with expectation:
@@ -1237,7 +1257,10 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
 
         for i in range(len(pars)):
             for j in range(i + 1, len(pars)):
-                with pytest.raises(AttributeError, match="can't set attribute 'mode'|property 'mode' of "):
+                with pytest.raises(
+                    AttributeError,
+                    match="can't set attribute 'mode'|property 'mode' of ",
+                ):
                     par_set = {
                         keys[i]: pars[keys[i]],
                         keys[j]: pars[keys[j]],
@@ -1818,14 +1841,22 @@ class TestMSplineBasis(BasisFuncsTesting):
         [
             (dict(), does_not_raise()),
             (dict(axis=0), does_not_raise()),
-            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (
+                dict(axis=1),
+                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+            ),
             (dict(shift=True), does_not_raise()),
             (dict(shift=True, axis=0), does_not_raise()),
-            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (
+                dict(shifts=True, axis=0),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
             (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
-            (dict(shift=True, axis=0, time_series=np.arange(10)),
-             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
-        ]
+            (
+                dict(shift=True, axis=0, time_series=np.arange(10)),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
+        ],
     )
     def test_init_conv_kwargs(self, conv_kwargs, expectation):
         with expectation:
@@ -1889,7 +1920,10 @@ class TestMSplineBasis(BasisFuncsTesting):
 
         for i in range(len(pars)):
             for j in range(i + 1, len(pars)):
-                with pytest.raises(AttributeError, match="can't set attribute 'mode'|property 'mode' of "):
+                with pytest.raises(
+                    AttributeError,
+                    match="can't set attribute 'mode'|property 'mode' of ",
+                ):
                     par_set = {
                         keys[i]: pars[keys[i]],
                         keys[j]: pars[keys[j]],
@@ -2548,18 +2582,32 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         [
             (dict(), does_not_raise()),
             (dict(axis=0), does_not_raise()),
-            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (
+                dict(axis=1),
+                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+            ),
             (dict(shift=True), does_not_raise()),
             (dict(shift=True, axis=0), does_not_raise()),
-            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (
+                dict(shifts=True, axis=0),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
             (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
-            (dict(shift=True, axis=0, time_series=np.arange(10)),
-             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
-        ]
+            (
+                dict(shift=True, axis=0, time_series=np.arange(10)),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
+        ],
     )
     def test_init_conv_kwargs(self, conv_kwargs, expectation):
         with expectation:
-            self.cls(5, mode="conv", window_size=200, decay_rates=np.arange(1, 6), **conv_kwargs)
+            self.cls(
+                5,
+                mode="conv",
+                window_size=200,
+                decay_rates=np.arange(1, 6),
+                **conv_kwargs,
+            )
 
     @pytest.mark.parametrize(
         "mode, ws, expectation",
@@ -2628,7 +2676,10 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
 
         for i in range(len(pars)):
             for j in range(i + 1, len(pars)):
-                with pytest.raises(AttributeError, match="can't set attribute 'mode'|property 'mode' of "):
+                with pytest.raises(
+                    AttributeError,
+                    match="can't set attribute 'mode'|property 'mode' of ",
+                ):
                     par_set = {
                         keys[i]: pars[keys[i]],
                         keys[j]: pars[keys[j]],
@@ -3154,14 +3205,22 @@ class TestBSplineBasis(BasisFuncsTesting):
         [
             (dict(), does_not_raise()),
             (dict(axis=0), does_not_raise()),
-            (dict(axis=1), pytest.raises(ValueError, match="Invalid `axis=1` provided")),
+            (
+                dict(axis=1),
+                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+            ),
             (dict(shift=True), does_not_raise()),
             (dict(shift=True, axis=0), does_not_raise()),
-            (dict(shifts=True, axis=0), pytest.raises(ValueError, match="Unrecognized keyword arguments")),
+            (
+                dict(shifts=True, axis=0),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
             (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
-            (dict(shift=True, axis=0, time_series=np.arange(10)),
-             pytest.raises(ValueError, match="Unrecognized keyword arguments")),
-        ]
+            (
+                dict(shift=True, axis=0, time_series=np.arange(10)),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+            ),
+        ],
     )
     def test_init_conv_kwargs(self, conv_kwargs, expectation):
         with expectation:
@@ -3225,7 +3284,10 @@ class TestBSplineBasis(BasisFuncsTesting):
 
         for i in range(len(pars)):
             for j in range(i + 1, len(pars)):
-                with pytest.raises(AttributeError, match="can't set attribute 'mode'|property 'mode' of "):
+                with pytest.raises(
+                    AttributeError,
+                    match="can't set attribute 'mode'|property 'mode' of ",
+                ):
                     par_set = {
                         keys[i]: pars[keys[i]],
                         keys[j]: pars[keys[j]],
@@ -3881,7 +3943,10 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
 
         for i in range(len(pars)):
             for j in range(i + 1, len(pars)):
-                with pytest.raises(AttributeError, match="can't set attribute 'mode'|property 'mode' of "):
+                with pytest.raises(
+                    AttributeError,
+                    match="can't set attribute 'mode'|property 'mode' of ",
+                ):
                     par_set = {
                         keys[i]: pars[keys[i]],
                         keys[j]: pars[keys[j]],

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -499,20 +499,32 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         "conv_kwargs, expectation",
         [
             (dict(), does_not_raise()),
-            (dict(axis=0), does_not_raise()),
+            (
+                dict(axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
             (
                 dict(axis=1),
-                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (dict(shift=True), does_not_raise()),
-            (dict(shift=True, axis=0), does_not_raise()),
             (
-                dict(shifts=True, axis=0),
+                dict(shift=True, axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
+            (
+                dict(shifts=True),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
-            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, predictor_causality="causal"), does_not_raise()),
             (
-                dict(shift=True, axis=0, time_series=np.arange(10)),
+                dict(shift=True, time_series=np.arange(10)),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
         ],
@@ -1177,20 +1189,32 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
         "conv_kwargs, expectation",
         [
             (dict(), does_not_raise()),
-            (dict(axis=0), does_not_raise()),
+            (
+                dict(axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
             (
                 dict(axis=1),
-                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (dict(shift=True), does_not_raise()),
-            (dict(shift=True, axis=0), does_not_raise()),
             (
-                dict(shifts=True, axis=0),
+                dict(shift=True, axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
+            (
+                dict(shifts=True),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
-            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, predictor_causality="causal"), does_not_raise()),
             (
-                dict(shift=True, axis=0, time_series=np.arange(10)),
+                dict(shift=True, time_series=np.arange(10)),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
         ],
@@ -1840,20 +1864,32 @@ class TestMSplineBasis(BasisFuncsTesting):
         "conv_kwargs, expectation",
         [
             (dict(), does_not_raise()),
-            (dict(axis=0), does_not_raise()),
+            (
+                dict(axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
             (
                 dict(axis=1),
-                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (dict(shift=True), does_not_raise()),
-            (dict(shift=True, axis=0), does_not_raise()),
             (
-                dict(shifts=True, axis=0),
+                dict(shift=True, axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
+            (
+                dict(shifts=True),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
-            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, predictor_causality="causal"), does_not_raise()),
             (
-                dict(shift=True, axis=0, time_series=np.arange(10)),
+                dict(shift=True, time_series=np.arange(10)),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
         ],
@@ -2581,20 +2617,32 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         "conv_kwargs, expectation",
         [
             (dict(), does_not_raise()),
-            (dict(axis=0), does_not_raise()),
+            (
+                dict(axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
             (
                 dict(axis=1),
-                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (dict(shift=True), does_not_raise()),
-            (dict(shift=True, axis=0), does_not_raise()),
             (
-                dict(shifts=True, axis=0),
+                dict(shift=True, axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
+            (
+                dict(shifts=True),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
-            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, predictor_causality="causal"), does_not_raise()),
             (
-                dict(shift=True, axis=0, time_series=np.arange(10)),
+                dict(shift=True, time_series=np.arange(10)),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
         ],
@@ -3204,20 +3252,32 @@ class TestBSplineBasis(BasisFuncsTesting):
         "conv_kwargs, expectation",
         [
             (dict(), does_not_raise()),
-            (dict(axis=0), does_not_raise()),
+            (
+                dict(axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
             (
                 dict(axis=1),
-                pytest.raises(ValueError, match="Invalid `axis=1` provided"),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (dict(shift=True), does_not_raise()),
-            (dict(shift=True, axis=0), does_not_raise()),
             (
-                dict(shifts=True, axis=0),
+                dict(shift=True, axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
+            (
+                dict(shifts=True),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
-            (dict(shift=True, axis=0, predictor_causality="causal"), does_not_raise()),
+            (dict(shift=True, predictor_causality="causal"), does_not_raise()),
             (
-                dict(shift=True, axis=0, time_series=np.arange(10)),
+                dict(shift=True, time_series=np.arange(10)),
                 pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
         ],


### PR DESCRIPTION
This PR fixes a corner-case bug related to basis in `mode="conv"`. 

## Issue

Before this PR, one could pass at basis initialization any kwargs from `nemos.convolve.create_convolutional_predictor`. This included `axis` meaning that one could specify what's the axis along which the convolution is applied.

What happened in `basis.compute_features` is that the axis is transposed to the first, and the rest of the axis are flattened to the second axis, so that the compute_features returns an 2darray. However, when the basis is composite, the we check that the number of samples matches for all input, and this check relied on the fact that the sample axis is `axis=0`.

This caused the following corner case:
```python
>>> b = nmo.basis.RaisedCosineBasisLog(5, mode="conv", window_size=100, axis=1)

>>> # this works because there is one input (the check on the sample axis passes)
>>> b.compute_features(np.ones((2, 200)))
Array([[       nan,        nan,        nan, ...,        nan,        nan,
               nan],
       [       nan,        nan,        nan, ...,        nan,        nan,
               nan],
       [       nan,        nan,        nan, ...,        nan,        nan,
               nan],
       ...,
       [ 2.4915924,  2.4915924,  5.5825534, ..., 20.70655  , 39.878582 ,
        39.878582 ],
       [ 2.4915924,  2.4915924,  5.5825534, ..., 20.70655  , 39.878582 ,
        39.878582 ],
       [ 2.4915924,  2.4915924,  5.5825534, ..., 20.706553 , 39.878582 ,
        39.878586 ]], dtype=float32)

>>> # this fails because the check on the sample axis will raise an error since 3 != 2
>>> (b + b).compute_features(np.ones((2, 200)), np.ones((3, 200)))
```

## Solution

Instead of complicating the check logic, or move it after the transposition happens for all 1D basis, I simplified our life and enforced that the sample axis is always the first one. This is always true for pynapple, and requires the user to transpose an array if the data are organized differently;

Now the initialization would raise an error if axis different from 0 is passed.
```python
>>> b = nmo.basis.RaisedCosineBasisLog(5, mode="conv", window_size=100, axis=1)
ValueError: Invalid `axis=1` provided. Basis requires  requires the convolution to be applied along the first axis (`axis=0`).
Please transpose your input so that the desired axis for convolution is the first dimension (axis=0).
```

