### PR TITLE
Basis refactor pr1

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
       - gem install html-proofer -v ">= 5.0.9"  # Ensure version >= 5.0.9
     post_build:
       # Check everything except 403s and a jneurosci, which returns 404 but the link works when clicking.
-      - htmlproofer $READTHEDOCS_OUTPUT/html  --checks Links,Scripts,Images --ignore-urls "https://fonts.gstatic.com,https://celltypes.brain-map.org/experiment/electrophysiology/478498617,https://www.jneurosci.org/content/25/47/11003" --assume-extension --check-external-hash --ignore-status-codes 403 --ignore-files "/.+\/_static\/.+/","/.+\/stubs\/.+/","/.+\/tutorials/plot_02_head_direction.+/"
+      - htmlproofer $READTHEDOCS_OUTPUT/html  --checks Links,Scripts,Images --ignore-urls "https://fonts.gstatic.com,https://celltypes.brain-map.org/experiment/electrophysiology/478498617,https://www.jneurosci.org/content/25/47/11003" --assume-extension --check-external-hash --ignore-status-codes 403,0 --ignore-files "/.+\/_static\/.+/","/.+\/stubs\/.+/","/.+\/tutorials/plot_02_head_direction.+/"
       # The auto-generated animation doesn't have a alt or src/srcset; I am able to ignore missing alt, but I cannot work around a missing src/srcset
       # therefore for this file I am not checking the figures.
       - htmlproofer $READTHEDOCS_OUTPUT/html/tutorials/plot_02_head_direction.html  --checks Links,Scripts --ignore-urls "https://www.jneurosci.org/content/25/47/11003"

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -95,7 +95,7 @@ These classes are the building blocks for the concrete basis classes.
     AdditiveBasis
     MultiplicativeBasis
 
-**Basis As `scikit-learn` Tranformers:**
+**Basis As ``scikit-learn`` Tranformers:**
 
 .. currentmodule:: nemos.basis._transformer_basis
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -26,9 +26,9 @@ Basis can be grouped according to the mode of operation into basis that performs
 as non-linear maps.
 
 
-**The abstract classes:**
+**The Abstract Classes:**
 
-These classes are building blocks for concrete basis classes.
+These classes are the building blocks for the concrete basis classes.
 
 .. currentmodule:: nemos.basis._basis
 
@@ -93,7 +93,7 @@ These classes are building blocks for concrete basis classes.
     AdditiveBasis
     MultiplicativeBasis
 
-**Basis as scikit-learn tranformers:**
+**Basis As `scikit-learn` Tranformers:**
 
 .. currentmodule:: nemos.basis._transformer_basis
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -22,6 +22,10 @@ Classes for creating Generalized Linear Models (GLMs) for both single neurons an
 The ``nemos.basis`` module
 --------------------------
 Provides basis function classes to construct and transform features for model inputs.
+Basis can be grouped according to the mode of operation into basis that performs convolution and basis that operates
+as non-linear maps.
+
+
 
 .. currentmodule:: nemos.basis
 
@@ -31,8 +35,45 @@ Provides basis function classes to construct and transform features for model in
     :nosignatures:
 
     Basis
-    EvalOrthExponential
+
+**Bases For Convolution:**
+
+.. autosummary::
+    :toctree: generated/basis
+    :recursive:
+    :nosignatures:
+
+
+    ConvMSpline
+    ConvBSpline
+    ConvCyclicBSpline
+    ConvRaisedCosineLinear
+    ConvRaisedCosineLog
     ConvOrthExponential
+
+**Bases For Non-Linear Mapping:**
+
+.. autosummary::
+    :toctree: generated/basis
+    :recursive:
+    :nosignatures:
+
+    EvalMSpline
+    EvalBSpline
+    EvalCyclicBSpline
+    EvalRaisedCosineLinear
+    EvalRaisedCosineLog
+    EvalOrthExponential
+
+**Composite Bases:**
+
+.. autosummary::
+    :toctree: generated/basis
+    :recursive:
+    :nosignatures:
+
+    AdditiveBasis
+    MultiplicativeBasis
 
 .. _observation_models:
 The ``nemos.observation_models`` module

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -50,7 +50,7 @@ These classes are the building blocks for the concrete basis classes.
 
 **Bases For Convolution:**
 
-.. currentmodule:: nemos.basis.basis
+.. currentmodule:: nemos.basis
 
 .. autosummary::
     :toctree: generated/basis
@@ -58,28 +58,30 @@ These classes are the building blocks for the concrete basis classes.
     :nosignatures:
 
 
-    ConvMSpline
-    ConvBSpline
-    ConvCyclicBSpline
-    ConvRaisedCosineLinear
-    ConvRaisedCosineLog
-    ConvOrthExponential
+    MSplineConv
+    BSplineConv
+    CyclicBSplineConv
+    RaisedCosineLinearConv
+    RaisedCosineLogConv
+    OrthExponentialConv
+
+.. check for a config that prints only nemos.basis.Name
 
 **Bases For Non-Linear Mapping:**
 
-.. currentmodule:: nemos.basis.basis
+.. currentmodule:: nemos.basis
 
 .. autosummary::
     :toctree: generated/basis
     :recursive:
     :nosignatures:
 
-    EvalMSpline
-    EvalBSpline
-    EvalCyclicBSpline
-    EvalRaisedCosineLinear
-    EvalRaisedCosineLog
-    EvalOrthExponential
+    MSplineEval
+    BSplineEval
+    CyclicBSplineEval
+    RaisedCosineLinearEval
+    RaisedCosineLogEval
+    OrthExponentialEval
 
 **Composite Bases:**
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -26,7 +26,7 @@ Basis can be grouped according to the mode of operation into basis that performs
 as non-linear maps.
 
 
-**The abstract class `Basis`:**
+**The abstract classes:**
 
 .. currentmodule:: nemos.basis._basis
 
@@ -36,6 +36,15 @@ as non-linear maps.
     :nosignatures:
 
     Basis
+
+.. currentmodule:: nemos.basis._spline_basis
+.. autosummary::
+    :toctree: generated/_basis
+    :recursive:
+    :nosignatures:
+
+    SplineBasis
+
 
 **Bases For Convolution:**
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -26,17 +26,20 @@ Basis can be grouped according to the mode of operation into basis that performs
 as non-linear maps.
 
 
+**The abstract class `Basis`:**
 
-.. currentmodule:: nemos.basis
+.. currentmodule:: nemos.basis._basis
 
 .. autosummary::
-    :toctree: generated/basis
+    :toctree: generated/_basis
     :recursive:
     :nosignatures:
 
     Basis
 
 **Bases For Convolution:**
+
+.. currentmodule:: nemos.basis.basis
 
 .. autosummary::
     :toctree: generated/basis
@@ -53,6 +56,8 @@ as non-linear maps.
 
 **Bases For Non-Linear Mapping:**
 
+.. currentmodule:: nemos.basis.basis
+
 .. autosummary::
     :toctree: generated/basis
     :recursive:
@@ -67,13 +72,26 @@ as non-linear maps.
 
 **Composite Bases:**
 
+.. currentmodule:: nemos.basis._basis
+
 .. autosummary::
-    :toctree: generated/basis
+    :toctree: generated/_basis
     :recursive:
     :nosignatures:
 
     AdditiveBasis
     MultiplicativeBasis
+
+**Basis as scikit-learn tranformers:**
+
+.. currentmodule:: nemos.basis._transformer_basis
+
+.. autosummary::
+    :toctree: generated/_transformer_basis
+    :recursive:
+    :nosignatures:
+
+    TransformerBasis
 
 .. _observation_models:
 The ``nemos.observation_models`` module
@@ -163,7 +181,7 @@ These objects can be provided as input to nemos GLM methods.
 .. currentmodule:: nemos.pytrees
 
 .. autosummary::
-    :toctree: generated/identifiability_constraints
+    :toctree: generated/pytree
     :recursive:
     :nosignatures:
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -28,6 +28,8 @@ as non-linear maps.
 
 **The abstract classes:**
 
+These classes are building blocks for concrete basis classes.
+
 .. currentmodule:: nemos.basis._basis
 
 .. autosummary::

--- a/docs/background/plot_01_1D_basis_function.md
+++ b/docs/background/plot_01_1D_basis_function.md
@@ -45,7 +45,7 @@ warnings.filterwarnings(
 
 ## Defining a 1D Basis Object
 
-We'll start by defining a 1D basis function object of the type [`MSplineBasis`](nemos.basis.MSplineBasis).
+We'll start by defining a 1D basis function object of the type [`EvalMSpline`](nemos.basis.EvalMSpline).
 The hyperparameters required to initialize this class are:
 
 - The number of basis functions, which should be a positive integer.
@@ -63,7 +63,7 @@ order = 4
 n_basis = 10
 
 # Define the 1D basis function object
-bspline = nmo.basis.BSplineBasis(n_basis_funcs=n_basis, order=order)
+bspline = nmo.basis.EvalBSpline(n_basis_funcs=n_basis, order=order)
 ```
 
 ## Evaluating a Basis
@@ -119,7 +119,7 @@ parameter at initialization. Evaluating the basis at any sample outside the boun
 
 
 ```{code-cell} ipython3
-bspline_range = nmo.basis.BSplineBasis(n_basis_funcs=n_basis, order=order, bounds=(0.2, 0.8))
+bspline_range = nmo.basis.EvalBSpline(n_basis_funcs=n_basis, order=order, bounds=(0.2, 0.8))
 
 print("Evaluated basis:")
 # 0.5  is within the support, 0.1 is outside the support
@@ -140,20 +140,18 @@ axs[1].set_title("bounds=[0.2, 0.8]")
 plt.tight_layout()
 ```
 
-## Basis `mode`
-In constructing features, [`Basis`](nemos.basis.Basis) objects can be used in two modalities: `"eval"` for evaluate or `"conv"`
-for convolve. These two modalities change the behavior of the [`compute_features`](nemos.basis.Basis.compute_features) method of [`Basis`](nemos.basis.Basis), in particular,
+## Feature Computation
+The bases in the module `nemos.basis` can be classified in two categories:
 
-- If a basis is in mode `"eval"`, then [`compute_features`](nemos.basis.Basis.compute_features) simply returns the evaluated basis.
-- If a basis is in mode `"conv"`, then [`compute_features`](nemos.basis.Basis.compute_features) will convolve the input with a kernel of basis
-  with `window_size` specified by the user.
+- **Evaluation Bases**: Objects for which [`compute_features`](nemos.basis.Basis.compute_features) that returns the evaluated basis. This means that the basis are applying a non-linear transformation of the input. The class name for this kind of bases starts with "Eval", e.g. "EvalBSpline".
+- **Convolution Bases**: Objects for which [`compute_features`](nemos.basis.Basis.compute_features) will convolve the input with a kernel of basis elements with `window_size` specified by the user. The class name for this kind of bases starts with "Conv", e.g. "ConvBSpline".
 
 Let's see how this two modalities operate.
 
 
 ```{code-cell} ipython3
-eval_mode = nmo.basis.MSplineBasis(n_basis_funcs=n_basis, mode="eval")
-conv_mode = nmo.basis.MSplineBasis(n_basis_funcs=n_basis, mode="conv", window_size=100)
+eval_mode = nmo.basis.EvalMSpline(n_basis_funcs=n_basis)
+conv_mode = nmo.basis.ConvMSpline(n_basis_funcs=n_basis, window_size=100)
 
 # define an input
 angles = np.linspace(0, np.pi*4, 201)
@@ -228,8 +226,8 @@ evaluate a log-spaced cosine raised function basis.
 
 
 ```{code-cell} ipython3
-# Instantiate the basis noting that the `RaisedCosineBasisLog` does not require an `order` parameter
-raised_cosine_log = nmo.basis.RaisedCosineBasisLog(n_basis_funcs=10, width=1.5, time_scaling=50)
+# Instantiate the basis noting that the `RaisedCosineLog` basis does not require an `order` parameter
+raised_cosine_log = nmo.basis.EvalRaisedCosineLog(n_basis_funcs=10, width=1.5, time_scaling=50)
 
 # Evaluate the raised cosine basis at the equi-spaced sample points
 # (same method in all Basis elements)

--- a/docs/background/plot_01_1D_basis_function.md
+++ b/docs/background/plot_01_1D_basis_function.md
@@ -141,10 +141,11 @@ plt.tight_layout()
 ```
 
 ## Feature Computation
-The bases in the module `nemos.basis` can be classified in two categories:
+The bases in the `nemos.basis` module can be grouped into two categories:
 
-- **Evaluation Bases**: Objects for which [`compute_features`](nemos.basis._basis.Basis.compute_features) that returns the evaluated basis. This means that the basis are applying a non-linear transformation of the input. The class name for this kind of bases starts with "Eval", e.g. "EvalBSpline".
-- **Convolution Bases**: Objects for which [`compute_features`](nemos.basis._basis.Basis.compute_features) will convolve the input with a kernel of basis elements with `window_size` specified by the user. The class name for this kind of bases starts with "Conv", e.g. "ConvBSpline".
+1. **Evaluation Bases**: These bases use the [`compute_features`](nemos.basis._basis.Basis.compute_features) method to evaluate the basis directly, applying a non-linear transformation to the input. Classes in this category have names starting with "Eval," such as `EvalBSpline`.
+
+2. **Convolution Bases**: These bases use the [`compute_features`](nemos.basis._basis.Basis.compute_features) method to convolve the input with a kernel of basis elements, using a `window_size` specified by the user. Classes in this category have names starting with "Conv," such as `ConvBSpline`.
 
 Let's see how this two modalities operate.
 

--- a/docs/background/plot_01_1D_basis_function.md
+++ b/docs/background/plot_01_1D_basis_function.md
@@ -68,8 +68,8 @@ bspline = nmo.basis.EvalBSpline(n_basis_funcs=n_basis, order=order)
 
 ## Evaluating a Basis
 
-The [`Basis`](nemos.basis.Basis) object is callable, and can be evaluated as a function. By default, the support of the basis
-is defined by the samples that we input to the [`__call__`](nemos.basis.Basis.__call__) method, and covers from the smallest to the largest value.
+The [`Basis`](nemos.basis._basis.Basis) object is callable, and can be evaluated as a function. By default, the support of the basis
+is defined by the samples that we input to the [`__call__`](nemos.basis._basis.Basis.__call__) method, and covers from the smallest to the largest value.
 
 
 ```{code-cell} ipython3
@@ -143,8 +143,8 @@ plt.tight_layout()
 ## Feature Computation
 The bases in the module `nemos.basis` can be classified in two categories:
 
-- **Evaluation Bases**: Objects for which [`compute_features`](nemos.basis.Basis.compute_features) that returns the evaluated basis. This means that the basis are applying a non-linear transformation of the input. The class name for this kind of bases starts with "Eval", e.g. "EvalBSpline".
-- **Convolution Bases**: Objects for which [`compute_features`](nemos.basis.Basis.compute_features) will convolve the input with a kernel of basis elements with `window_size` specified by the user. The class name for this kind of bases starts with "Conv", e.g. "ConvBSpline".
+- **Evaluation Bases**: Objects for which [`compute_features`](nemos.basis._basis.Basis.compute_features) that returns the evaluated basis. This means that the basis are applying a non-linear transformation of the input. The class name for this kind of bases starts with "Eval", e.g. "EvalBSpline".
+- **Convolution Bases**: Objects for which [`compute_features`](nemos.basis._basis.Basis.compute_features) will convolve the input with a kernel of basis elements with `window_size` specified by the user. The class name for this kind of bases starts with "Conv", e.g. "ConvBSpline".
 
 Let's see how this two modalities operate.
 
@@ -198,7 +198,7 @@ check out the tutorial on [1D convolutions](plot_03_1D_convolution).
 Plotting the Basis Function Elements:
 --------------------------------------
 We suggest visualizing the basis post-instantiation by evaluating each element on a set of equi-spaced sample points
-and then plotting the result. The method [`Basis.evaluate_on_grid`](nemos.basis.Basis.evaluate_on_grid) is designed for this, as it generates and returns
+and then plotting the result. The method [`Basis.evaluate_on_grid`](nemos.basis._basis.Basis.evaluate_on_grid) is designed for this, as it generates and returns
 the equi-spaced samples along with the evaluated basis functions. The benefits of using Basis.evaluate_on_grid become
 particularly evident when working with multidimensional basis functions. You can find more details and visual
 background in the

--- a/docs/background/plot_01_1D_basis_function.md
+++ b/docs/background/plot_01_1D_basis_function.md
@@ -45,7 +45,7 @@ warnings.filterwarnings(
 
 ## Defining a 1D Basis Object
 
-We'll start by defining a 1D basis function object of the type [`EvalMSpline`](nemos.basis.EvalMSpline).
+We'll start by defining a 1D basis function object of the type [`EvalMSpline`](nemos.basis.basis.EvalMSpline).
 The hyperparameters required to initialize this class are:
 
 - The number of basis functions, which should be a positive integer.

--- a/docs/background/plot_01_1D_basis_function.md
+++ b/docs/background/plot_01_1D_basis_function.md
@@ -46,7 +46,7 @@ warnings.filterwarnings(
 
 ## Defining a 1D Basis Object
 
-We'll start by defining a 1D basis function object of the type [`MSplineEval`](nemos.basis.basis.MSplineEval).
+We'll start by defining a 1D basis function object of the type [`MSplineEval`](nemos.basis.MSplineEval).
 The hyperparameters required to initialize this class are:
 
 - The number of basis functions, which should be a positive integer.

--- a/docs/background/plot_01_1D_basis_function.md
+++ b/docs/background/plot_01_1D_basis_function.md
@@ -38,6 +38,7 @@ warnings.filterwarnings(
     ),
     category=RuntimeWarning,
 )
+
 ```
 
 (simple_basis_function)=
@@ -58,12 +59,48 @@ import pynapple as nap
 
 import nemos as nmo
 
+# configure plots some
+plt.style.use(nmo.styles.plot_style)
+
 # Initialize hyperparameters
 order = 4
 n_basis = 10
 
 # Define the 1D basis function object
 bspline = nmo.basis.BSplineEval(n_basis_funcs=n_basis, order=order)
+```
+
+We provide the convenience method `evaluate_on_grid` for evaluating the basis on an equi-spaced grid of points that makes it easier to plot and visualize all basis elements.
+
+```{code-cell} ipython3
+# evaluate the basis on 100 sample points
+x, y = bspline.evaluate_on_grid(100)
+
+fig = plt.figure(figsize=(5, 3))
+plt.plot(x, y, lw=2)
+plt.title("B-Spline Basis")
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+# save image for thumbnail
+from pathlib import Path
+import os
+
+root = os.environ.get("READTHEDOCS_OUTPUT")
+if root:
+   path = Path(root) / "html/_static/thumbnails/background"
+# if local store in ../_build/html/...
+else:
+   path = Path("../_build/html/_static/thumbnails/background")
+ 
+# make sure the folder exists if run from build
+if root or Path("../_build/html/_static").exists():
+   path.mkdir(parents=True, exist_ok=True)
+
+if path.exists():
+  fig.savefig(path / "plot_01_1D_basis_function.svg")
 ```
 
 ## Feature Computation
@@ -74,7 +111,6 @@ The bases in the `nemos.basis` module can be grouped into two categories:
 2. **Convolution Bases**: These bases use the [`compute_features`](nemos.basis._basis.Basis.compute_features) method to convolve the input with a kernel of basis elements, using a `window_size` specified by the user. Classes in this category have names starting with "Conv," such as `BSplineConv`.
 
 Let's see how this two modalities operate.
-
 
 ```{code-cell} ipython3
 eval_mode = nmo.basis.MSplineEval(n_basis_funcs=n_basis)
@@ -165,6 +201,7 @@ the fixed range basis.
 
 
 ```{code-cell} ipython3
+samples = np.linspace(0, 1, 200)
 fig, axs = plt.subplots(2,1, sharex=True)
 plt.suptitle("B-spline basis ")
 axs[0].plot(samples, bspline.compute_features(samples), color="k")

--- a/docs/background/plot_01_1D_basis_function.md
+++ b/docs/background/plot_01_1D_basis_function.md
@@ -45,7 +45,7 @@ warnings.filterwarnings(
 
 ## Defining a 1D Basis Object
 
-We'll start by defining a 1D basis function object of the type [`EvalMSpline`](nemos.basis.basis.EvalMSpline).
+We'll start by defining a 1D basis function object of the type [`MSplineEval`](nemos.basis.basis.MSplineEval).
 The hyperparameters required to initialize this class are:
 
 - The number of basis functions, which should be a positive integer.
@@ -63,96 +63,22 @@ order = 4
 n_basis = 10
 
 # Define the 1D basis function object
-bspline = nmo.basis.EvalBSpline(n_basis_funcs=n_basis, order=order)
-```
-
-## Evaluating a Basis
-
-The [`Basis`](nemos.basis._basis.Basis) object is callable, and can be evaluated as a function. By default, the support of the basis
-is defined by the samples that we input to the [`__call__`](nemos.basis._basis.Basis.__call__) method, and covers from the smallest to the largest value.
-
-
-```{code-cell} ipython3
-
-# Generate a time series of sample points
-samples = nap.Tsd(t=np.arange(1001), d=np.linspace(0, 1,1001))
-
-# Evaluate the basis at the sample points
-eval_basis = bspline(samples)
-
-# Output information about the evaluated basis
-print(f"Evaluated B-spline of order {order} with {eval_basis.shape[1]} "
-      f"basis element and {eval_basis.shape[0]} samples.")
-
-fig = plt.figure()
-plt.title("B-spline basis")
-plt.plot(samples, eval_basis);
-```
-
-```{code-cell} ipython3
-:tags: [hide-input]
-
-# save image for thumbnail
-from pathlib import Path
-import os
-
-root = os.environ.get("READTHEDOCS_OUTPUT")
-if root:
-   path = Path(root) / "html/_static/thumbnails/background"
-# if local store in ../_build/html/...
-else:
-   path = Path("../_build/html/_static/thumbnails/background")
- 
-# make sure the folder exists if run from build
-if root or Path("../_build/html/_static").exists():
-   path.mkdir(parents=True, exist_ok=True)
-
-if path.exists():
-  fig.savefig(path / "plot_01_1D_basis_function.svg")
-```
-
-## Setting the basis support
-Sometimes, it is useful to restrict the basis to a fixed range. This can help manage outliers or ensure that
-your basis covers the same range across multiple experimental sessions.
-You can specify a range for the support of your basis by setting the `bounds`
-parameter at initialization. Evaluating the basis at any sample outside the bounds will result in a NaN.
-
-
-```{code-cell} ipython3
-bspline_range = nmo.basis.EvalBSpline(n_basis_funcs=n_basis, order=order, bounds=(0.2, 0.8))
-
-print("Evaluated basis:")
-# 0.5  is within the support, 0.1 is outside the support
-print(np.round(bspline_range([0.5, 0.1]), 3))
-```
-
-Let's compare the default behavior of basis (estimating the range from the samples) with
-the fixed range basis.
-
-
-```{code-cell} ipython3
-fig, axs = plt.subplots(2,1, sharex=True)
-plt.suptitle("B-spline basis ")
-axs[0].plot(samples, bspline(samples), color="k")
-axs[0].set_title("default")
-axs[1].plot(samples, bspline_range(samples), color="tomato")
-axs[1].set_title("bounds=[0.2, 0.8]")
-plt.tight_layout()
+bspline = nmo.basis.BSplineEval(n_basis_funcs=n_basis, order=order)
 ```
 
 ## Feature Computation
 The bases in the `nemos.basis` module can be grouped into two categories:
 
-1. **Evaluation Bases**: These bases use the [`compute_features`](nemos.basis._basis.Basis.compute_features) method to evaluate the basis directly, applying a non-linear transformation to the input. Classes in this category have names starting with "Eval," such as `EvalBSpline`.
+1. **Evaluation Bases**: These bases use the [`compute_features`](nemos.basis._basis.Basis.compute_features) method to evaluate the basis directly, applying a non-linear transformation to the input. Classes in this category have names starting with "Eval," such as `BSplineEval`.
 
-2. **Convolution Bases**: These bases use the [`compute_features`](nemos.basis._basis.Basis.compute_features) method to convolve the input with a kernel of basis elements, using a `window_size` specified by the user. Classes in this category have names starting with "Conv," such as `ConvBSpline`.
+2. **Convolution Bases**: These bases use the [`compute_features`](nemos.basis._basis.Basis.compute_features) method to convolve the input with a kernel of basis elements, using a `window_size` specified by the user. Classes in this category have names starting with "Conv," such as `BSplineConv`.
 
 Let's see how this two modalities operate.
 
 
 ```{code-cell} ipython3
-eval_mode = nmo.basis.EvalMSpline(n_basis_funcs=n_basis)
-conv_mode = nmo.basis.ConvMSpline(n_basis_funcs=n_basis, window_size=100)
+eval_mode = nmo.basis.MSplineEval(n_basis_funcs=n_basis)
+conv_mode = nmo.basis.MSplineConv(n_basis_funcs=n_basis, window_size=100)
 
 # define an input
 angles = np.linspace(0, np.pi*4, 201)
@@ -195,7 +121,6 @@ check out the tutorial on [1D convolutions](plot_03_1D_convolution).
 :::
 
 
-
 Plotting the Basis Function Elements:
 --------------------------------------
 We suggest visualizing the basis post-instantiation by evaluating each element on a set of equi-spaced sample points
@@ -218,6 +143,37 @@ plt.plot(equispaced_samples, eval_basis)
 plt.show()
 ```
 
+
+## Setting the basis support (Eval only)
+Sometimes, it is useful to restrict the basis to a fixed range. This can help manage outliers or ensure that
+your basis covers the same range across multiple experimental sessions.
+You can specify a range for the support of your basis by setting the `bounds`
+parameter at initialization of "Eval" type basis (it doesn't make sense for convolutions). 
+Evaluating the basis at any sample outside the bounds will result in a NaN.
+
+
+```{code-cell} ipython3
+bspline_range = nmo.basis.BSplineEval(n_basis_funcs=n_basis, order=order, bounds=(0.2, 0.8))
+
+print("Evaluated basis:")
+# 0.5  is within the support, 0.1 is outside the support
+print(np.round(bspline_range.compute_features([0.5, 0.1]), 3))
+```
+
+Let's compare the default behavior of basis (estimating the range from the samples) with
+the fixed range basis.
+
+
+```{code-cell} ipython3
+fig, axs = plt.subplots(2,1, sharex=True)
+plt.suptitle("B-spline basis ")
+axs[0].plot(samples, bspline.compute_features(samples), color="k")
+axs[0].set_title("default")
+axs[1].plot(samples, bspline_range.compute_features(samples), color="tomato")
+axs[1].set_title("bounds=[0.2, 0.8]")
+plt.tight_layout()
+```
+
 Other Basis Types
 -----------------
 Each basis type may necessitate specific hyperparameters for instantiation. For a comprehensive description,
@@ -228,7 +184,7 @@ evaluate a log-spaced cosine raised function basis.
 
 ```{code-cell} ipython3
 # Instantiate the basis noting that the `RaisedCosineLog` basis does not require an `order` parameter
-raised_cosine_log = nmo.basis.EvalRaisedCosineLog(n_basis_funcs=10, width=1.5, time_scaling=50)
+raised_cosine_log = nmo.basis.RaisedCosineLogEval(n_basis_funcs=10, width=1.5, time_scaling=50)
 
 # Evaluate the raised cosine basis at the equi-spaced sample points
 # (same method in all Basis elements)

--- a/docs/background/plot_02_ND_basis_function.md
+++ b/docs/background/plot_02_ND_basis_function.md
@@ -127,10 +127,11 @@ Here, we simply add two basis objects, `a_basis` and `b_basis`, together to defi
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
+import nemos as nmo
 
 # Define 1D basis objects
-a_basis = nemos.basis.basis.EvalMSpline(n_basis_funcs=15, order=3)
-b_basis = nemos.basis.basis.RaisedCosineBasisLog(n_basis_funcs=14)
+a_basis = nmo.basis.EvalMSpline(n_basis_funcs=15, order=3)
+b_basis = nmo.basis.EvalRaisedCosineLog(n_basis_funcs=14)
 
 # Define the 2D additive basis object
 additive_basis = a_basis + b_basis
@@ -279,7 +280,7 @@ for i, j in element_pairs:
     # select & plot the corresponding product basis element
     k = i * b_basis.n_basis_funcs + j
     axs[cc, 2].contourf(X, Y, Z[:, :, k], cmap='Blues')
-    axs[cc, 2].set_title(f"$A_{{{k}}}(x,y) = a_{{{i}}}(x) \cdot b_{{{j}}}(y)$", color='b')
+    axs[cc, 2].set_title(fr"$A_{{{k}}}(x,y) = a_{{{i}}}(x) \cdot b_{{{j}}}(y)$", color='b')
     axs[cc, 2].set_xlabel('x-coord')
     axs[cc, 2].set_ylabel('y-coord')
     axs[cc, 2].set_aspect("equal")
@@ -339,9 +340,9 @@ will output a $K^N \times T$ matrix.
 T = 10
 n_basis = 8
 
-a_basis = nmo.basis.RaisedCosineBasisLinear(n_basis_funcs=n_basis)
-b_basis = nmo.basis.RaisedCosineBasisLinear(n_basis_funcs=n_basis)
-c_basis = nmo.basis.RaisedCosineBasisLinear(n_basis_funcs=n_basis)
+a_basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=n_basis)
+b_basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=n_basis)
+c_basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=n_basis)
 
 prod_basis_3 = a_basis * b_basis * c_basis
 samples = np.linspace(0, 1, T)

--- a/docs/background/plot_02_ND_basis_function.md
+++ b/docs/background/plot_02_ND_basis_function.md
@@ -130,8 +130,8 @@ import numpy as np
 import nemos as nmo
 
 # Define 1D basis objects
-a_basis = nmo.basis.EvalMSpline(n_basis_funcs=15, order=3)
-b_basis = nmo.basis.EvalRaisedCosineLog(n_basis_funcs=14)
+a_basis = nmo.basis.MSplineEval(n_basis_funcs=15, order=3)
+b_basis = nmo.basis.RaisedCosineLogEval(n_basis_funcs=14)
 
 # Define the 2D additive basis object
 additive_basis = a_basis + b_basis
@@ -340,9 +340,9 @@ will output a $K^N \times T$ matrix.
 T = 10
 n_basis = 8
 
-a_basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=n_basis)
-b_basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=n_basis)
-c_basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=n_basis)
+a_basis = nmo.basis.RaisedCosineLinearEval(n_basis_funcs=n_basis)
+b_basis = nmo.basis.RaisedCosineLinearEval(n_basis_funcs=n_basis)
+c_basis = nmo.basis.RaisedCosineLinearEval(n_basis_funcs=n_basis)
 
 prod_basis_3 = a_basis * b_basis * c_basis
 samples = np.linspace(0, 1, T)

--- a/docs/background/plot_02_ND_basis_function.md
+++ b/docs/background/plot_02_ND_basis_function.md
@@ -150,7 +150,7 @@ x_coord = np.linspace(0, 1, 1000)
 y_coord = np.linspace(0, 1, 1000)
 
 # Evaluate the basis functions for the given trajectory.
-eval_basis = additive_basis(x_coord, y_coord)
+eval_basis = additive_basis.compute_features(x_coord, y_coord)
 
 print(f"Sum of two 1D splines with {eval_basis.shape[1]} "
       f"basis element and {eval_basis.shape[0]} samples:\n"
@@ -169,13 +169,13 @@ basis_b_element = 1
 fig, axs = plt.subplots(1, 2, figsize=(6, 3))
 
 axs[0].set_title(f"$a_{{{basis_a_element}}}(x)$", color="b")
-axs[0].plot(x_coord, a_basis(x_coord), "grey", alpha=.3)
-axs[0].plot(x_coord, a_basis(x_coord)[:, basis_a_element], "b")
+axs[0].plot(x_coord, a_basis.compute_features(x_coord), "grey", alpha=.3)
+axs[0].plot(x_coord, a_basis.compute_features(x_coord)[:, basis_a_element], "b")
 axs[0].set_xlabel("x-coord")
 
 axs[1].set_title(f"$b_{{{basis_b_element}}}(x)$", color="b")
-axs[1].plot(y_coord, b_basis(x_coord), "grey", alpha=.3)
-axs[1].plot(y_coord, b_basis(x_coord)[:, basis_b_element], "b")
+axs[1].plot(y_coord, b_basis.compute_features(x_coord), "grey", alpha=.3)
+axs[1].plot(y_coord, b_basis.compute_features(x_coord)[:, basis_b_element], "b")
 axs[1].set_xlabel("y-coord")
 plt.tight_layout()
 ```
@@ -242,7 +242,7 @@ The number of elements of the product basis will be the product of the elements 
 
 ```{code-cell} ipython3
 # Evaluate the product basis at the x and y coordinates
-eval_basis = prod_basis(x_coord, y_coord)
+eval_basis = prod_basis.compute_features(x_coord, y_coord)
 
 # Output the number of elements and samples of the evaluated basis, 
 # as well as the number of elements in the original 1D basis objects
@@ -268,13 +268,13 @@ fig, axs = plt.subplots(3,3,figsize=(8, 6))
 cc = 0
 for i, j in element_pairs:
     # plot the element form a_basis
-    axs[cc, 0].plot(x_coord, a_basis(x_coord), "grey", alpha=.3)
-    axs[cc, 0].plot(x_coord, a_basis(x_coord)[:, i], "b")
+    axs[cc, 0].plot(x_coord, a_basis.compute_features(x_coord), "grey", alpha=.3)
+    axs[cc, 0].plot(x_coord, a_basis.compute_features(x_coord)[:, i], "b")
     axs[cc, 0].set_title(f"$a_{{{i}}}(x)$",color='b')
 
     # plot the element form b_basis
-    axs[cc, 1].plot(y_coord, b_basis(y_coord), "grey", alpha=.3)
-    axs[cc, 1].plot(y_coord, b_basis(y_coord)[:, j], "b")
+    axs[cc, 1].plot(y_coord, b_basis.compute_features(y_coord), "grey", alpha=.3)
+    axs[cc, 1].plot(y_coord, b_basis.compute_features(y_coord)[:, j], "b")
     axs[cc, 1].set_title(f"$b_{{{j}}}(y)$",color='b')
 
     # select & plot the corresponding product basis element
@@ -322,7 +322,6 @@ in a linear maze and the LFP phase angle.
 :::
 
 
-
 N-Dimensional Basis
 -------------------
 Sometimes it may be useful to model even higher dimensional interactions, for example between the heding direction of
@@ -346,7 +345,7 @@ c_basis = nmo.basis.RaisedCosineLinearEval(n_basis_funcs=n_basis)
 
 prod_basis_3 = a_basis * b_basis * c_basis
 samples = np.linspace(0, 1, T)
-eval_basis = prod_basis_3(samples, samples, samples)
+eval_basis = prod_basis_3.compute_features(samples, samples, samples)
 
 print(f"Product of three 1D splines results in {prod_basis_3.n_basis_funcs} "
       f"basis elements.\nEvaluation output of shape {eval_basis.shape}")

--- a/docs/background/plot_03_1D_convolution.md
+++ b/docs/background/plot_03_1D_convolution.md
@@ -82,7 +82,7 @@ see [jax.numpy.convolve](https://jax.readthedocs.io/en/latest/_autosummary/jax.n
 
 ```{code-cell} ipython3
 # create three filters
-basis_obj = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=3)
+basis_obj = nmo.basis.RaisedCosineLinearEval(n_basis_funcs=3)
 _, w = basis_obj.evaluate_on_grid(ws)
 
 plt.plot(w)
@@ -198,18 +198,18 @@ Let's see how we can get the same results through [`Basis`](nemos.basis._basis.B
 
 ```{code-cell} ipython3
 # define basis with different predictor causality
-causal_basis = nmo.basis.ConvRaisedCosineLinear(
+causal_basis = nmo.basis.RaisedCosineLinearConv(
         n_basis_funcs=3, window_size=ws,
         conv_kwargs=dict(predictor_causality="causal")
         
 )
 
-acausal_basis = nmo.basis.ConvRaisedCosineLinear(
+acausal_basis = nmo.basis.RaisedCosineLinearConv(
         n_basis_funcs=3, window_size=ws,
         conv_kwargs=dict(predictor_causality="acausal")
 )
 
-anticausal_basis = nmo.basis.ConvRaisedCosineLinear(
+anticausal_basis = nmo.basis.RaisedCosineLinearConv(
         n_basis_funcs=3, window_size=ws,
         conv_kwargs=dict(predictor_causality="anti-causal")
 )

--- a/docs/background/plot_03_1D_convolution.md
+++ b/docs/background/plot_03_1D_convolution.md
@@ -186,14 +186,14 @@ if path.exists():
   fig.savefig(path / "plot_03_1D_convolution.svg")
 ```
 
-## Convolve using [`Basis.compute_features`](nemos.basis.Basis.compute_features)
+## Convolve using [`Basis.compute_features`](nemos.basis._basis.Basis.compute_features)
 
 Every basis in the `nemos.basis` module whose class name starts with "Conv" will perform a 1D convolution over the 
 provided input when the `compute_features` method is called. The basis elements will be used as filters for the
 convolution.
 
 All the parameters of [`create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor) can be passed to the object directly at initialization. 
-Let's see how we can get the same results through [`Basis`](nemos.basis.Basis).
+Let's see how we can get the same results through [`Basis`](nemos.basis._basis.Basis).
 
 
 ```{code-cell} ipython3

--- a/docs/background/plot_03_1D_convolution.md
+++ b/docs/background/plot_03_1D_convolution.md
@@ -82,7 +82,7 @@ see [jax.numpy.convolve](https://jax.readthedocs.io/en/latest/_autosummary/jax.n
 
 ```{code-cell} ipython3
 # create three filters
-basis_obj = nmo.basis.RaisedCosineBasisLinear(n_basis_funcs=3)
+basis_obj = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=3)
 _, w = basis_obj.evaluate_on_grid(ws)
 
 plt.plot(w)
@@ -187,26 +187,31 @@ if path.exists():
 ```
 
 ## Convolve using [`Basis.compute_features`](nemos.basis.Basis.compute_features)
-All the parameters of [`create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor) can be passed to a [`Basis`](nemos.basis.Basis) directly
-at initialization. Note that you must set `mode == "conv"` to actually perform convolution
-with [`Basis.compute_features`](nemos.basis.Basis.compute_features). Let's see how we can get the same results through [`Basis`](nemos.basis.Basis).
+
+Every basis in the `nemos.basis` module whose class name starts with "Conv" will perform a 1D convolution over the 
+provided input when the `compute_features` method is called. The basis elements will be used as filters for the
+convolution.
+
+All the parameters of [`create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor) can be passed to the object directly at initialization. 
+Let's see how we can get the same results through [`Basis`](nemos.basis.Basis).
 
 
 ```{code-cell} ipython3
 # define basis with different predictor causality
-causal_basis = nmo.basis.RaisedCosineBasisLinear(
-        n_basis_funcs=3, mode="conv", window_size=ws,
-        predictor_causality="causal"
+causal_basis = nmo.basis.ConvRaisedCosineLinear(
+        n_basis_funcs=3, window_size=ws,
+        conv_kwargs=dict(predictor_causality="causal")
+        
 )
 
-acausal_basis = nmo.basis.RaisedCosineBasisLinear(
-        n_basis_funcs=3, mode="conv", window_size=ws,
-        predictor_causality="acausal"
+acausal_basis = nmo.basis.ConvRaisedCosineLinear(
+        n_basis_funcs=3, window_size=ws,
+        conv_kwargs=dict(predictor_causality="acausal")
 )
 
-anticausal_basis = nmo.basis.RaisedCosineBasisLinear(
-        n_basis_funcs=3, mode="conv", window_size=ws,
-        predictor_causality="anti-causal"
+anticausal_basis = nmo.basis.ConvRaisedCosineLinear(
+        n_basis_funcs=3, window_size=ws,
+        conv_kwargs=dict(predictor_causality="anti-causal")
 )
 
 # compute convolutions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,3 +158,5 @@ exclude_tutorials = os.environ.get("EXCLUDE_TUTORIALS", "false").lower() == "tru
 
 if exclude_tutorials:
     nb_execution_excludepatterns = ["tutorials/**", "how_to_guide/**", "background/**"]
+
+viewcode_follow_imported_members = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ autodoc_default_options = {
     'inherited-members': True,
     'undoc-members': True,
     'show-inheritance': True,
-    'special-members': '__call__, __add__, __mul__, __pow__'
+    'special-members': ' __add__, __mul__, __pow__'
 }
 
 # # napolean configs

--- a/docs/developers_notes/04-basis_module.md
+++ b/docs/developers_notes/04-basis_module.md
@@ -26,23 +26,23 @@ Abstract Class Basis
 └─ Concrete Subclass OrthExponentialBasis
 ```
 
-The super-class [`Basis`](nemos.basis.Basis) provides two public methods, [`compute_features`](the-public-method-compute_features) and [`evaluate_on_grid`](the-public-method-evaluate_on_grid). These methods perform checks on both the input provided by the user and the output of the evaluation to ensure correctness, and are thus considered "safe". They both make use of the abstract method [`__call__`](nemos.basis.Basis.__call__) that is specific for each concrete class. See below for more details.
+The super-class [`Basis`](nemos.basis._basis.Basis) provides two public methods, [`compute_features`](the-public-method-compute_features) and [`evaluate_on_grid`](the-public-method-evaluate_on_grid). These methods perform checks on both the input provided by the user and the output of the evaluation to ensure correctness, and are thus considered "safe". They both make use of the abstract method [`__call__`](nemos.basis._basis.Basis.__call__) that is specific for each concrete class. See below for more details.
 
-## The Class `nemos.basis.Basis`
+## The Class `nemos.basis._basis.Basis`
 
 (the-public-method-compute_features)=
 ### The Public Method `compute_features`
 
-The [`compute_features`](nemos.basis.Basis.compute_features) method checks input consistency and applies the basis function to the inputs. 
-[`Basis`](nemos.basis.Basis) can operate in two modes defined at initialization: `"eval"` and `"conv"`. When a basis is in mode `"eval"`,
-[`compute_features`](nemos.basis.Basis.compute_features) evaluates the basis at the given input samples. When in mode `"conv"`, it will convolve the samples
+The [`compute_features`](nemos.basis._basis.Basis.compute_features) method checks input consistency and applies the basis function to the inputs. 
+[`Basis`](nemos.basis._basis.Basis) can operate in two modes defined at initialization: `"eval"` and `"conv"`. When a basis is in mode `"eval"`,
+[`compute_features`](nemos.basis._basis.Basis.compute_features) evaluates the basis at the given input samples. When in mode `"conv"`, it will convolve the samples
 with a bank of kernels, one per basis function.
 
 It accepts one or more NumPy array or pynapple `Tsd` object as input, and performs the following steps:
 
 1. Checks that the inputs all have the same sample size `M`, and raises a `ValueError` if this is not the case.
 2. Checks that the number of inputs matches what the basis being evaluated expects (e.g., one input for a 1-D basis, N inputs for an N-D basis, or the sum of N 1-D bases), and raises a `ValueError` if this is not the case.
-3. In `"eval"` mode, calls the `__call__` method on the input, which is the subclass-specific implementation of the basis set evaluation. In `"conv"` mode, generates a filter bank using [`compute_features`](nemos.basis.Basis.evaluate_on_grid) and then applies the convolution to the input with [`nemos.convolve.create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor).
+3. In `"eval"` mode, calls the `__call__` method on the input, which is the subclass-specific implementation of the basis set evaluation. In `"conv"` mode, generates a filter bank using [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) and then applies the convolution to the input with [`nemos.convolve.create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor).
 4. Returns a NumPy array or  pynapple `TsdFrame` of shape `(M, n_basis_funcs)`, with each basis element evaluated at the samples.
 
 :::{admonition} Multiple epochs
@@ -55,20 +55,20 @@ input.
 (the-public-method-evaluate_on_grid)=
 ### The Public Method `evaluate_on_grid`
 
-The [`compute_features`](nemos.basis.Basis.compute_features) method evaluates the basis set on a grid of equidistant sample points. The user specifies the input as a series of integers, one for each dimension of the basis function, that indicate the number of sample points in each coordinate of the grid.
+The [`compute_features`](nemos.basis._basis.Basis.compute_features) method evaluates the basis set on a grid of equidistant sample points. The user specifies the input as a series of integers, one for each dimension of the basis function, that indicate the number of sample points in each coordinate of the grid.
 
 This method performs the following steps:
 
 1. Checks that the number of inputs matches what the basis being evaluated expects (e.g., one input for a 1-D basis, N inputs for an N-D basis, or the sum of N 1-D bases), and raises a `ValueError` if this is not the case.
 2. Calls `_get_samples` method, which returns equidistant samples over the domain of the basis function. The domain may depend on the type of basis.
-3. Calls the [`__call__`](nemos.basis.Basis.__call__) method.
+3. Calls the [`__call__`](nemos.basis._basis.Basis.__call__) method.
 4. Returns both the sample grid points of shape `(m1, ..., mN)`, and the evaluation output at each grid point of shape `(m1, ..., mN, n_basis_funcs)`, where `mi` is the number of sample points for the i-th axis of the grid.
 
 ### Abstract Methods
 
-The [`nemos.basis.Basis`](nemos.basis.Basis) class has the following abstract methods, which every concrete subclass must implement:
+The [`nemos.basis._basis.Basis`](nemos.basis._basis.Basis) class has the following abstract methods, which every concrete subclass must implement:
 
-1. [`__call__`](nemos.basis.Basis.__call__): Evaluates a basis over some specified samples.
+1. [`__call__`](nemos.basis._basis.Basis.__call__): Evaluates a basis over some specified samples.
 2. `_check_n_basis_min`: Checks the minimum number of basis functions required. This requirement can be specific to the type of basis.
 
 ## Contributors Guidelines
@@ -76,8 +76,8 @@ The [`nemos.basis.Basis`](nemos.basis.Basis) class has the following abstract me
 ### Implementing Concrete Basis Objects
 To write a usable (i.e., concrete, non-abstract) basis object, you
 
-- **Must** inherit the abstract superclass [`Basis`](nemos.basis.Basis)
-- **Must** define the [`__call__`](nemos.basis.Basis.__call__) and `_check_n_basis_min` methods with the expected input/output format, see [API Reference](nemos_basis) for the specifics.
-- **Should not** overwrite the [`compute_features`](nemos.basis.Basis.compute_features) and [`compute_features`](nemos.basis.Basis.evaluate_on_grid) methods inherited from [`Basis`](nemos.basis.Basis).
-- **May** inherit any number of abstract intermediate classes (e.g., [`SplineBasis`](nemos.basis.SplineBasis)). 
+- **Must** inherit the abstract superclass [`Basis`](nemos.basis._basis.Basis)
+- **Must** define the [`__call__`](nemos.basis._basis.Basis.__call__) and `_check_n_basis_min` methods with the expected input/output format, see [API Reference](nemos_basis) for the specifics.
+- **Should not** overwrite the [`compute_features`](nemos.basis._basis.Basis.compute_features) and [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) methods inherited from [`Basis`](nemos.basis._basis.Basis).
+- **May** inherit any number of abstract intermediate classes (e.g., [`SplineBasis`](nemos.basis._spline_basis.SplineBasis)). 
 

--- a/docs/developers_notes/04-basis_module.md
+++ b/docs/developers_notes/04-basis_module.md
@@ -21,7 +21,7 @@ Abstract Class Basis
 │
 ├─ Concrete Subclass RaisedCosineBasisLinear 
 │   │
-│   └─ Concrete Subclass RaisedCosineBasisLog
+│   └─ Concrete Subclass EvalRaisedCosineLog
 │
 └─ Concrete Subclass OrthExponentialBasis
 ```

--- a/docs/developers_notes/04-basis_module.md
+++ b/docs/developers_notes/04-basis_module.md
@@ -21,12 +21,12 @@ Abstract Class Basis
 │
 ├─ Concrete Subclass RaisedCosineBasisLinear 
 │   │
-│   └─ Concrete Subclass EvalRaisedCosineLog
+│   └─ Concrete Subclass RaisedCosineLogEval
 │
 └─ Concrete Subclass OrthExponentialBasis
 ```
 
-The super-class [`Basis`](nemos.basis._basis.Basis) provides two public methods, [`compute_features`](the-public-method-compute_features) and [`evaluate_on_grid`](the-public-method-evaluate_on_grid). These methods perform checks on both the input provided by the user and the output of the evaluation to ensure correctness, and are thus considered "safe". They both make use of the abstract method [`__call__`](nemos.basis._basis.Basis.__call__) that is specific for each concrete class. See below for more details.
+The super-class [`Basis`](nemos.basis._basis.Basis) provides two public methods, [`compute_features`](the-public-method-compute_features) and [`evaluate_on_grid`](the-public-method-evaluate_on_grid). These methods perform checks on both the input provided by the user and the output of the evaluation to ensure correctness, and are thus considered "safe". They both make use of the abstract method [`_evaluate`](nemos.basis._basis.Basis._evaluate) that is specific for each concrete class. See below for more details.
 
 ## The Class `nemos.basis._basis.Basis`
 
@@ -42,7 +42,7 @@ It accepts one or more NumPy array or pynapple `Tsd` object as input, and perfor
 
 1. Checks that the inputs all have the same sample size `M`, and raises a `ValueError` if this is not the case.
 2. Checks that the number of inputs matches what the basis being evaluated expects (e.g., one input for a 1-D basis, N inputs for an N-D basis, or the sum of N 1-D bases), and raises a `ValueError` if this is not the case.
-3. In `"eval"` mode, calls the `__call__` method on the input, which is the subclass-specific implementation of the basis set evaluation. In `"conv"` mode, generates a filter bank using [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) and then applies the convolution to the input with [`nemos.convolve.create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor).
+3. In `"eval"` mode, calls the `_evaluate` method on the input, which is the subclass-specific implementation of the basis set evaluation. In `"conv"` mode, generates a filter bank using [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) and then applies the convolution to the input with [`nemos.convolve.create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor).
 4. Returns a NumPy array or  pynapple `TsdFrame` of shape `(M, n_basis_funcs)`, with each basis element evaluated at the samples.
 
 :::{admonition} Multiple epochs
@@ -61,14 +61,14 @@ This method performs the following steps:
 
 1. Checks that the number of inputs matches what the basis being evaluated expects (e.g., one input for a 1-D basis, N inputs for an N-D basis, or the sum of N 1-D bases), and raises a `ValueError` if this is not the case.
 2. Calls `_get_samples` method, which returns equidistant samples over the domain of the basis function. The domain may depend on the type of basis.
-3. Calls the [`__call__`](nemos.basis._basis.Basis.__call__) method.
+3. Calls the [`_evaluate`](nemos.basis._basis.Basis._evaluate) method.
 4. Returns both the sample grid points of shape `(m1, ..., mN)`, and the evaluation output at each grid point of shape `(m1, ..., mN, n_basis_funcs)`, where `mi` is the number of sample points for the i-th axis of the grid.
 
 ### Abstract Methods
 
 The [`nemos.basis._basis.Basis`](nemos.basis._basis.Basis) class has the following abstract methods, which every concrete subclass must implement:
 
-1. [`__call__`](nemos.basis._basis.Basis.__call__): Evaluates a basis over some specified samples.
+1. [`_evaluate`](nemos.basis._basis.Basis._evaluate): Evaluates a basis over some specified samples.
 2. `_check_n_basis_min`: Checks the minimum number of basis functions required. This requirement can be specific to the type of basis.
 
 ## Contributors Guidelines
@@ -77,7 +77,7 @@ The [`nemos.basis._basis.Basis`](nemos.basis._basis.Basis) class has the followi
 To write a usable (i.e., concrete, non-abstract) basis object, you
 
 - **Must** inherit the abstract superclass [`Basis`](nemos.basis._basis.Basis)
-- **Must** define the [`__call__`](nemos.basis._basis.Basis.__call__) and `_check_n_basis_min` methods with the expected input/output format, see [API Reference](nemos_basis) for the specifics.
+- **Must** define the [`_evaluate`](nemos.basis._basis.Basis._evaluate) and `_check_n_basis_min` methods with the expected input/output format, see [API Reference](nemos_basis) for the specifics.
 - **Should not** overwrite the [`compute_features`](nemos.basis._basis.Basis.compute_features) and [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) methods inherited from [`Basis`](nemos.basis._basis.Basis).
 - **May** inherit any number of abstract intermediate classes (e.g., [`SplineBasis`](nemos.basis._spline_basis.SplineBasis)). 
 

--- a/docs/developers_notes/04-basis_module.md
+++ b/docs/developers_notes/04-basis_module.md
@@ -42,7 +42,7 @@ It accepts one or more NumPy array or pynapple `Tsd` object as input, and perfor
 
 1. Checks that the inputs all have the same sample size `M`, and raises a `ValueError` if this is not the case.
 2. Checks that the number of inputs matches what the basis being evaluated expects (e.g., one input for a 1-D basis, N inputs for an N-D basis, or the sum of N 1-D bases), and raises a `ValueError` if this is not the case.
-3. In `"eval"` mode, calls the [`_evaluate`](nemos.basis._basis.Basis._evaluate) method on the input, which is the subclass-specific implementation of the basis set evaluation. In `"conv"` mode, generates a filter bank using [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) and then applies the convolution to the input with [`nemos.convolve.create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor).
+3. In `"eval"` mode, calls the `_evaluate` method on the input, which is the subclass-specific implementation of the basis set evaluation. In `"conv"` mode, generates a filter bank using [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) and then applies the convolution to the input with [`nemos.convolve.create_convolutional_predictor`](nemos.convolve.create_convolutional_predictor).
 4. Returns a NumPy array or  pynapple `TsdFrame` of shape `(M, n_basis_funcs)`, with each basis element evaluated at the samples.
 
 :::{admonition} Multiple epochs
@@ -61,14 +61,14 @@ This method performs the following steps:
 
 1. Checks that the number of inputs matches what the basis being evaluated expects (e.g., one input for a 1-D basis, N inputs for an N-D basis, or the sum of N 1-D bases), and raises a `ValueError` if this is not the case.
 2. Calls `_get_samples` method, which returns equidistant samples over the domain of the basis function. The domain may depend on the type of basis.
-3. Calls the [`_evaluate`](nemos.basis._basis.Basis._evaluate) method on these samples.
+3. Calls the `_evaluate` method on these samples.
 4. Returns both the sample grid points of shape `(m1, ..., mN)`, and the evaluation output at each grid point of shape `(m1, ..., mN, n_basis_funcs)`, where `mi` is the number of sample points for the i-th axis of the grid.
 
 ### Abstract Methods
 
 The [`nemos.basis._basis.Basis`](nemos.basis._basis.Basis) class has the following abstract methods, which every concrete subclass must implement:
 
-1. [`_evaluate`](nemos.basis._basis.Basis._evaluate) : Evaluates a basis over some specified samples.
+1. `_evaluate` : Evaluates a basis over some specified samples.
 2. `_check_n_basis_min`: Checks the minimum number of basis functions required. This requirement can be specific to the type of basis.
 
 ## Contributors Guidelines

--- a/docs/developers_notes/04-basis_module.md
+++ b/docs/developers_notes/04-basis_module.md
@@ -26,7 +26,7 @@ Abstract Class Basis
 └─ Concrete Subclass OrthExponentialBasis
 ```
 
-The super-class [`Basis`](nemos.basis._basis.Basis) provides two public methods, [`compute_features`](the-public-method-compute_features) and [`evaluate_on_grid`](the-public-method-evaluate_on_grid). These methods perform checks on both the input provided by the user and the output of the evaluation to ensure correctness, and are thus considered "safe". They both make use of the abstract method [`_evaluate`](nemos.basis._basis.Basis._evaluate) that is specific for each concrete class. See below for more details.
+The super-class [`Basis`](nemos.basis._basis.Basis) provides two public methods, [`compute_features`](the-public-method-compute_features) and [`evaluate_on_grid`](the-public-method-evaluate_on_grid). These methods perform checks on both the input provided by the user and the output of the evaluation to ensure correctness, and are thus considered "safe". They both make use of the abstract method `_evaluate` that is specific for each concrete class. See below for more details.
 
 ## The Class `nemos.basis._basis.Basis`
 
@@ -61,14 +61,14 @@ This method performs the following steps:
 
 1. Checks that the number of inputs matches what the basis being evaluated expects (e.g., one input for a 1-D basis, N inputs for an N-D basis, or the sum of N 1-D bases), and raises a `ValueError` if this is not the case.
 2. Calls `_get_samples` method, which returns equidistant samples over the domain of the basis function. The domain may depend on the type of basis.
-3. Calls the [`_evaluate`](nemos.basis._basis.Basis._evaluate) method.
+3. Calls the `_evaluate` method.
 4. Returns both the sample grid points of shape `(m1, ..., mN)`, and the evaluation output at each grid point of shape `(m1, ..., mN, n_basis_funcs)`, where `mi` is the number of sample points for the i-th axis of the grid.
 
 ### Abstract Methods
 
 The [`nemos.basis._basis.Basis`](nemos.basis._basis.Basis) class has the following abstract methods, which every concrete subclass must implement:
 
-1. [`_evaluate`](nemos.basis._basis.Basis._evaluate): Evaluates a basis over some specified samples.
+1. `_evaluate`: Evaluates a basis over some specified samples.
 2. `_check_n_basis_min`: Checks the minimum number of basis functions required. This requirement can be specific to the type of basis.
 
 ## Contributors Guidelines
@@ -77,7 +77,7 @@ The [`nemos.basis._basis.Basis`](nemos.basis._basis.Basis) class has the followi
 To write a usable (i.e., concrete, non-abstract) basis object, you
 
 - **Must** inherit the abstract superclass [`Basis`](nemos.basis._basis.Basis)
-- **Must** define the [`_evaluate`](nemos.basis._basis.Basis._evaluate) and `_check_n_basis_min` methods with the expected input/output format, see [API Reference](nemos_basis) for the specifics.
+- **Must** define the `_evaluate` and `_check_n_basis_min` methods with the expected input/output format, see [API Reference](nemos_basis) for the specifics.
 - **Should not** overwrite the [`compute_features`](nemos.basis._basis.Basis.compute_features) and [`compute_features`](nemos.basis._basis.Basis.evaluate_on_grid) methods inherited from [`Basis`](nemos.basis._basis.Basis).
 - **May** inherit any number of abstract intermediate classes (e.g., [`SplineBasis`](nemos.basis._spline_basis.SplineBasis)). 
 

--- a/docs/how_to_guide/plot_02_glm_demo.md
+++ b/docs/how_to_guide/plot_02_glm_demo.md
@@ -329,7 +329,7 @@ coupling_filter_bank *= 0.8
 
 # define a basis function
 n_basis_funcs = 20
-basis = nmo.basis.RaisedCosineBasisLog(n_basis_funcs)
+basis = nmo.basis.EvalRaisedCosineLog(n_basis_funcs)
 
 # approximate the coupling filters in terms of the basis function
 _, coupling_basis = basis.evaluate_on_grid(coupling_filter_bank.shape[0])

--- a/docs/how_to_guide/plot_02_glm_demo.md
+++ b/docs/how_to_guide/plot_02_glm_demo.md
@@ -329,7 +329,7 @@ coupling_filter_bank *= 0.8
 
 # define a basis function
 n_basis_funcs = 20
-basis = nmo.basis.EvalRaisedCosineLog(n_basis_funcs)
+basis = nmo.basis.RaisedCosineLogEval(n_basis_funcs)
 
 # approximate the coupling filters in terms of the basis function
 _, coupling_basis = basis.evaluate_on_grid(coupling_filter_bank.shape[0])

--- a/docs/how_to_guide/plot_04_batch_glm.md
+++ b/docs/how_to_guide/plot_04_batch_glm.md
@@ -106,7 +106,7 @@ Here we instantiate the basis. `ws` is 40 time bins. It corresponds to a 200 ms 
 
 ```{code-cell} ipython3
 ws = 40
-basis = nmo.basis.ConvRaisedCosineLog(5, window_size=ws)
+basis = nmo.basis.RaisedCosineLogConv(5, window_size=ws)
 ```
 
 ## Batch definition

--- a/docs/how_to_guide/plot_04_batch_glm.md
+++ b/docs/how_to_guide/plot_04_batch_glm.md
@@ -106,7 +106,7 @@ Here we instantiate the basis. `ws` is 40 time bins. It corresponds to a 200 ms 
 
 ```{code-cell} ipython3
 ws = 40
-basis = nmo.basis.RaisedCosineBasisLog(5, mode="conv", window_size=ws)
+basis = nmo.basis.ConvRaisedCosineLog(5, window_size=ws)
 ```
 
 ## Batch definition

--- a/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
+++ b/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
@@ -152,12 +152,18 @@ sns.despine(ax=ax)
 ### Converting NeMoS `Basis` to a transformer
 In order to use NeMoS [`Basis`](nemos.basis._basis.Basis) in a pipeline, we need to convert it into a scikit-learn transformer. This can be achieved through the [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) wrapper class.
 
-Instantiating a [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) can be done with [`Basis.to_transformer()`](nemos.basis._basis.Basis.to_transformer):
+Instantiating a [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) can be done either using by the constructor directly or with [`Basis.to_transformer()`](nemos.basis._basis.Basis.to_transformer):
 
 
 ```{code-cell} ipython3
 bas = nmo.basis.RaisedCosineLinearConv(5, window_size=5)
+
+# initalize using the constructor
+trans_bas = nmo.basis.TransformerBasis(bas)
+
+# equivalent initialization via "to_transformer"
 trans_bas = bas.to_transformer()
+
 ```
 
 [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) provides convenient access to the underlying [`Basis`](nemos.basis._basis.Basis) object's attributes:

--- a/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
+++ b/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
@@ -152,31 +152,29 @@ sns.despine(ax=ax)
 ### Converting NeMoS `Basis` to a transformer
 In order to use NeMoS [`Basis`](nemos.basis.Basis) in a pipeline, we need to convert it into a scikit-learn transformer. This can be achieved through the [`TransformerBasis`](nemos.basis.TransformerBasis) wrapper class.
 
-Instantiating a [`TransformerBasis`](nemos.basis.TransformerBasis) can be done either using the constructor directly or with [`Basis.to_transformer()`](nemos.basis.Basis.to_transformer):
+Instantiating a [`TransformerBasis`](nemos.basis.TransformerBasis) can be done with [`Basis.to_transformer()`](nemos.basis.Basis.to_transformer):
 
 
 ```{code-cell} ipython3
-bas = nmo.basis.RaisedCosineBasisLinear(5, mode="conv", window_size=5)
-# these two ways of creating the TransformerBasis are equivalent
-trans_bas_a = nmo.basis.TransformerBasis(bas)
-trans_bas_b = bas.to_transformer()
+bas = nmo.basis.ConvRaisedCosineLinear(5, window_size=5)
+trans_bas = bas.to_transformer()
 ```
 
 [`TransformerBasis`](nemos.basis.TransformerBasis) provides convenient access to the underlying [`Basis`](nemos.basis.Basis) object's attributes:
 
 
 ```{code-cell} ipython3
-print(bas.n_basis_funcs, trans_bas_a.n_basis_funcs, trans_bas_b.n_basis_funcs)
+print(bas.n_basis_funcs, trans_bas.n_basis_funcs)
 ```
 
 We can also set attributes of the underlying [`Basis`](nemos.basis.Basis). Note that -- because [`TransformerBasis`](nemos.basis.TransformerBasis) is created with a copy of the [`Basis`](nemos.basis.Basis) object passed to it -- this does not change the original [`Basis`](nemos.basis.Basis), and neither does changing the original [`Basis`](nemos.basis.Basis) change [`TransformerBasis`](nemos.basis.TransformerBasis) we created:
 
 
 ```{code-cell} ipython3
-trans_bas_a.n_basis_funcs = 10
+trans_bas.n_basis_funcs = 10
 bas.n_basis_funcs = 100
 
-print(bas.n_basis_funcs, trans_bas_a.n_basis_funcs, trans_bas_b.n_basis_funcs)
+print(bas.n_basis_funcs, trans_bas.n_basis_funcs)
 ```
 
 ### Creating and fitting a pipeline
@@ -190,7 +188,7 @@ pipeline = Pipeline(
     [
         (
             "transformerbasis",
-            nmo.basis.TransformerBasis(nmo.basis.RaisedCosineBasisLinear(6)),
+            nmo.basis.EvalRaisedCosineLinear(6).to_transformer(),
         ),
         (
             "glm",
@@ -326,7 +324,7 @@ scores = np.zeros((len(regularizer_strength) * len(n_basis_funcs), n_folds))
 coeffs = {}
 
 # initialize basis and model
-basis = nmo.basis.TransformerBasis(nmo.basis.RaisedCosineBasisLinear(6))
+basis = nmo.basis.TransformerBasis(nmo.basis.EvalRaisedCosineLinear(6))
 model = nmo.glm.GLM(regularizer="Ridge")
 
 # loop over combinations
@@ -453,12 +451,12 @@ Here we include `transformerbasis___basis` in the parameter grid to try differen
 param_grid = dict(
     glm__regularizer_strength=(0.1, 0.01, 0.001, 1e-6),
     transformerbasis___basis=(
-        nmo.basis.RaisedCosineBasisLinear(5),
-        nmo.basis.RaisedCosineBasisLinear(10),
-        nmo.basis.RaisedCosineBasisLog(5),
-        nmo.basis.RaisedCosineBasisLog(10),
-        nmo.basis.MSplineBasis(5),
-        nmo.basis.MSplineBasis(10),
+        nmo.basis.EvalRaisedCosineLinear(5),
+        nmo.basis.EvalRaisedCosineLinear(10),
+        nmo.basis.EvalRaisedCosineLog(5),
+        nmo.basis.EvalRaisedCosineLog(10),
+        nmo.basis.EvalMSpline(5),
+        nmo.basis.EvalMSpline(10),
     ),
 )
 ```
@@ -498,7 +496,7 @@ cvdf_wide = cvdf.pivot(
 doc_plots.plot_heatmap_cv_results(cvdf_wide)
 ```
 
-As shown in the table, the model with the highest score, highlighted in blue, used a RaisedCosineBasisLinear basis (as used above), which appears to be a suitable choice for our toy data. 
+As shown in the table, the model with the highest score, highlighted in blue, used a EvalRaisedCosineLinear basis (as used above), which appears to be a suitable choice for our toy data. 
 We can confirm that by plotting the firing rate predictions:
 
 
@@ -539,12 +537,12 @@ param_grid = dict(
     glm__regularizer_strength=(0.1, 0.01, 0.001, 1e-6),
     transformerbasis__n_basis_funcs=(3, 5, 10, 20, 100),
     transformerbasis___basis=(
-        nmo.basis.RaisedCosineBasisLinear(5),
-        nmo.basis.RaisedCosineBasisLinear(10),
-        nmo.basis.RaisedCosineBasisLog(5),
-        nmo.basis.RaisedCosineBasisLog(10),
-        nmo.basis.MSplineBasis(5),
-        nmo.basis.MSplineBasis(10),
+        nmo.basis.EvalRaisedCosineLinear(5),
+        nmo.basis.EvalRaisedCosineLinear(10),
+        nmo.basis.EvalRaisedCosineLog(5),
+        nmo.basis.EvalRaisedCosineLog(10),
+        nmo.basis.EvalMSpline(5),
+        nmo.basis.EvalMSpline(10),
     ),
 )
 ```

--- a/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
+++ b/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
@@ -152,7 +152,7 @@ sns.despine(ax=ax)
 ### Converting NeMoS `Basis` to a transformer
 In order to use NeMoS [`Basis`](nemos.basis._basis.Basis) in a pipeline, we need to convert it into a scikit-learn transformer. This can be achieved through the [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) wrapper class.
 
-Instantiating a [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) can be done with [`Basis.to_transformer()`](nemos.basis.Basis.to_transformer):
+Instantiating a [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) can be done with [`Basis.to_transformer()`](nemos.basis._basis.Basis.to_transformer):
 
 
 ```{code-cell} ipython3

--- a/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
+++ b/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
@@ -156,7 +156,7 @@ Instantiating a [`TransformerBasis`](nemos.basis._transformer_basis.TransformerB
 
 
 ```{code-cell} ipython3
-bas = nmo.basis.ConvRaisedCosineLinear(5, window_size=5)
+bas = nmo.basis.RaisedCosineLinearConv(5, window_size=5)
 trans_bas = bas.to_transformer()
 ```
 
@@ -188,7 +188,7 @@ pipeline = Pipeline(
     [
         (
             "transformerbasis",
-            nmo.basis.EvalRaisedCosineLinear(6).to_transformer(),
+            nmo.basis.RaisedCosineLinearEval(6).to_transformer(),
         ),
         (
             "glm",
@@ -324,7 +324,7 @@ scores = np.zeros((len(regularizer_strength) * len(n_basis_funcs), n_folds))
 coeffs = {}
 
 # initialize basis and model
-basis = nmo.basis.TransformerBasis(nmo.basis.EvalRaisedCosineLinear(6))
+basis = nmo.basis.TransformerBasis(nmo.basis.RaisedCosineLinearEval(6))
 model = nmo.glm.GLM(regularizer="Ridge")
 
 # loop over combinations
@@ -451,12 +451,12 @@ Here we include `transformerbasis___basis` in the parameter grid to try differen
 param_grid = dict(
     glm__regularizer_strength=(0.1, 0.01, 0.001, 1e-6),
     transformerbasis___basis=(
-        nmo.basis.EvalRaisedCosineLinear(5),
-        nmo.basis.EvalRaisedCosineLinear(10),
-        nmo.basis.EvalRaisedCosineLog(5),
-        nmo.basis.EvalRaisedCosineLog(10),
-        nmo.basis.EvalMSpline(5),
-        nmo.basis.EvalMSpline(10),
+        nmo.basis.RaisedCosineLinearEval(5),
+        nmo.basis.RaisedCosineLinearEval(10),
+        nmo.basis.RaisedCosineLogEval(5),
+        nmo.basis.RaisedCosineLogEval(10),
+        nmo.basis.MSplineEval(5),
+        nmo.basis.MSplineEval(10),
     ),
 )
 ```
@@ -496,7 +496,7 @@ cvdf_wide = cvdf.pivot(
 doc_plots.plot_heatmap_cv_results(cvdf_wide)
 ```
 
-As shown in the table, the model with the highest score, highlighted in blue, used a EvalRaisedCosineLinear basis (as used above), which appears to be a suitable choice for our toy data. 
+As shown in the table, the model with the highest score, highlighted in blue, used a RaisedCosineLinearEval basis (as used above), which appears to be a suitable choice for our toy data. 
 We can confirm that by plotting the firing rate predictions:
 
 
@@ -537,12 +537,12 @@ param_grid = dict(
     glm__regularizer_strength=(0.1, 0.01, 0.001, 1e-6),
     transformerbasis__n_basis_funcs=(3, 5, 10, 20, 100),
     transformerbasis___basis=(
-        nmo.basis.EvalRaisedCosineLinear(5),
-        nmo.basis.EvalRaisedCosineLinear(10),
-        nmo.basis.EvalRaisedCosineLog(5),
-        nmo.basis.EvalRaisedCosineLog(10),
-        nmo.basis.EvalMSpline(5),
-        nmo.basis.EvalMSpline(10),
+        nmo.basis.RaisedCosineLinearEval(5),
+        nmo.basis.RaisedCosineLinearEval(10),
+        nmo.basis.RaisedCosineLogEval(5),
+        nmo.basis.RaisedCosineLogEval(10),
+        nmo.basis.MSplineEval(5),
+        nmo.basis.MSplineEval(10),
     ),
 )
 ```

--- a/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
+++ b/docs/how_to_guide/plot_05_sklearn_pipeline_cv_demo.md
@@ -48,7 +48,7 @@ In particular, we will learn:
 
 1. What a scikit-learn pipeline is.
 2. Why pipelines are useful.
-3. How to combine NeMoS [`Basis`](nemos.basis.Basis) and [`GLM`](nemos.glm.GLM) objects in a pipeline.
+3. How to combine NeMoS [`Basis`](nemos.basis._basis.Basis) and [`GLM`](nemos.glm.GLM) objects in a pipeline.
 4. How to select the number of bases and the basis type through cross-validation (or any other hyperparameter in the pipeline).
 5. How to use a custom scoring metric to quantify the performance of each configuration.
 
@@ -150,9 +150,9 @@ sns.despine(ax=ax)
 ```
 
 ### Converting NeMoS `Basis` to a transformer
-In order to use NeMoS [`Basis`](nemos.basis.Basis) in a pipeline, we need to convert it into a scikit-learn transformer. This can be achieved through the [`TransformerBasis`](nemos.basis.TransformerBasis) wrapper class.
+In order to use NeMoS [`Basis`](nemos.basis._basis.Basis) in a pipeline, we need to convert it into a scikit-learn transformer. This can be achieved through the [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) wrapper class.
 
-Instantiating a [`TransformerBasis`](nemos.basis.TransformerBasis) can be done with [`Basis.to_transformer()`](nemos.basis.Basis.to_transformer):
+Instantiating a [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) can be done with [`Basis.to_transformer()`](nemos.basis.Basis.to_transformer):
 
 
 ```{code-cell} ipython3
@@ -160,14 +160,14 @@ bas = nmo.basis.ConvRaisedCosineLinear(5, window_size=5)
 trans_bas = bas.to_transformer()
 ```
 
-[`TransformerBasis`](nemos.basis.TransformerBasis) provides convenient access to the underlying [`Basis`](nemos.basis.Basis) object's attributes:
+[`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) provides convenient access to the underlying [`Basis`](nemos.basis._basis.Basis) object's attributes:
 
 
 ```{code-cell} ipython3
 print(bas.n_basis_funcs, trans_bas.n_basis_funcs)
 ```
 
-We can also set attributes of the underlying [`Basis`](nemos.basis.Basis). Note that -- because [`TransformerBasis`](nemos.basis.TransformerBasis) is created with a copy of the [`Basis`](nemos.basis.Basis) object passed to it -- this does not change the original [`Basis`](nemos.basis.Basis), and neither does changing the original [`Basis`](nemos.basis.Basis) change [`TransformerBasis`](nemos.basis.TransformerBasis) we created:
+We can also set attributes of the underlying [`Basis`](nemos.basis._basis.Basis). Note that -- because [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) is created with a copy of the [`Basis`](nemos.basis._basis.Basis) object passed to it -- this does not change the original [`Basis`](nemos.basis._basis.Basis), and neither does changing the original [`Basis`](nemos.basis._basis.Basis) change [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis) we created:
 
 
 ```{code-cell} ipython3
@@ -442,7 +442,7 @@ We are now able to capture the distribution of the firing rate appropriately: bo
 
 ### Evaluating different bases directly
 
-In the previous example we set the number of basis functions of the [`Basis`](nemos.basis.Basis) wrapped in our [`TransformerBasis`](nemos.basis.TransformerBasis). However, if we are for example not sure about the type of basis functions we want to use, or we have already defined some basis functions of our own, then we can use cross-validation to directly evaluate those as well.
+In the previous example we set the number of basis functions of the [`Basis`](nemos.basis._basis.Basis) wrapped in our [`TransformerBasis`](nemos.basis._transformer_basis.TransformerBasis). However, if we are for example not sure about the type of basis functions we want to use, or we have already defined some basis functions of our own, then we can use cross-validation to directly evaluate those as well.
 
 Here we include `transformerbasis___basis` in the parameter grid to try different values for `TransformerBasis._basis`:
 

--- a/docs/how_to_guide/plot_06_glm_pytree.md
+++ b/docs/how_to_guide/plot_06_glm_pytree.md
@@ -274,7 +274,7 @@ Okay, let's use unit number 7.
 Now let's set up our design matrix. First, let's fit the head direction by
 itself. Head direction is a circular variable (pi and -pi are adjacent to
 each other), so we need to use a basis that has this property as well.
-[`EvalCyclicBSpline`](nemos.basis.EvalCyclicBSpline) is one such basis.
+[`EvalCyclicBSpline`](nemos.basis.basis.EvalCyclicBSpline) is one such basis.
 
 Let's create our basis and then arrange our data properly.
 

--- a/docs/how_to_guide/plot_06_glm_pytree.md
+++ b/docs/how_to_guide/plot_06_glm_pytree.md
@@ -274,7 +274,7 @@ Okay, let's use unit number 7.
 Now let's set up our design matrix. First, let's fit the head direction by
 itself. Head direction is a circular variable (pi and -pi are adjacent to
 each other), so we need to use a basis that has this property as well.
-[`EvalCyclicBSpline`](nemos.basis.basis.EvalCyclicBSpline) is one such basis.
+[`CyclicBSplineEval`](nemos.basis.basis.CyclicBSplineEval) is one such basis.
 
 Let's create our basis and then arrange our data properly.
 
@@ -283,7 +283,7 @@ Let's create our basis and then arrange our data properly.
 unit_no = 7
 spikes = nwb['units'][unit_no]
 
-basis = nmo.basis.EvalCyclicBSpline(10, order=5)
+basis = nmo.basis.CyclicBSplineEval(10, order=5)
 x = np.linspace(-np.pi, np.pi, 100)
 plt.figure()
 plt.plot(x, basis(x))
@@ -351,7 +351,7 @@ our data similarly.
 
 
 ```{code-cell} ipython3
-pos_basis = nmo.basis.EvalRaisedCosineLinear(10) * nmo.basis.EvalRaisedCosineLinear(10)
+pos_basis = nmo.basis.RaisedCosineLinearEval(10) * nmo.basis.RaisedCosineLinearEval(10)
 spatial_pos = nwb['SpatialSeriesLED1'].restrict(valid_data)
 
 X['spatial_position'] = pos_basis(*spatial_pos.values.T)

--- a/docs/how_to_guide/plot_06_glm_pytree.md
+++ b/docs/how_to_guide/plot_06_glm_pytree.md
@@ -274,7 +274,7 @@ Okay, let's use unit number 7.
 Now let's set up our design matrix. First, let's fit the head direction by
 itself. Head direction is a circular variable (pi and -pi are adjacent to
 each other), so we need to use a basis that has this property as well.
-[`CyclicBSplineBasis`](nemos.basis.CyclicBSplineBasis) is one such basis.
+[`EvalCyclicBSpline`](nemos.basis.EvalCyclicBSpline) is one such basis.
 
 Let's create our basis and then arrange our data properly.
 
@@ -283,7 +283,7 @@ Let's create our basis and then arrange our data properly.
 unit_no = 7
 spikes = nwb['units'][unit_no]
 
-basis = nmo.basis.CyclicBSplineBasis(10, order=5)
+basis = nmo.basis.EvalCyclicBSpline(10, order=5)
 x = np.linspace(-np.pi, np.pi, 100)
 plt.figure()
 plt.plot(x, basis(x))
@@ -351,7 +351,7 @@ our data similarly.
 
 
 ```{code-cell} ipython3
-pos_basis = nmo.basis.RaisedCosineBasisLinear(10) * nmo.basis.RaisedCosineBasisLinear(10)
+pos_basis = nmo.basis.EvalRaisedCosineLinear(10) * nmo.basis.EvalRaisedCosineLinear(10)
 spatial_pos = nwb['SpatialSeriesLED1'].restrict(valid_data)
 
 X['spatial_position'] = pos_basis(*spatial_pos.values.T)

--- a/docs/how_to_guide/plot_06_glm_pytree.md
+++ b/docs/how_to_guide/plot_06_glm_pytree.md
@@ -274,7 +274,7 @@ Okay, let's use unit number 7.
 Now let's set up our design matrix. First, let's fit the head direction by
 itself. Head direction is a circular variable (pi and -pi are adjacent to
 each other), so we need to use a basis that has this property as well.
-[`CyclicBSplineEval`](nemos.basis.basis.CyclicBSplineEval) is one such basis.
+[`CyclicBSplineEval`](nemos.basis.CyclicBSplineEval) is one such basis.
 
 Let's create our basis and then arrange our data properly.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -165,7 +165,7 @@ you need to specify the number of basis functions. For some `basis` objects, add
 >>> import nemos as nmo
 
 >>> n_basis_funcs = 10
->>> basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs)
+>>> basis = nmo.basis.RaisedCosineLinearEval(n_basis_funcs)
 
 ```
 
@@ -205,7 +205,7 @@ number of sample points.
 
 >>> n_basis_funcs = 10
 >>> # define a filter bank of 10 basis function, 200 samples long.
->>> basis = nmo.basis.ConvBSpline(n_basis_funcs, window_size=200)
+>>> basis = nmo.basis.BSplineConv(n_basis_funcs, window_size=200)
 
 ```
 
@@ -350,7 +350,7 @@ You can download this dataset by clicking [here](https://www.dropbox.com/s/su4oa
 >>> upsampled_head_dir = head_dir.bin_average(0.01)  
 
 >>> # create your features
->>> X = nmo.basis.EvalCyclicBSpline(10).compute_features(upsampled_head_dir)
+>>> X = nmo.basis.CyclicBSplineEval(10).compute_features(upsampled_head_dir)
 
 >>> # add a neuron axis and fit model
 >>> model = nmo.glm.GLM().fit(X, counts) 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -165,7 +165,7 @@ you need to specify the number of basis functions. For some `basis` objects, add
 >>> import nemos as nmo
 
 >>> n_basis_funcs = 10
->>> basis = nmo.basis.RaisedCosineBasisLinear(n_basis_funcs)
+>>> basis = nmo.basis.EvalRaisedCosineLinear(n_basis_funcs)
 
 ```
 
@@ -205,7 +205,7 @@ number of sample points.
 
 >>> n_basis_funcs = 10
 >>> # define a filter bank of 10 basis function, 200 samples long.
->>> basis = nmo.basis.BSplineBasis(n_basis_funcs, mode="conv", window_size=200)
+>>> basis = nmo.basis.ConvBSpline(n_basis_funcs, window_size=200)
 
 ```
 
@@ -350,7 +350,7 @@ You can download this dataset by clicking [here](https://www.dropbox.com/s/su4oa
 >>> upsampled_head_dir = head_dir.bin_average(0.01)  
 
 >>> # create your features
->>> X = nmo.basis.CyclicBSplineBasis(10).compute_features(upsampled_head_dir)
+>>> X = nmo.basis.EvalCyclicBSpline(10).compute_features(upsampled_head_dir)
 
 >>> # add a neuron axis and fit model
 >>> model = nmo.glm.GLM().fit(X, counts) 

--- a/docs/tutorials/plot_01_current_injection.md
+++ b/docs/tutorials/plot_01_current_injection.md
@@ -446,7 +446,7 @@ following properties:
 :::{admonition} What is jax?
 :class: note
 
-[jax](https://github.com/google/jax) is a Google-supported python library
+[jax](https://github.com/jax-ml/jax) is a Google-supported python library
 for automatic differentiation. It has all sorts of neat features, but the
 most relevant of which for NeMoS is its GPU-compatibility and
 just-in-time compilation (both of which make code faster with little

--- a/docs/tutorials/plot_01_current_injection.md
+++ b/docs/tutorials/plot_01_current_injection.md
@@ -357,7 +357,7 @@ if you are interested.
 :::
 
 ```{code-cell} ipython3
-doc_plots.current_injection_plot(current, spikes, firing_rate)
+doc_plots.current_injection_plot(current, spikes, firing_rate);
 ```
 
 So now that we can view the details of our experiment a little more clearly,

--- a/docs/tutorials/plot_02_head_direction.md
+++ b/docs/tutorials/plot_02_head_direction.md
@@ -419,8 +419,8 @@ the cost of adding additional parameters.
 
 ```{code-cell} ipython3
 # a basis object can be instantiated in "conv" mode for convolving  the input.
-basis = nmo.basis.RaisedCosineBasisLog(
-    n_basis_funcs=8, mode="conv", window_size=window_size
+basis = nmo.basis.ConvRaisedCosineLog(
+    n_basis_funcs=8, window_size=window_size
 )
 
 # `basis.evaluate_on_grid` is a convenience method to view all basis functions
@@ -600,8 +600,8 @@ to get an array of predictors of shape, `(num_time_points, num_neurons * num_bas
 
 ```{code-cell} ipython3
 # re-initialize basis
-basis = nmo.basis.RaisedCosineBasisLog(
-    n_basis_funcs=8, mode="conv", window_size=window_size
+basis = nmo.basis.ConvRaisedCosineLog(
+    n_basis_funcs=8, window_size=window_size
 )
 
 # convolve all the neurons

--- a/docs/tutorials/plot_02_head_direction.md
+++ b/docs/tutorials/plot_02_head_direction.md
@@ -419,7 +419,7 @@ the cost of adding additional parameters.
 
 ```{code-cell} ipython3
 # a basis object can be instantiated in "conv" mode for convolving  the input.
-basis = nmo.basis.ConvRaisedCosineLog(
+basis = nmo.basis.RaisedCosineLogConv(
     n_basis_funcs=8, window_size=window_size
 )
 
@@ -600,7 +600,7 @@ to get an array of predictors of shape, `(num_time_points, num_neurons * num_bas
 
 ```{code-cell} ipython3
 # re-initialize basis
-basis = nmo.basis.ConvRaisedCosineLog(
+basis = nmo.basis.RaisedCosineLogConv(
     n_basis_funcs=8, window_size=window_size
 )
 

--- a/docs/tutorials/plot_03_grid_cells.md
+++ b/docs/tutorials/plot_03_grid_cells.md
@@ -146,9 +146,9 @@ We can define a two-dimensional basis for position by multiplying two one-dimens
 see [here](../../background/plot_02_ND_basis_function) for more details.
 
 ```{code-cell} ipython3
-basis_2d = nmo.basis.EvalRaisedCosineLinear(
+basis_2d = nmo.basis.RaisedCosineLinearEval(
     n_basis_funcs=10
-) * nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=10)
+) * nmo.basis.RaisedCosineLinearEval(n_basis_funcs=10)
 ```
 
 Let's see what a few basis look like. Here we evaluate it on a 100 x 100 grid.

--- a/docs/tutorials/plot_03_grid_cells.md
+++ b/docs/tutorials/plot_03_grid_cells.md
@@ -175,7 +175,7 @@ Now we can "evaluate" the basis for each position of the animal
 
 
 ```{code-cell} ipython3
-position_basis = basis_2d(position["x"], position["y"])
+position_basis = basis_2d.compute_features(position["x"], position["y"])
 ```
 
 Now try to make sense of what it is

--- a/docs/tutorials/plot_03_grid_cells.md
+++ b/docs/tutorials/plot_03_grid_cells.md
@@ -143,7 +143,7 @@ position = position.interpolate(counts)
 ```
 
 We can define a two-dimensional basis for position by multiplying two one-dimensional bases,
-see [here](../../background/plot_02_ND_basis_function) for more details.
+see [here](composing_basis_function) for more details.
 
 ```{code-cell} ipython3
 basis_2d = nmo.basis.RaisedCosineLinearEval(

--- a/docs/tutorials/plot_03_grid_cells.md
+++ b/docs/tutorials/plot_03_grid_cells.md
@@ -146,9 +146,9 @@ We can define a two-dimensional basis for position by multiplying two one-dimens
 see [here](../../background/plot_02_ND_basis_function) for more details.
 
 ```{code-cell} ipython3
-basis_2d = nmo.basis.RaisedCosineBasisLinear(
+basis_2d = nmo.basis.EvalRaisedCosineLinear(
     n_basis_funcs=10
-) * nmo.basis.RaisedCosineBasisLinear(n_basis_funcs=10)
+) * nmo.basis.EvalRaisedCosineLinear(n_basis_funcs=10)
 ```
 
 Let's see what a few basis look like. Here we evaluate it on a 100 x 100 grid.

--- a/docs/tutorials/plot_04_v1_cells.md
+++ b/docs/tutorials/plot_04_v1_cells.md
@@ -345,7 +345,7 @@ GLM:
 
 ```{code-cell} ipython3
 window_size = 100
-basis = nmo.basis.ConvRaisedCosineLog(8, window_size=window_size)
+basis = nmo.basis.RaisedCosineLogConv(8, window_size=window_size)
 
 convolved_input = basis.compute_features(filtered_stimulus)
 ```

--- a/docs/tutorials/plot_04_v1_cells.md
+++ b/docs/tutorials/plot_04_v1_cells.md
@@ -345,7 +345,7 @@ GLM:
 
 ```{code-cell} ipython3
 window_size = 100
-basis = nmo.basis.ConvRaisedCosineLog(8 window_size=window_size)
+basis = nmo.basis.ConvRaisedCosineLog(8, window_size=window_size)
 
 convolved_input = basis.compute_features(filtered_stimulus)
 ```

--- a/docs/tutorials/plot_04_v1_cells.md
+++ b/docs/tutorials/plot_04_v1_cells.md
@@ -345,7 +345,7 @@ GLM:
 
 ```{code-cell} ipython3
 window_size = 100
-basis = nmo.basis.RaisedCosineBasisLog(8, mode="conv", window_size=window_size)
+basis = nmo.basis.ConvRaisedCosineLog(8 window_size=window_size)
 
 convolved_input = basis.compute_features(filtered_stimulus)
 ```

--- a/docs/tutorials/plot_05_place_cells.md
+++ b/docs/tutorials/plot_05_place_cells.md
@@ -335,15 +335,15 @@ print(count.shape)
 
 For each feature, we will use a different set of basis :
 
-  -   position : [`MSplineBasis`](nemos.basis.MSplineBasis)
-  -   theta phase : [`CyclicBSplineBasis`](nemos.basis.CyclicBSplineBasis)
-  -   speed : [`MSplineBasis`](nemos.basis.MSplineBasis)
+  -   position : [`EvalMSpline`](nemos.basis.EvalMSpline)
+  -   theta phase : [`EvalCyclicBSpline`](nemos.basis.EvalCyclicBSpline)
+  -   speed : [`EvalMSpline`](nemos.basis.EvalMSpline)
 
 
 ```{code-cell} ipython3
-position_basis = nmo.basis.MSplineBasis(n_basis_funcs=10)
-phase_basis = nmo.basis.CyclicBSplineBasis(n_basis_funcs=12)
-speed_basis = nmo.basis.MSplineBasis(n_basis_funcs=15)
+position_basis = nmo.basis.EvalMSpline(n_basis_funcs=10)
+phase_basis = nmo.basis.EvalCyclicBSpline(n_basis_funcs=12)
+speed_basis = nmo.basis.EvalMSpline(n_basis_funcs=15)
 ```
 
 In addition, we will consider position and phase to be a joint variable. In NeMoS, we can combine basis by multiplying them and adding them. In this case the final basis object for our model can be made in one line :

--- a/docs/tutorials/plot_05_place_cells.md
+++ b/docs/tutorials/plot_05_place_cells.md
@@ -357,7 +357,7 @@ The object basis only tell us how each basis covers the feature space. For each 
 
 
 ```{code-cell} ipython3
-X = basis(position, theta, speed)
+X = basis.compute_features(position, theta, speed)
 ```
 
 `X` is our design matrix. For each timestamps, it contains the information about the current position,
@@ -455,7 +455,7 @@ predicted_rates = {}
 
 for m in models:
     print("1. Evaluating basis : ", m)
-    X = models[m](*features[m])
+    X = models[m].compute_features(*features[m])
 
     print("2. Fitting model : ", m)
     glm.fit(

--- a/docs/tutorials/plot_05_place_cells.md
+++ b/docs/tutorials/plot_05_place_cells.md
@@ -335,9 +335,9 @@ print(count.shape)
 
 For each feature, we will use a different set of basis :
 
-  -   position : [`MSplineEval`](nemos.basis.basis.MSplineEval)
-  -   theta phase : [`CyclicBSplineEval`](nemos.basis.basis.CyclicBSplineEval)
-  -   speed : [`MSplineEval`](nemos.basis.basis.MSplineEval)
+  -   position : [`MSplineEval`](nemos.basis.MSplineEval)
+  -   theta phase : [`CyclicBSplineEval`](nemos.basis.CyclicBSplineEval)
+  -   speed : [`MSplineEval`](nemos.basis.MSplineEval)
 
 
 ```{code-cell} ipython3

--- a/docs/tutorials/plot_05_place_cells.md
+++ b/docs/tutorials/plot_05_place_cells.md
@@ -335,15 +335,15 @@ print(count.shape)
 
 For each feature, we will use a different set of basis :
 
-  -   position : [`EvalMSpline`](nemos.basis.basis.EvalMSpline)
-  -   theta phase : [`EvalCyclicBSpline`](nemos.basis.basis.EvalCyclicBSpline)
-  -   speed : [`EvalMSpline`](nemos.basis.basis.EvalMSpline)
+  -   position : [`MSplineEval`](nemos.basis.basis.MSplineEval)
+  -   theta phase : [`CyclicBSplineEval`](nemos.basis.basis.CyclicBSplineEval)
+  -   speed : [`MSplineEval`](nemos.basis.basis.MSplineEval)
 
 
 ```{code-cell} ipython3
-position_basis = nmo.basis.EvalMSpline(n_basis_funcs=10)
-phase_basis = nmo.basis.EvalCyclicBSpline(n_basis_funcs=12)
-speed_basis = nmo.basis.EvalMSpline(n_basis_funcs=15)
+position_basis = nmo.basis.MSplineEval(n_basis_funcs=10)
+phase_basis = nmo.basis.CyclicBSplineEval(n_basis_funcs=12)
+speed_basis = nmo.basis.MSplineEval(n_basis_funcs=15)
 ```
 
 In addition, we will consider position and phase to be a joint variable. In NeMoS, we can combine basis by multiplying them and adding them. In this case the final basis object for our model can be made in one line :

--- a/docs/tutorials/plot_05_place_cells.md
+++ b/docs/tutorials/plot_05_place_cells.md
@@ -335,9 +335,9 @@ print(count.shape)
 
 For each feature, we will use a different set of basis :
 
-  -   position : [`EvalMSpline`](nemos.basis.EvalMSpline)
-  -   theta phase : [`EvalCyclicBSpline`](nemos.basis.EvalCyclicBSpline)
-  -   speed : [`EvalMSpline`](nemos.basis.EvalMSpline)
+  -   position : [`EvalMSpline`](nemos.basis.basis.EvalMSpline)
+  -   theta phase : [`EvalCyclicBSpline`](nemos.basis.basis.EvalCyclicBSpline)
+  -   speed : [`EvalMSpline`](nemos.basis.basis.EvalMSpline)
 
 
 ```{code-cell} ipython3

--- a/docs/tutorials/plot_06_calcium_imaging.md
+++ b/docs/tutorials/plot_06_calcium_imaging.md
@@ -180,8 +180,8 @@ We can combine the two bases.
 
 
 ```{code-cell} ipython3
-heading_basis = nmo.basis.CyclicBSplineBasis(n_basis_funcs=12)
-coupling_basis = nmo.basis.RaisedCosineBasisLog(3, mode="conv", window_size=10)
+heading_basis = nmo.basis.EvalCyclicBSpline(n_basis_funcs=12)
+coupling_basis = nmo.basis.ConvRaisedCosineLog(3, window_size=10)
 ```
 
 We need to make sure the design matrix will be full-rank by applying identifiability constraints to the Cyclic Bspline, and then combine the bases (the resturned object will be an [`AdditiveBasis`](nemos.basis.AdditiveBasis) object).

--- a/docs/tutorials/plot_06_calcium_imaging.md
+++ b/docs/tutorials/plot_06_calcium_imaging.md
@@ -180,8 +180,8 @@ We can combine the two bases.
 
 
 ```{code-cell} ipython3
-heading_basis = nmo.basis.EvalCyclicBSpline(n_basis_funcs=12)
-coupling_basis = nmo.basis.ConvRaisedCosineLog(3, window_size=10)
+heading_basis = nmo.basis.CyclicBSplineEval(n_basis_funcs=12)
+coupling_basis = nmo.basis.RaisedCosineLogConv(3, window_size=10)
 ```
 
 We need to make sure the design matrix will be full-rank by applying identifiability constraints to the Cyclic Bspline, and then combine the bases (the resturned object will be an [`AdditiveBasis`](nemos.basis._basis.AdditiveBasis) object).

--- a/docs/tutorials/plot_06_calcium_imaging.md
+++ b/docs/tutorials/plot_06_calcium_imaging.md
@@ -184,7 +184,7 @@ heading_basis = nmo.basis.EvalCyclicBSpline(n_basis_funcs=12)
 coupling_basis = nmo.basis.ConvRaisedCosineLog(3, window_size=10)
 ```
 
-We need to make sure the design matrix will be full-rank by applying identifiability constraints to the Cyclic Bspline, and then combine the bases (the resturned object will be an [`AdditiveBasis`](nemos.basis.AdditiveBasis) object).
+We need to make sure the design matrix will be full-rank by applying identifiability constraints to the Cyclic Bspline, and then combine the bases (the resturned object will be an [`AdditiveBasis`](nemos.basis._basis.AdditiveBasis) object).
 
 
 ```{code-cell} ipython3

--- a/src/nemos/_documentation_utils/plotting.py
+++ b/src/nemos/_documentation_utils/plotting.py
@@ -33,7 +33,7 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.patches import Rectangle
 from numpy.typing import NDArray
 
-from ..basis import RaisedCosineBasisLog
+from ..basis import EvalRaisedCosineLog
 
 warnings.warn(
     "plotting functions contained within `_documentation_utils` are intended for nemos's documentation. "
@@ -682,7 +682,7 @@ def plot_rates_and_smoothed_counts(
 
 def plot_basis(n_basis_funcs=8, window_size_sec=0.8):
     fig = plt.figure()
-    basis = RaisedCosineBasisLog(n_basis_funcs=n_basis_funcs)
+    basis = EvalRaisedCosineLog(n_basis_funcs=n_basis_funcs)
     time, basis_kernels = basis.evaluate_on_grid(1000)
     time *= window_size_sec
     plt.plot(time, basis_kernels)

--- a/src/nemos/_documentation_utils/plotting.py
+++ b/src/nemos/_documentation_utils/plotting.py
@@ -33,7 +33,7 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.patches import Rectangle
 from numpy.typing import NDArray
 
-from ..basis import EvalRaisedCosineLog
+from ..basis import RaisedCosineLogEval
 
 warnings.warn(
     "plotting functions contained within `_documentation_utils` are intended for nemos's documentation. "
@@ -682,7 +682,7 @@ def plot_rates_and_smoothed_counts(
 
 def plot_basis(n_basis_funcs=8, window_size_sec=0.8):
     fig = plt.figure()
-    basis = EvalRaisedCosineLog(n_basis_funcs=n_basis_funcs)
+    basis = RaisedCosineLogEval(n_basis_funcs=n_basis_funcs)
     time, basis_kernels = basis.evaluate_on_grid(1000)
     time *= window_size_sec
     plt.plot(time, basis_kernels)

--- a/src/nemos/basis/__init__.py
+++ b/src/nemos/basis/__init__.py
@@ -1,18 +1,16 @@
-from ._basis import AdditiveBasis, Basis, MultiplicativeBasis
-from ._raised_cosine_basis import RaisedCosineBasisLinear, RaisedCosineBasisLog
-from ._spline_basis import BSplineBasis
+from ._basis import AdditiveBasis, MultiplicativeBasis
 from ._transformer_basis import TransformerBasis
 from .basis import (
-    ConvBSpline,
-    ConvCyclicBSpline,
-    ConvMSpline,
-    ConvOrthExponential,
-    ConvRaisedCosineLinear,
-    ConvRaisedCosineLog,
-    EvalBSpline,
-    EvalCyclicBSpline,
-    EvalMSpline,
-    EvalOrthExponential,
-    EvalRaisedCosineLinear,
-    EvalRaisedCosineLog,
+    BSplineConv,
+    BSplineEval,
+    CyclicBSplineConv,
+    CyclicBSplineEval,
+    MSplineConv,
+    MSplineEval,
+    OrthExponentialConv,
+    OrthExponentialEval,
+    RaisedCosineLinearConv,
+    RaisedCosineLinearEval,
+    RaisedCosineLogConv,
+    RaisedCosineLogEval,
 )

--- a/src/nemos/basis/__init__.py
+++ b/src/nemos/basis/__init__.py
@@ -1,6 +1,7 @@
 from ._basis import AdditiveBasis, Basis, MultiplicativeBasis
 from ._raised_cosine_basis import RaisedCosineBasisLinear, RaisedCosineBasisLog
 from ._spline_basis import BSplineBasis
+from ._transformer_basis import TransformerBasis
 from .basis import (
     ConvBSpline,
     ConvCyclicBSpline,

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -550,9 +550,6 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Calculate and return the slicing for features based on the input structure.
 
         This method determines how to slice the features for different basis types.
-        If the instance is of ``AdditiveBasis`` type, the slicing is calculated recursively
-        for each component basis. Otherwise, it determines the slicing based on
-        the number of basis functions and ``split_by_input`` flag.
 
         Parameters
         ----------

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -683,6 +683,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         -------
         dict
             A dictionary where:
+
             - **Key**: Label of the basis.
             - **Value**: the array reshaped to: ``(..., n_inputs, n_basis_funcs, ...)``
         """
@@ -1039,6 +1040,7 @@ class AdditiveBasis(Basis):
         -------
         dict
             A dictionary where:
+
             - **Keys**: Labels of the additive basis components.
             - **Values**: Sub-arrays corresponding to each component. Each sub-array has the shape:
 

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -51,6 +51,7 @@ def check_transform_input(func: Callable) -> Callable:
 
 def check_one_dimensional(func: Callable) -> Callable:
     """Check if the input is one-dimensional."""
+
     @wraps(func)
     def wrapper(self: Basis, *xi: ArrayLike, **kwargs):
         if any(x.ndim != 1 for x in xi):

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -9,7 +9,7 @@ from typing import Callable, Generator, Literal, Optional, Tuple, Union
 import jax
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from pynapple import Tsd, TsdFrame
+from pynapple import Tsd, TsdFrame, TsdTensor
 
 from ..base_class import Base
 from ..type_casting import support_pynapple
@@ -242,13 +242,13 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         return X
 
     @check_transform_input
-    def compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
+    def compute_features(self, *xi: ArrayLike | Tsd | TsdFrame |  TsdTensor) -> FeatureMatrix:
         """
         Apply the basis transformation to the input data.
 
         This method is designed to be a high-level interface for transforming input
         data using the basis functions defined by the subclass. Depending on the basis'
-        mode ('eval' or 'conv'), it either evaluates the basis functions at the sample
+        mode ('Eval' or 'Conv'), it either evaluates the basis functions at the sample
         points or performs a convolution operation between the input data and the
         basis functions.
 
@@ -256,7 +256,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         ----------
         *xi :
             Input data arrays to be transformed. The shape and content requirements
-            depend on the subclass and mode of operation ('eval' or 'conv').
+            depend on the subclass and mode of operation ('Eval' or 'Conv').
 
         Returns
         -------
@@ -276,7 +276,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         return self._compute_features(*xi)
 
     @abc.abstractmethod
-    def _compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
+    def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """Convolve or evaluate the basis."""
         pass
 
@@ -286,7 +286,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         pass
 
     @abc.abstractmethod
-    def _evaluate(self, *xi: ArrayLike) -> FeatureMatrix:
+    def _evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Abstract method to evaluate the basis functions at given points.
 
@@ -579,36 +579,13 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         n_inputs = n_inputs or self._n_basis_input
         start_slice = start_slice or 0
 
-        # If the instance is of AdditiveBasis type, handle slicing for the additive components
-        if isinstance(self, AdditiveBasis):
-            split_dict, start_slice = self._basis1._get_feature_slicing(
-                n_inputs[: len(self._basis1._n_basis_input)],
-                start_slice,
-                split_by_input=split_by_input,
-            )
-            sp2, start_slice = self._basis2._get_feature_slicing(
-                n_inputs[len(self._basis1._n_basis_input) :],
-                start_slice,
-                split_by_input=split_by_input,
-            )
-            split_dict = self._merge_slicing_dicts(split_dict, sp2)
-        else:
-            # Handle the default case for other basis types
-            split_dict, start_slice = self._get_default_slicing(
-                split_by_input, start_slice
-            )
+        # Handle the default case for non-additive basis types
+        # See overwritten method for recursion logic
+        split_dict, start_slice = self._get_default_slicing(
+            split_by_input=split_by_input, start_slice=start_slice
+        )
 
         return split_dict, start_slice
-
-    def _merge_slicing_dicts(self, dict1: dict, dict2: dict) -> dict:
-        """Merge two slicing dictionaries, handling key conflicts."""
-        for key, val in dict2.items():
-            if key in dict1:
-                new_key = self._generate_unique_key(dict1, key)
-                dict1[new_key] = val
-            else:
-                dict1[key] = val
-        return dict1
 
     @staticmethod
     def _generate_unique_key(existing_dict: dict, key: str) -> str:
@@ -884,7 +861,7 @@ class AdditiveBasis(Basis):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, *xi: ArrayLike) -> FeatureMatrix:
+    def _evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Evaluate the basis at the input samples.
 
@@ -924,7 +901,7 @@ class AdditiveBasis(Basis):
         return X
 
     @add_docstring("compute_features", Basis)
-    def compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
+    def compute_features(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         r"""
         Examples
         --------
@@ -941,7 +918,7 @@ class AdditiveBasis(Basis):
         """
         return super().compute_features(*xi)
 
-    def _compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
+    def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Compute features for added bases and concatenate.
 
@@ -1159,6 +1136,70 @@ class AdditiveBasis(Basis):
         """
         return super().evaluate_on_grid(*n_samples)
 
+    def _get_feature_slicing(
+        self,
+        n_inputs: Optional[tuple] = None,
+        start_slice: Optional[int] = None,
+        split_by_input: bool = True,
+    ) -> Tuple[dict, int]:
+        """
+        Calculate and return the slicing for features based on the input structure.
+
+        This method determines how to slice the features for different basis types.
+
+        Parameters
+        ----------
+        n_inputs :
+            The number of input basis for each component, by default it uses ``self._n_basis_input``.
+        start_slice :
+            The starting index for slicing, by default it starts from 0.
+        split_by_input :
+            Flag indicating whether to split the slicing by individual inputs or not.
+            If ``False``, a single slice is generated for all inputs.
+
+        Returns
+        -------
+        split_dict :
+            Dictionary with keys as labels and values as slices representing
+            the slicing for each input or additive component, if split_by_input equals to
+            True or False respectively.
+        start_slice :
+            The updated starting index after slicing.
+
+        See Also
+        --------
+        _get_default_slicing : Handles default slicing logic.
+        _merge_slicing_dicts : Merges multiple slicing dictionaries, handling keys conflicts.
+        """
+        # Set default values for n_inputs and start_slice if not provided
+        n_inputs = n_inputs or self._n_basis_input
+        start_slice = start_slice or 0
+
+        # If the instance is of AdditiveBasis type, handle slicing for the additive components
+
+        split_dict, start_slice = self._basis1._get_feature_slicing(
+            n_inputs[: len(self._basis1._n_basis_input)],
+            start_slice,
+            split_by_input=split_by_input,
+        )
+        sp2, start_slice = self._basis2._get_feature_slicing(
+            n_inputs[len(self._basis1._n_basis_input) :],
+            start_slice,
+            split_by_input=split_by_input,
+        )
+        split_dict = self._merge_slicing_dicts(split_dict, sp2)
+        return split_dict, start_slice
+
+    def _merge_slicing_dicts(self, dict1: dict, dict2: dict) -> dict:
+        """Merge two slicing dictionaries, handling key conflicts."""
+        for key, val in dict2.items():
+            if key in dict1:
+                new_key = self._generate_unique_key(dict1, key)
+                dict1[new_key] = val
+            else:
+                dict1[key] = val
+        return dict1
+
 
 class MultiplicativeBasis(Basis):
     """
@@ -1205,7 +1246,6 @@ class MultiplicativeBasis(Basis):
         self._label = "(" + basis1.label + " * " + basis2.label + ")"
         self._basis1 = basis1
         self._basis2 = basis2
-        BasisTransformerMixin.__init__(self)
 
     def _check_n_basis_min(self) -> None:
         pass
@@ -1232,7 +1272,7 @@ class MultiplicativeBasis(Basis):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, *xi: ArrayLike) -> FeatureMatrix:
+    def _evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Evaluate the basis at the input samples.
 
@@ -1264,7 +1304,7 @@ class MultiplicativeBasis(Basis):
         )
         return X
 
-    def _compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
+    def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Compute the features for the multiplied bases, and compute their outer product.
 
@@ -1357,7 +1397,7 @@ class MultiplicativeBasis(Basis):
         return super().evaluate_on_grid(*n_samples)
 
     @add_docstring("compute_features", Basis)
-    def compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
+    def compute_features(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Examples
         --------

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -98,7 +98,7 @@ def min_max_rescale_samples(
     return sample_pts, scaling
 
 
-class Basis(Base, abc.ABC):
+class Basis(Base, abc.ABC, BasisTransformerMixin):
     """
     Abstract base class for defining basis functions for feature transformation.
 
@@ -824,7 +824,7 @@ add_docstring_additive = partial(add_docstring, cls=Basis)
 add_docstring_multiplicative = partial(add_docstring, cls=Basis)
 
 
-class AdditiveBasis(Basis, BasisTransformerMixin):
+class AdditiveBasis(Basis):
     """
     Class representing the addition of two Basis objects.
 
@@ -869,7 +869,6 @@ class AdditiveBasis(Basis, BasisTransformerMixin):
         self._label = "(" + basis1.label + " + " + basis2.label + ")"
         self._basis1 = basis1
         self._basis2 = basis2
-        BasisTransformerMixin.__init__(self)
 
     def _set_num_output_features(self, *xi: NDArray) -> Basis:
         self._n_basis_input = (
@@ -1167,7 +1166,7 @@ class AdditiveBasis(Basis, BasisTransformerMixin):
         return super().evaluate_on_grid(*n_samples)
 
 
-class MultiplicativeBasis(Basis, BasisTransformerMixin):
+class MultiplicativeBasis(Basis):
     """
     Class representing the multiplication (external product) of two Basis objects.
 

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import abc
 import copy
-from functools import wraps, partial
+from functools import partial, wraps
 from typing import Callable, Generator, Literal, Optional, Tuple, Union
 
 import jax

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -242,7 +242,9 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         return X
 
     @check_transform_input
-    def compute_features(self, *xi: ArrayLike | Tsd | TsdFrame |  TsdTensor) -> FeatureMatrix:
+    def compute_features(
+        self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         """
         Apply the basis transformation to the input data.
 
@@ -276,7 +278,9 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         return self._compute_features(*xi)
 
     @abc.abstractmethod
-    def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def _compute_features(
+        self, *xi: NDArray | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         """Convolve or evaluate the basis."""
         pass
 
@@ -901,7 +905,9 @@ class AdditiveBasis(Basis):
         return X
 
     @add_docstring("compute_features", Basis)
-    def compute_features(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def compute_features(
+        self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         r"""
         Examples
         --------
@@ -918,7 +924,9 @@ class AdditiveBasis(Basis):
         """
         return super().compute_features(*xi)
 
-    def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def _compute_features(
+        self, *xi: NDArray | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         """
         Compute features for added bases and concatenate.
 
@@ -1304,7 +1312,9 @@ class MultiplicativeBasis(Basis):
         )
         return X
 
-    def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def _compute_features(
+        self, *xi: NDArray | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         """
         Compute the features for the multiplied bases, and compute their outer product.
 
@@ -1397,7 +1407,9 @@ class MultiplicativeBasis(Basis):
         return super().evaluate_on_grid(*n_samples)
 
     @add_docstring("compute_features", Basis)
-    def compute_features(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def compute_features(
+        self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         """
         Examples
         --------

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -20,6 +20,7 @@ from ._basis_mixin import BasisTransformerMixin
 
 
 def add_docstring(method_name, cls=None):
+    """Prepend super-class docstrings."""
     attr = getattr(cls, method_name, None)
     if attr is None:
         raise AttributeError(f"{cls.__name__} has no attribute {method_name}!")
@@ -49,6 +50,7 @@ def check_transform_input(func: Callable) -> Callable:
 
 
 def check_one_dimensional(func: Callable) -> Callable:
+    """Check if the input is one-dimensional."""
     @wraps(func)
     def wrapper(self: Basis, *xi: ArrayLike, **kwargs):
         if any(x.ndim != 1 for x in xi):

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -104,6 +104,9 @@ class ConvBasisMixin:
             as multiple arguments, each representing a different dimension for multivariate inputs.
 
         """
+        if self.kernel_ is None:
+            raise ValueError("You must call `_set_kernel` before `_compute_features`! "
+                             "Convolution kernel is not set.")
         # before calling the convolve, check that the input matches
         # the expectation. We can check xi[0] only, since convolution
         # is applied at the end of the recursion on the 1D basis, ensuring len(xi) == 1.

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -1,4 +1,5 @@
 """Mixin classes for basis."""
+
 from __future__ import annotations
 
 import copy

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -12,6 +12,7 @@ from ._transformer_basis import TransformerBasis
 
 
 class EvalBasisMixin:
+    """Mixin class for evaluational basis."""
 
     def __init__(self, bounds: Optional[Tuple[float, float]] = None):
         self.bounds = bounds
@@ -80,6 +81,7 @@ class EvalBasisMixin:
 
 
 class ConvBasisMixin:
+    """Mixin class for convolutional basis."""
 
     def __init__(self, window_size: int, conv_kwargs: Optional[dict] = None):
         self.window_size = window_size
@@ -153,7 +155,6 @@ class ConvBasisMixin:
     @window_size.setter
     def window_size(self, window_size):
         """Setter for the window size parameter."""
-
         if window_size is None:
             raise ValueError(
                 "If the basis is in `conv` mode, you must provide a window_size!"
@@ -225,7 +226,7 @@ class ConvBasisMixin:
 
 
 class BasisTransformerMixin:
-    """Mixin class for constructing a transformer"""
+    """Mixin class for constructing a transformer."""
 
     def to_transformer(self) -> TransformerBasis:
         """

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -81,8 +81,7 @@ class ConvBasisMixin:
 
     def __init__(self, window_size: int, conv_kwargs: Optional[dict] = None):
         self.window_size = window_size
-        self._conv_kwargs = {} if conv_kwargs is None else conv_kwargs
-        self._check_convolution_kwargs()
+        self.conv_kwargs = {} if conv_kwargs is None else conv_kwargs
 
     def _compute_features(self, *xi: ArrayLike):
         """
@@ -171,7 +170,14 @@ class ConvBasisMixin:
         """
         return self._conv_kwargs
 
-    def _check_convolution_kwargs(self):
+    @conv_kwargs.setter
+    def conv_kwargs(self, values: dict):
+        """Check and set convolution kwargs."""
+        self._check_convolution_kwargs(values)
+        self._conv_kwargs = values
+
+    @staticmethod
+    def _check_convolution_kwargs(conv_kwargs: dict):
         """Check convolution kwargs settings.
 
         Raises
@@ -183,7 +189,7 @@ class ConvBasisMixin:
             If ``self._conv_kwargs`` include parameters not recognized or that do not have
             default values in ``create_convolutional_predictor``.
         """
-        if "axis" in self._conv_kwargs:
+        if "axis" in conv_kwargs:
             raise ValueError(
                 "Setting the `axis` parameter is not allowed. Basis requires the "
                 "convolution to be applied along the first axis (`axis=0`).\n"
@@ -199,12 +205,12 @@ class ConvBasisMixin:
             # `basis_matrix` or `time_series` in kwargs.
             is not inspect.Parameter.empty
         }
-        if not set(self._conv_kwargs.keys()).issubset(convolve_configs):
+        if not set(conv_kwargs.keys()).issubset(convolve_configs):
             # do not encourage to set axis.
             convolve_configs = convolve_configs.difference({"axis"})
             # remove the parameter in case axis=0 was passed, since it is allowed.
             invalid = (
-                set(self._conv_kwargs.keys())
+                set(conv_kwargs.keys())
                 .difference(convolve_configs)
                 .difference({"axis"})
             )

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -91,21 +91,23 @@ class ConvBasisMixin:
 
     def _compute_features(self, *xi: ArrayLike):
         """
-        Apply the basis transformation to the input data.
+        Convolve basis functions with input time series.
 
         A bank of basis filters (created by calling fit) is convolved with the
-        samples. Samples can be a NDArray, or a pynapple Tsd/TsdFrame/TsdTensor. All the dimensions
+        input data. Inputs can be a NDArray, or a pynapple Tsd/TsdFrame/TsdTensor. All the dimensions
         except for the sample-axis are flattened, so that the method always returns a matrix.
-        For example, if samples are of shape (num_samples, 2, 3), the output will be
+
+        For example, if inputs are of shape (num_samples, 2, 3), the output will be
         ``(num_samples, num_basis_funcs * 2 * 3)``.
+
         The time-axis can be specified at basis initialization by setting the keyword argument ``axis``.
-        For example, if ``axis == 1`` your samples should be ``(N1, num_samples N3, ...)``, the output of
-        transform will be ``(num_samples, num_basis_funcs * N1 * N3 *...)``.
+        For example, if ``axis == 1`` your input should be of shape ``(N1, num_samples N3, ...)``, the output of
+        transform will be of shape ``(num_samples, num_basis_funcs * N1 * N3 *...)``.
 
         Parameters
         ----------
         *xi:
-            The input samples over which to apply the basis transformation. The samples can be passed
+            The input data over which to apply the basis transformation. The samples can be passed
             as multiple arguments, each representing a different dimension for multivariate inputs.
 
         """
@@ -126,7 +128,7 @@ class ConvBasisMixin:
         Prepare or compute the convolutional kernel for the basis functions.
 
         This method is called to prepare the basis functions for convolution operations
-        in subclasses where the 'conv' mode is used. It typically involves computing a
+        in subclasses. It computes a
         kernel based on the basis functions that will be used for convolution with the
         input data. The specifics of kernel computation depend on the subclass implementation
         and the nature of the basis functions.
@@ -134,14 +136,13 @@ class ConvBasisMixin:
         Returns
         -------
         self :
-            The instance itself, modified to include the computed kernel if applicable. This
+            The instance itself, modified to include the computed kernel. This
             allows for method chaining and integration into transformation pipelines.
 
         Notes
         -----
         Subclasses implementing this method should detail the specifics of how the kernel is
-        computed and how the input parameters are utilized. If the basis operates in 'eval'
-        mode exclusively, this method should simply return `self` without modification.
+        computed and how the input parameters are utilized.
         """
         self.kernel_ = self._evaluate(np.linspace(0, 1, self.window_size))
         return self

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -104,8 +104,10 @@ class ConvBasisMixin:
 
         """
         if self.kernel_ is None:
-            raise ValueError("You must call `_set_kernel` before `_compute_features`! "
-                             "Convolution kernel is not set.")
+            raise ValueError(
+                "You must call `_set_kernel` before `_compute_features`! "
+                "Convolution kernel is not set."
+            )
         # before calling the convolve, check that the input matches
         # the expectation. We can check xi[0] only, since convolution
         # is applied at the end of the recursion on the 1D basis, ensuring len(xi) == 1.

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -1,4 +1,5 @@
 """Mixin classes for basis."""
+from __future__ import annotations
 
 import copy
 import inspect
@@ -95,10 +96,10 @@ class ConvBasisMixin:
         samples. Samples can be a NDArray, or a pynapple Tsd/TsdFrame/TsdTensor. All the dimensions
         except for the sample-axis are flattened, so that the method always returns a matrix.
         For example, if samples are of shape (num_samples, 2, 3), the output will be
-        (num_samples, num_basis_funcs * 2 * 3).
+        ``(num_samples, num_basis_funcs * 2 * 3)``.
         The time-axis can be specified at basis initialization by setting the keyword argument ``axis``.
-        For example, if ``axis == 1`` your samples should be (N1, num_samples N3, ...), the output of
-        transform will be (num_samples, num_basis_funcs * N1 * N3 *...).
+        For example, if ``axis == 1`` your samples should be ``(N1, num_samples N3, ...)``, the output of
+        transform will be ``(num_samples, num_basis_funcs * N1 * N3 *...)``.
 
         Parameters
         ----------

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -36,7 +36,7 @@ class EvalBasisMixin:
         Returns
         -------
         :
-            A matrix with the transformed features. 
+            A matrix with the transformed features.
 
         """
         return self._evaluate(*xi)
@@ -149,17 +149,14 @@ class ConvBasisMixin:
 
     @property
     def window_size(self):
-        """Duration of the convolutional kernel in number of samples.
-        """
+        """Duration of the convolutional kernel in number of samples."""
         return self._window_size
 
     @window_size.setter
     def window_size(self, window_size):
         """Setter for the window size parameter."""
         if window_size is None:
-            raise ValueError(
-                "You must provide a window_size!"
-            )
+            raise ValueError("You must provide a window_size!")
 
         elif not (isinstance(window_size, int) and window_size > 0):
             raise ValueError(

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -21,11 +21,17 @@ class EvalBasisMixin:
         self.bounds = bounds
 
     def _compute_features(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor):
-        """
-        Evaluate basis at sample points.
+        """Evaluate basis at sample points.
 
-        The basis evaluated at the samples, or :math:`b_i(*xi)`, where :math:`b_i` is a
-        basis element. xi[k] must be a one-dimensional array or a pynapple Tsd/TsdFrame/TsdTensor.
+        The basis is evaluated at the locations specified in the inputs. For example,
+        ``compute_features(np.array([0, .5]))`` would return the array:
+
+        .. code-block:: text
+
+           b_1(0) ... b_n(0)
+           b_1(.5) ... b_n(.5)
+
+        where ``b_i`` is the i-th basis.
 
         Parameters
         ----------
@@ -89,19 +95,14 @@ class ConvBasisMixin:
         self.conv_kwargs = {} if conv_kwargs is None else conv_kwargs
 
     def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor):
-        """
-        Convolve basis functions with input time series.
+        """Convolve basis functions with input time series.
 
-        A bank of basis filters (created by calling fit) is convolved with the
-        input data. Inputs can be a NDArray, or a pynapple Tsd/TsdFrame/TsdTensor. All the dimensions
-        except for the sample-axis are flattened, so that the method always returns a matrix.
+        A bank of basis filters is convolved with the input data. All the dimensions
+        except for the sample-axis are flattened, so that the method always returns a
+        matrix.
 
         For example, if inputs are of shape (num_samples, 2, 3), the output will be
         ``(num_samples, num_basis_funcs * 2 * 3)``.
-
-        The time-axis can be specified at basis initialization by setting the keyword argument ``axis``.
-        For example, if ``axis == 1`` your input should be of shape ``(N1, num_samples N3, ...)``, the output of
-        transform will be of shape ``(num_samples, num_basis_funcs * N1 * N3 *...)``.
 
         Parameters
         ----------

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -7,7 +7,8 @@ import inspect
 from typing import Optional, Tuple, Union
 
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, NDArray
+from pynapple import Tsd, TsdFrame, TsdTensor
 
 from ..convolve import create_convolutional_predictor
 from ._transformer_basis import TransformerBasis
@@ -19,12 +20,12 @@ class EvalBasisMixin:
     def __init__(self, bounds: Optional[Tuple[float, float]] = None):
         self.bounds = bounds
 
-    def _compute_features(self, *xi: ArrayLike):
+    def _compute_features(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor):
         """
-        Apply the basis transformation to the input data.
+        Evaluate basis at sample points.
 
         The basis evaluated at the samples, or :math:`b_i(*xi)`, where :math:`b_i` is a
-        basis element. xi[k] must be a one-dimensional array or a pynapple Tsd.
+        basis element. xi[k] must be a one-dimensional array or a pynapple Tsd/TsdFrame/TsdTensor.
 
         Parameters
         ----------
@@ -89,7 +90,7 @@ class ConvBasisMixin:
         self.window_size = window_size
         self.conv_kwargs = {} if conv_kwargs is None else conv_kwargs
 
-    def _compute_features(self, *xi: ArrayLike):
+    def _compute_features(self, *xi: NDArray | Tsd | TsdFrame | TsdTensor):
         """
         Convolve basis functions with input time series.
 

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -38,7 +38,7 @@ class EvalBasisMixin:
             or a pynapple Tsd.
 
         """
-        return self.__call__(*xi)
+        return self._evaluate(*xi)
 
     def _set_kernel(self) -> "EvalBasisMixin":
         """
@@ -141,7 +141,7 @@ class ConvBasisMixin:
         computed and how the input parameters are utilized. If the basis operates in 'eval'
         mode exclusively, this method should simply return `self` without modification.
         """
-        self.kernel_ = self.__call__(np.linspace(0, 1, self.window_size))
+        self.kernel_ = self._evaluate(np.linspace(0, 1, self.window_size))
         return self
 
     @property
@@ -241,7 +241,7 @@ class BasisTransformerMixin:
         >>> from sklearn.model_selection import GridSearchCV
         >>> # load some data
         >>> X, y = np.random.normal(size=(30, 1)), np.random.poisson(size=30)
-        >>> basis = nmo.basis.EvalRaisedCosineLinear(10).to_transformer()
+        >>> basis = nmo.basis.RaisedCosineLinearEval(10).to_transformer()
         >>> glm = nmo.glm.GLM(regularizer="Ridge", regularizer_strength=1.)
         >>> pipeline = Pipeline([("basis", basis), ("glm", glm)])
         >>> param_grid = dict(

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import abc
-from functools import partial
 from typing import Optional, Tuple
 
 import numpy as np
@@ -15,7 +14,6 @@ from ..type_casting import support_pynapple
 from ..typing import FeatureMatrix
 from ._basis import (
     Basis,
-    add_docstring,
     check_one_dimensional,
     check_transform_input,
     min_max_rescale_samples,
@@ -134,7 +132,7 @@ class OrthExponentialBasis(Basis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def __call__(
+    def _evaluate(
         self,
         sample_pts: NDArray,
     ) -> FeatureMatrix:
@@ -193,6 +191,3 @@ class OrthExponentialBasis(Basis, abc.ABC):
             OrthExponential basis functions, shape (n_samples, n_basis_funcs).
         """
         return super().evaluate_on_grid(n_samples)
-
-
-add_orth_exp_decay_docstring = partial(add_docstring, cls=OrthExponentialBasis)

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -118,7 +118,7 @@ class OrthExponentialBasis(Basis, abc.ABC):
         """
         if len(set(self._decay_rates)) != len(self._decay_rates):
             raise ValueError(
-                "Two or more rate are repeated! Repeating rate will result in a "
+                "Two or more rates are repeated! Repeating rates will result in a "
                 "linearly dependent set of function for the basis."
             )
 

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -34,10 +34,6 @@ class OrthExponentialBasis(Basis, abc.ABC):
     mode :
         The mode of operation. ``'eval'`` for evaluation at sample points,
         ``'conv'`` for convolutional operation.
-    bounds :
-        The bounds for the basis domain in ``mode="eval"``. The default ``bounds[0]`` and ``bounds[1]`` are the
-        minimum and the maximum of the samples provided when evaluating the basis.
-        If a sample is outside the bounds, the basis will return NaN.
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple
 import numpy as np
 import scipy.linalg
 from numpy.typing import ArrayLike, NDArray
+from pynapple import Tsd, TsdFrame, TsdTensor
 
 from ..type_casting import support_pynapple
 from ..typing import FeatureMatrix
@@ -19,7 +20,6 @@ from ._basis import (
     min_max_rescale_samples,
 )
 
-from pynapple import Tsd, TsdFrame, TsdTensor
 
 class OrthExponentialBasis(Basis, abc.ABC):
     """Set of 1D basis decaying exponential functions numerically orthogonalized.

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -34,8 +34,6 @@ class OrthExponentialBasis(Basis, abc.ABC):
     mode :
         The mode of operation. ``'eval'`` for evaluation at sample points,
         ``'conv'`` for convolutional operation.
-    window_size :
-        The window size for convolution. Required if mode is ``'conv'``.
     bounds :
         The bounds for the basis domain in ``mode="eval"``. The default ``bounds[0]`` and ``bounds[1]`` are the
         minimum and the maximum of the samples provided when evaluating the basis.
@@ -43,12 +41,6 @@ class OrthExponentialBasis(Basis, abc.ABC):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-    **kwargs :
-        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor` when
-        ``mode='conv'``; These arguments are used to change the default behavior of the convolution.
-        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
-        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
-        that the convolution axis is ``axis=0``.
     """
 
     def __init__(
@@ -57,13 +49,11 @@ class OrthExponentialBasis(Basis, abc.ABC):
         decay_rates: NDArray[np.floating],
         mode="eval",
         label: Optional[str] = "OrthExponentialBasis",
-        **kwargs,
     ):
         super().__init__(
             n_basis_funcs,
             mode=mode,
             label=label,
-            **kwargs,
         )
         self.decay_rates = decay_rates
         self._check_rates()

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -8,7 +8,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 import scipy.linalg
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike, NDArray
 
 from ..type_casting import support_pynapple
 from ..typing import FeatureMatrix
@@ -19,6 +19,7 @@ from ._basis import (
     min_max_rescale_samples,
 )
 
+from pynapple import Tsd, TsdFrame, TsdTensor
 
 class OrthExponentialBasis(Basis, abc.ABC):
     """Set of 1D basis decaying exponential functions numerically orthogonalized.
@@ -134,7 +135,7 @@ class OrthExponentialBasis(Basis, abc.ABC):
     @check_one_dimensional
     def _evaluate(
         self,
-        sample_pts: NDArray,
+        sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
         """Generate basis functions with given spacing.
 

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -43,12 +43,6 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-    **kwargs :
-        Additional keyword arguments passed to ``nemos.convolve.create_convolutional_predictor`` when
-        ``mode='conv'``; These arguments are used to change the default behavior of the convolution.
-        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
-        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
-        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -70,7 +64,6 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
             n_basis_funcs,
             mode=mode,
             label=label,
-            **kwargs,
         )
         self._n_input_dimensionality = 1
         self._check_width(width)
@@ -240,12 +233,6 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-    **kwargs :
-        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor` when
-        ``mode='conv'``; These arguments are used to change the default behavior of the convolution.
-        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
-        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
-        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -263,13 +250,11 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         time_scaling: float = None,
         enforce_decay_to_zero: bool = True,
         label: Optional[str] = "RaisedCosineBasisLog",
-        **kwargs,
     ) -> None:
         super().__init__(
             n_basis_funcs,
             mode=mode,
             width=width,
-            **kwargs,
             label=label,
         )
         # The samples are scaled appropriately in the self._transform_samples which scales

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -34,12 +34,6 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
         'conv' for convolutional operation.
     width :
         Width of the raised cosine. By default, it's set to 2.0.
-    window_size :
-        The window size for convolution. Required if mode is 'conv'.
-    bounds :
-        The bounds for the basis domain in ``mode="eval"``. The default ``bounds[0]`` and ``bounds[1]`` are the
-        minimum and the maximum of the samples provided when evaluating the basis.
-        If a sample is outside the bounds, the basis will return NaN.
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
@@ -58,7 +52,6 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
         mode="eval",
         width: float = 2.0,
         label: Optional[str] = "RaisedCosineBasisLinear",
-        **kwargs,
     ) -> None:
         super().__init__(
             n_basis_funcs,

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -217,12 +217,6 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         If set to True, the algorithm first constructs a basis with ``n_basis_funcs + ceil(width)`` elements
         and subsequently trims off the extra basis elements. This ensures that the final basis element
         decays to 0.
-    window_size :
-        The window size for convolution. Required if mode is 'conv'.
-    bounds :
-        The bounds for the basis domain in ``mode="eval"``. The default ``bounds[0]`` and ``bounds[1]`` are the
-        minimum and the maximum of the samples provided when evaluating the basis.
-        If a sample is outside the bounds, the basis will return NaN.
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -123,7 +123,7 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
             # basis1 = nmo.basis.RaisedCosineBasisLinear(5)
             # basis2 = nmo.basis.RaisedCosineBasisLog(5)
             # additive_basis = basis1 + basis2
-            # additive_basis(*([x] * 2)) would modify both inputs
+            # additive_basis._evaluate(*([x] * 2)) would modify both inputs
             sample_pts, _ = min_max_rescale_samples(
                 np.copy(sample_pts), getattr(self, "bounds", None)
             )

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -16,6 +16,7 @@ from ._basis import (
     min_max_rescale_samples,
 )
 
+from pynapple import Tsd, TsdFrame, TsdTensor
 
 class RaisedCosineBasisLinear(Basis, abc.ABC):
     """Represent linearly-spaced raised cosine basis functions.
@@ -101,7 +102,7 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
     @check_one_dimensional
     def _evaluate(  # call these _evaluate
         self,
-        sample_pts: ArrayLike,
+        sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
         """Generate basis functions with given samples.
 
@@ -330,7 +331,7 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
     @check_one_dimensional
     def _evaluate(
         self,
-        sample_pts: ArrayLike,
+        sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
         """Generate log-spaced raised cosine basis with given samples.
 

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -50,15 +50,6 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
         Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
         that the convolution axis is ``axis=0``.
 
-    Examples
-    --------
-    >>> from numpy import linspace
-    >>> from nemos.basis import RaisedCosineBasisLinear
-    >>> X = np.random.normal(size=(1000, 1))
-    >>> cosine_basis = RaisedCosineBasisLinear(n_basis_funcs=5, mode="conv", window_size=10)
-    >>> sample_points = linspace(0, 1, 100)
-    >>> basis_functions = cosine_basis(sample_points)
-
     References
     ----------
     .. [1] Pillow, J. W., Paninski, L., Uzzel, V. J., Simoncelli, E. P., & J.,
@@ -255,15 +246,6 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
         Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
         that the convolution axis is ``axis=0``.
-
-    Examples
-    --------
-    >>> from numpy import linspace
-    >>> from nemos.basis import RaisedCosineBasisLog
-    >>> X = np.random.normal(size=(1000, 1))
-    >>> cosine_basis = RaisedCosineBasisLog(n_basis_funcs=5, mode="conv", window_size=10)
-    >>> sample_points = linspace(0, 1, 100)
-    >>> basis_functions = cosine_basis(sample_points)
 
     References
     ----------

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+from pynapple import Tsd, TsdFrame, TsdTensor
 
 from ..type_casting import support_pynapple
 from ..typing import FeatureMatrix
@@ -16,7 +17,6 @@ from ._basis import (
     min_max_rescale_samples,
 )
 
-from pynapple import Tsd, TsdFrame, TsdTensor
 
 class RaisedCosineBasisLinear(Basis, abc.ABC):
     """Represent linearly-spaced raised cosine basis functions.

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import abc
-from functools import partial
 from typing import Optional, Tuple
 
 import numpy as np
@@ -12,7 +11,6 @@ from ..type_casting import support_pynapple
 from ..typing import FeatureMatrix
 from ._basis import (
     Basis,
-    add_docstring,
     check_one_dimensional,
     check_transform_input,
     min_max_rescale_samples,
@@ -101,7 +99,7 @@ class RaisedCosineBasisLinear(Basis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def __call__(
+    def _evaluate(  # call these _evaluate
         self,
         sample_pts: ArrayLike,
     ) -> FeatureMatrix:
@@ -330,7 +328,7 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def __call__(
+    def _evaluate(
         self,
         sample_pts: ArrayLike,
     ) -> FeatureMatrix:
@@ -351,9 +349,4 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         ValueError
             If the sample provided do not lie in [0,1].
         """
-        return super().__call__(self._transform_samples(sample_pts))
-
-
-add_raised_cosine_linear_docstring = partial(add_docstring, cls=RaisedCosineBasisLinear)
-
-add_raised_cosine_log_docstring = partial(add_docstring, cls=RaisedCosineBasisLog)
+        return super()._evaluate(self._transform_samples(sample_pts))

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import abc
 import copy
-from functools import partial
 from typing import Literal, Optional, Tuple
 
 import numpy as np
@@ -14,7 +13,6 @@ from ..type_casting import support_pynapple
 from ..typing import FeatureMatrix
 from ._basis import (
     Basis,
-    add_docstring,
     check_one_dimensional,
     check_transform_input,
     min_max_rescale_samples,
@@ -194,12 +192,12 @@ class MSplineBasis(SplineBasis, abc.ABC):
     Examples
     --------
     >>> from numpy import linspace
-    >>> from nemos.basis import EvalMSpline
+    >>> from nemos.basis import MSplineEval
     >>> n_basis_funcs = 5
     >>> order = 3
-    >>> mspline_basis = EvalMSpline(n_basis_funcs, order=order)
+    >>> mspline_basis = MSplineEval(n_basis_funcs, order=order)
     >>> sample_points = linspace(0, 1, 100)
-    >>> basis_functions = mspline_basis(sample_points)
+    >>> basis_functions = mspline_basis.compute_features(sample_points)
     """
 
     def __init__(
@@ -207,7 +205,7 @@ class MSplineBasis(SplineBasis, abc.ABC):
         n_basis_funcs: int,
         mode: Literal["eval", "conv"] = "eval",
         order: int = 2,
-        label: Optional[str] = "EvalMSpline",
+        label: Optional[str] = "MSplineEval",
     ) -> None:
         super().__init__(
             n_basis_funcs,
@@ -219,7 +217,7 @@ class MSplineBasis(SplineBasis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def __call__(self, sample_pts: ArrayLike) -> FeatureMatrix:
+    def _evaluate(self, sample_pts: ArrayLike) -> FeatureMatrix:
         """
         Evaluate the M-spline basis functions at given sample points.
 
@@ -336,7 +334,7 @@ class BSplineBasis(SplineBasis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def __call__(self, sample_pts: ArrayLike) -> FeatureMatrix:
+    def _evaluate(self, sample_pts: ArrayLike) -> FeatureMatrix:
         """
         Evaluate the B-spline basis functions with given sample points.
 
@@ -445,7 +443,7 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def __call__(
+    def _evaluate(
         self,
         sample_pts: ArrayLike,
     ) -> FeatureMatrix:
@@ -669,8 +667,3 @@ def bspline(
         )
 
     return basis_eval.T
-
-
-add_docstrings_mspline = partial(add_docstring, cls=MSplineBasis)
-add_docstrings_bspline = partial(add_docstring, cls=BSplineBasis)
-add_docstrings_cyclic_bspline = partial(add_docstring, cls=CyclicBSplineBasis)

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -18,6 +18,7 @@ from ._basis import (
     min_max_rescale_samples,
 )
 
+from pynapple import Tsd, TsdFrame, TsdTensor
 
 class SplineBasis(Basis, abc.ABC):
     """
@@ -217,7 +218,7 @@ class MSplineBasis(SplineBasis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, sample_pts: ArrayLike) -> FeatureMatrix:
+    def _evaluate(self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Evaluate the M-spline basis functions at given sample points.
 
@@ -334,7 +335,7 @@ class BSplineBasis(SplineBasis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, sample_pts: ArrayLike) -> FeatureMatrix:
+    def _evaluate(self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Evaluate the B-spline basis functions with given sample points.
 
@@ -445,7 +446,7 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
     @check_one_dimensional
     def _evaluate(
         self,
-        sample_pts: ArrayLike,
+        sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
         """Evaluate the Cyclic B-spline basis functions with given sample points.
 

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import abc
 import copy
 from functools import partial
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -34,21 +34,9 @@ class SplineBasis(Basis, abc.ABC):
         'conv' for convolutional operation.
     order : optional
         Spline order.
-    window_size :
-        The window size for convolution. Required if mode is 'conv'.
-    bounds :
-        The bounds for the basis domain in ``mode="eval"``. The default ``bounds[0]`` and ``bounds[1]`` are the
-        minimum and the maximum of the samples provided when evaluating the basis.
-        If a sample is outside the bounds, the basis will return NaN.
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-    **kwargs :
-        Additional keyword arguments passed to ``nemos.convolve.create_convolutional_predictor`` when
-        ``mode='conv'``; These arguments are used to change the default behavior of the convolution.
-        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
-        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
-        that the convolution axis is ``axis=0``.
 
     Attributes
     ----------
@@ -61,13 +49,13 @@ class SplineBasis(Basis, abc.ABC):
         n_basis_funcs: int,
         order: int = 2,
         label: Optional[str] = None,
-        **kwargs,
+        mode: Literal["conv", "eval"] = "eval",
     ) -> None:
         self.order = order
         super().__init__(
             n_basis_funcs,
             label=label,
-            **kwargs,
+            mode=mode,
         )
 
         self._n_input_dimensionality = 1
@@ -186,17 +174,9 @@ class MSplineBasis(SplineBasis, abc.ABC):
         The order of the splines used in basis functions. Must be between [1,
         n_basis_funcs]. Default is 2. Higher order splines have more continuous
         derivatives at each interior knot, resulting in smoother basis functions.
-    window_size :
-        The window size for convolution. Required if mode is 'conv'.
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-    **kwargs:
-        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor` when
-        ``mode='conv'``; These arguments are used to change the default behavior of the convolution.
-        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
-        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
-        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -225,13 +205,13 @@ class MSplineBasis(SplineBasis, abc.ABC):
     def __init__(
         self,
         n_basis_funcs: int,
+        mode: Literal["eval", "conv"] = "eval",
         order: int = 2,
         label: Optional[str] = "EvalMSpline",
-        **kwargs,
     ) -> None:
         super().__init__(
             n_basis_funcs,
-            mode="eval",
+            mode=mode,
             order=order,
             label=label,
         )
@@ -326,12 +306,6 @@ class BSplineBasis(SplineBasis, abc.ABC):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-    **kwargs :
-        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor` when
-        ``mode='conv'``; These arguments are used to change the default behavior of the convolution.
-        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
-        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
-        that the convolution axis is ``axis=0``.
 
     Attributes
     ----------
@@ -351,14 +325,12 @@ class BSplineBasis(SplineBasis, abc.ABC):
         mode="eval",
         order: int = 4,
         label: Optional[str] = "BSplineBasis",
-        **kwargs,
     ):
         super().__init__(
             n_basis_funcs,
             mode=mode,
             order=order,
             label=label,
-            **kwargs,
         )
 
     @support_pynapple(conv_type="numpy")
@@ -442,12 +414,6 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-    **kwargs :
-        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor` when
-        ``mode='conv'``; These arguments are used to change the default behavior of the convolution.
-        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
-        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
-        that the convolution axis is ``axis=0``.
 
     Attributes
     ----------
@@ -462,17 +428,13 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
         n_basis_funcs: int,
         mode="eval",
         order: int = 4,
-        window_size: Optional[int] = None,
-        bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "CyclicBSplineBasis",
-        **kwargs,
     ):
         super().__init__(
             n_basis_funcs,
             mode=mode,
             order=order,
             label=label,
-            **kwargs,
         )
         if self.order < 2:
             raise ValueError(

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -7,6 +7,7 @@ from typing import Literal, Optional, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+from pynapple import Tsd, TsdFrame, TsdTensor
 from scipy.interpolate import splev
 
 from ..type_casting import support_pynapple
@@ -18,7 +19,6 @@ from ._basis import (
     min_max_rescale_samples,
 )
 
-from pynapple import Tsd, TsdFrame, TsdTensor
 
 class SplineBasis(Basis, abc.ABC):
     """
@@ -218,7 +218,9 @@ class MSplineBasis(SplineBasis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def _evaluate(
+        self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         """
         Evaluate the M-spline basis functions at given sample points.
 
@@ -335,7 +337,9 @@ class BSplineBasis(SplineBasis, abc.ABC):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def _evaluate(
+        self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
+    ) -> FeatureMatrix:
         """
         Evaluate the B-spline basis functions with given sample points.
 

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -343,14 +343,6 @@ class BSplineBasis(SplineBasis, abc.ABC):
     ----------
     .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline Techniques.
         Mathematics and Visualization. Springer, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-04919-8_5
-
-    Examples
-    --------
-    >>> from numpy import linspace
-    >>> from nemos.basis import BSplineBasis
-    >>> bspline_basis = BSplineBasis(n_basis_funcs=5, order=3)
-    >>> sample_points = linspace(0, 1, 100)
-    >>> basis_functions = bspline_basis(sample_points)
     """
 
     def __init__(
@@ -463,15 +455,6 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
         Number of basis functions, int.
     order :
         Order of the splines used in basis functions, int.
-
-    Examples
-    --------
-    >>> from numpy import linspace
-    >>> from nemos.basis import EvalCyclicBSpline
-    >>> X = np.random.normal(size=(1000, 1))
-    >>> cyclic_basis = EvalCyclicBSpline(n_basis_funcs=5, order=3, mode="conv", window_size=10)
-    >>> sample_points = linspace(0, 1, 100)
-    >>> basis_functions = cyclic_basis(sample_points)
     """
 
     def __init__(

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+from ..typing import FeatureMatrix
+
+if TYPE_CHECKING:
+    from ._basis import Basis
+
+
+class TransformerBasis:
+    """Basis as ``scikit-learn`` transformers.
+
+    This class abstracts the underlying basis function details, offering methods
+    similar to scikit-learn's transformers but specifically designed for basis
+    transformations. It supports fitting to data (calculating any necessary parameters
+    of the basis functions), transforming data (applying the basis functions to
+    data), and both fitting and transforming in one step.
+
+    ``TransformerBasis``, unlike ``Basis``, is compatible with scikit-learn pipelining and
+    model selection, enabling the cross-validation of the basis type and parameters,
+    for example ``n_basis_funcs``. See the example section below.
+
+    Parameters
+    ----------
+    basis :
+        A concrete subclass of ``Basis``.
+
+    Examples
+    --------
+    >>> from nemos.basis import EvalBSpline
+    >>> from nemos.basis import TransformerBasis
+    >>> from nemos.glm import GLM
+    >>> from sklearn.pipeline import Pipeline
+    >>> from sklearn.model_selection import GridSearchCV
+    >>> import numpy as np
+    >>> np.random.seed(123)
+
+    >>> # Generate data
+    >>> num_samples, num_features = 10000, 1
+    >>> x = np.random.normal(size=(num_samples, ))  # raw time series
+    >>> basis = EvalBSpline(10)
+    >>> features = basis.compute_features(x)  # basis transformed time series
+    >>> weights = np.random.normal(size=basis.n_basis_funcs)  # true weights
+    >>> y = np.random.poisson(np.exp(features.dot(weights)))  # spike counts
+
+    >>> # transformer can be used in pipelines
+    >>> transformer = TransformerBasis(basis)
+    >>> pipeline = Pipeline([ ("compute_features", transformer), ("glm", GLM()),])
+    >>> pipeline = pipeline.fit(x[:, None], y)  # x need to be 2D for sklearn transformer API
+    >>> out = pipeline.predict(np.arange(10)[:, None]) # predict rate from new datas
+    >>> # TransformerBasis parameter can be cross-validated.
+    >>> # 5-fold cross-validate the number of basis
+    >>> param_grid = dict(compute_features__n_basis_funcs=[4, 10])
+    >>> grid_cv = GridSearchCV(pipeline, param_grid, cv=5)
+    >>> grid_cv = grid_cv.fit(x[:, None], y)
+    >>> print("Cross-validated number of basis:", grid_cv.best_params_)
+    Cross-validated number of basis: {'compute_features__n_basis_funcs': 10}
+    """
+
+    def __init__(self, basis: Basis):
+        self._basis = copy.deepcopy(basis)
+
+    @staticmethod
+    def _unpack_inputs(X: FeatureMatrix):
+        """Unpack impute without using transpose.
+
+        Unpack horizontally stacked inputs using slicing. This works gracefully with ``pynapple``,
+        returning a list of Tsd objects. Attempt to unpack using *X.T will raise a ``pynapple``
+        exception since ``pynapple`` assumes that the time axis is the first axis.
+
+        Parameters
+        ----------
+        X:
+            The inputs horizontally stacked.
+
+        Returns
+        -------
+        :
+            A tuple of each individual input.
+
+        """
+        return (X[:, k] for k in range(X.shape[1]))
+
+    def fit(self, X: FeatureMatrix, y=None):
+        """
+        Compute the convolutional kernels.
+
+        If any of the 1D basis in self._basis is in "conv" mode, it computes the convolutional kernels.
+
+        Parameters
+        ----------
+        X :
+            The data to fit the basis functions to, shape (num_samples, num_input).
+        y : ignored
+            Not used, present for API consistency by convention.
+
+        Returns
+        -------
+        self :
+            The transformer object.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import EvalMSpline, TransformerBasis
+
+        >>> # Example input
+        >>> X = np.random.normal(size=(100, 2))
+
+        >>> # Define and fit tranformation basis
+        >>> basis = EvalMSpline(10)
+        >>> transformer = TransformerBasis(basis)
+        >>> transformer_fitted = transformer.fit(X)
+        """
+        self._basis._set_kernel()
+        return self
+
+    def transform(self, X: FeatureMatrix, y=None) -> FeatureMatrix:
+        """
+        Transform the data using the fitted basis functions.
+
+        Parameters
+        ----------
+        X :
+            The data to transform using the basis functions, shape (num_samples, num_input).
+        y :
+            Not used, present for API consistency by convention.
+
+        Returns
+        -------
+        :
+            The data transformed by the basis functions.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import EvalMSpline, TransformerBasis
+
+        >>> # Example input
+        >>> X = np.random.normal(size=(10000, 2))
+
+        >>> # Define and fit tranformation basis
+        >>> basis = EvalMSpline(10, mode="conv", window_size=200)
+        >>> transformer = TransformerBasis(basis)
+        >>> # Before calling `fit` the convolution kernel is not set
+        >>> transformer.kernel_
+
+        >>> transformer_fitted = transformer.fit(X)
+        >>> # Now the convolution kernel is initialized and has shape (window_size, n_basis_funcs)
+        >>> transformer_fitted.kernel_.shape
+        (200, 10)
+
+        >>> # Transform basis
+        >>> feature_transformed = transformer.transform(X[:, 0:1])
+        """
+        # transpose does not work with pynapple
+        # can't use func(*X.T) to unwrap
+        return self._basis._compute_features(*self._unpack_inputs(X))
+
+    def fit_transform(self, X: FeatureMatrix, y=None) -> FeatureMatrix:
+        """
+        Compute the kernels and the features.
+
+        This method is a convenience that combines fit and transform into
+        one step.
+
+        Parameters
+        ----------
+        X :
+            The data to fit the basis functions to and then transform.
+        y :
+            Not used, present for API consistency by convention.
+
+        Returns
+        -------
+        array-like
+            The data transformed by the basis functions, after fitting the basis
+            functions to the data.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import EvalMSpline, TransformerBasis
+
+        >>> # Example input
+        >>> X = np.random.normal(size=(100, 1))
+
+        >>> # Define tranformation basis
+        >>> basis = EvalMSpline(10)
+        >>> transformer = TransformerBasis(basis)
+
+        >>> # Fit and transform basis
+        >>> feature_transformed = transformer.fit_transform(X)
+        """
+        return self._basis.compute_features(*self._unpack_inputs(X))
+
+    def __getstate__(self):
+        """
+        Explicitly define how to pickle TransformerBasis object.
+
+        See https://docs.python.org/3/library/pickle.html#object.__getstate__
+        and https://docs.python.org/3/library/pickle.html#pickle-state
+        """
+        return {"_basis": self._basis}
+
+    def __setstate__(self, state):
+        """
+        Define how to populate the object's state when unpickling.
+
+        Note that during unpickling a new object is created without calling __init__.
+        Needed to avoid infinite recursion in __getattr__ when unpickling.
+
+        See https://docs.python.org/3/library/pickle.html#object.__setstate__
+        and https://docs.python.org/3/library/pickle.html#pickle-state
+        """
+        self._basis = state["_basis"]
+
+    def __getattr__(self, name: str):
+        """
+        Enable easy access to attributes of the underlying Basis object.
+
+        Examples
+        --------
+        >>> from nemos import basis
+        >>> bas = basis.EvalRaisedCosineLinear(5)
+        >>> trans_bas = basis.TransformerBasis(bas)
+        >>> bas.n_basis_funcs
+        5
+        >>> trans_bas.n_basis_funcs
+        5
+        """
+        return getattr(self._basis, name)
+
+    def __setattr__(self, name: str, value) -> None:
+        r"""
+        Allow setting _basis or the attributes of _basis with a convenient dot assignment syntax.
+
+        Setting any other attribute is not allowed.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If the attribute being set is not ``_basis`` or an attribute of ``_basis``.
+
+        Examples
+        --------
+        >>> import nemos as nmo
+        >>> trans_bas = nmo.basis.TransformerBasis(nmo.basis.EvalMSpline(10))
+        >>> # allowed
+        >>> trans_bas._basis = nmo.basis.EvalBSpline(10)
+        >>> # allowed
+        >>> trans_bas.n_basis_funcs = 20
+        >>> # not allowed
+        >>> try:
+        ...     trans_bas.random_attribute_name = "some value"
+        ... except ValueError as e:
+        ...     print(repr(e))
+        ValueError('Only setting _basis or existing attributes of _basis is allowed.')
+        """
+        # allow self._basis = basis
+        if name == "_basis":
+            super().__setattr__(name, value)
+        # allow changing existing attributes of self._basis
+        elif hasattr(self._basis, name):
+            setattr(self._basis, name, value)
+        # don't allow setting any other attribute
+        else:
+            raise ValueError(
+                "Only setting _basis or existing attributes of _basis is allowed."
+            )
+
+    def __sklearn_clone__(self) -> TransformerBasis:
+        """
+        Customize how TransformerBasis objects are cloned when used with sklearn.model_selection.
+
+        By default, scikit-learn tries to clone the object by calling __init__ using the output of get_params,
+        which fails in our case.
+
+        For more info: https://scikit-learn.org/stable/developers/develop.html#cloning
+        """
+        cloned_obj = TransformerBasis(copy.deepcopy(self._basis))
+        cloned_obj._basis.kernel_ = None
+        return cloned_obj
+
+    def set_params(self, **parameters) -> TransformerBasis:
+        """
+        Set TransformerBasis parameters.
+
+        When used with ``sklearn.model_selection``, users can set either the ``_basis`` attribute directly
+        or the parameters of the underlying Basis, but not both.
+
+        Examples
+        --------
+        >>> from nemos.basis import EvalBSpline, EvalMSpline, TransformerBasis
+        >>> basis = EvalMSpline(10)
+        >>> transformer_basis = TransformerBasis(basis=basis)
+
+        >>> # setting parameters of _basis is allowed
+        >>> print(transformer_basis.set_params(n_basis_funcs=8).n_basis_funcs)
+        8
+        >>> # setting _basis directly is allowed
+        >>> print(type(transformer_basis.set_params(_basis=EvalBSpline(10))._basis))
+        <class 'nemos.basis.BSplineBasis'>
+        >>> # mixing is not allowed, this will raise an exception
+        >>> try:
+        ...     transformer_basis.set_params(_basis=EvalBSpline(10), n_basis_funcs=2)
+        ... except ValueError as e:
+        ...     print(repr(e))
+        ValueError('Set either new _basis object or parameters for existing _basis, not both.')
+        """
+        new_basis = parameters.pop("_basis", None)
+        if new_basis is not None:
+            self._basis = new_basis
+            if len(parameters) > 0:
+                raise ValueError(
+                    "Set either new _basis object or parameters for existing _basis, not both."
+                )
+        else:
+            self._basis = self._basis.set_params(**parameters)
+
+        return self
+
+    def get_params(self, deep: bool = True) -> dict:
+        """Extend the dict of parameters from the underlying Basis with _basis."""
+        return {"_basis": self._basis, **self._basis.get_params(deep)}
+
+    def __dir__(self) -> list[str]:
+        """Extend the list of properties of methods with the ones from the underlying Basis."""
+        return list(super().__dir__()) + list(self._basis.__dir__())
+
+    def __add__(self, other: TransformerBasis) -> TransformerBasis:
+        """
+        Add two TransformerBasis objects.
+
+        Parameters
+        ----------
+        other
+            The other TransformerBasis object to add.
+
+        Returns
+        -------
+        : TransformerBasis
+            The resulting Basis object.
+        """
+        return TransformerBasis(self._basis + other._basis)
+
+    def __mul__(self, other: TransformerBasis) -> TransformerBasis:
+        """
+        Multiply two TransformerBasis objects.
+
+        Parameters
+        ----------
+        other
+            The other TransformerBasis object to multiply.
+
+        Returns
+        -------
+        :
+            The resulting Basis object.
+        """
+        return TransformerBasis(self._basis * other._basis)
+
+    def __pow__(self, exponent: int) -> TransformerBasis:
+        """Exponentiation of a TransformerBasis object.
+
+        Define the power of a basis by repeatedly applying the method __mul__.
+        The exponent must be a positive integer.
+
+        Parameters
+        ----------
+        exponent :
+            Positive integer exponent
+
+        Returns
+        -------
+        :
+            The product of the basis with itself "exponent" times. Equivalent to self * self * ... * self.
+
+        Raises
+        ------
+        TypeError
+            If the provided exponent is not an integer.
+        ValueError
+            If the integer is zero or negative.
+        """
+        # errors are handled by Basis.__pow__
+        return TransformerBasis(self._basis**exponent)

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -29,7 +29,7 @@ class TransformerBasis:
 
     Examples
     --------
-    >>> from nemos.basis import EvalBSpline
+    >>> from nemos.basis import BSplineEval
     >>> from nemos.basis import TransformerBasis
     >>> from nemos.glm import GLM
     >>> from sklearn.pipeline import Pipeline
@@ -40,7 +40,7 @@ class TransformerBasis:
     >>> # Generate data
     >>> num_samples, num_features = 10000, 1
     >>> x = np.random.normal(size=(num_samples, ))  # raw time series
-    >>> basis = EvalBSpline(10)
+    >>> basis = BSplineEval(10)
     >>> features = basis.compute_features(x)  # basis transformed time series
     >>> weights = np.random.normal(size=basis.n_basis_funcs)  # true weights
     >>> y = np.random.poisson(np.exp(features.dot(weights)))  # spike counts
@@ -104,13 +104,13 @@ class TransformerBasis:
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalMSpline, TransformerBasis
+        >>> from nemos.basis import MSplineEval, TransformerBasis
 
         >>> # Example input
         >>> X = np.random.normal(size=(100, 2))
 
         >>> # Define and fit tranformation basis
-        >>> basis = EvalMSpline(10)
+        >>> basis = MSplineEval(10)
         >>> transformer = TransformerBasis(basis)
         >>> transformer_fitted = transformer.fit(X)
         """
@@ -136,12 +136,12 @@ class TransformerBasis:
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvMSpline, TransformerBasis
+        >>> from nemos.basis import MSplineConv, TransformerBasis
 
         >>> # Example input
         >>> X = np.random.normal(size=(10000, 2))
 
-        >>> basis = ConvMSpline(10, window_size=200)
+        >>> basis = MSplineConv(10, window_size=200)
         >>> transformer = TransformerBasis(basis)
         >>> # Before calling `fit` the convolution kernel is not set
         >>> transformer.kernel_
@@ -181,13 +181,13 @@ class TransformerBasis:
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalMSpline, TransformerBasis
+        >>> from nemos.basis import MSplineEval, TransformerBasis
 
         >>> # Example input
         >>> X = np.random.normal(size=(100, 1))
 
         >>> # Define tranformation basis
-        >>> basis = EvalMSpline(10)
+        >>> basis = MSplineEval(10)
         >>> transformer = TransformerBasis(basis)
 
         >>> # Fit and transform basis
@@ -223,7 +223,7 @@ class TransformerBasis:
         Examples
         --------
         >>> from nemos import basis
-        >>> bas = basis.EvalRaisedCosineLinear(5)
+        >>> bas = basis.RaisedCosineLinearEval(5)
         >>> trans_bas = basis.TransformerBasis(bas)
         >>> bas.n_basis_funcs
         5
@@ -250,9 +250,9 @@ class TransformerBasis:
         Examples
         --------
         >>> import nemos as nmo
-        >>> trans_bas = nmo.basis.TransformerBasis(nmo.basis.EvalMSpline(10))
+        >>> trans_bas = nmo.basis.TransformerBasis(nmo.basis.MSplineEval(10))
         >>> # allowed
-        >>> trans_bas._basis = nmo.basis.EvalBSpline(10)
+        >>> trans_bas._basis = nmo.basis.BSplineEval(10)
         >>> # allowed
         >>> trans_bas.n_basis_funcs = 20
         >>> # not allowed
@@ -296,19 +296,19 @@ class TransformerBasis:
 
         Examples
         --------
-        >>> from nemos.basis import EvalBSpline, EvalMSpline, TransformerBasis
-        >>> basis = EvalMSpline(10)
+        >>> from nemos.basis import BSplineEval, MSplineEval, TransformerBasis
+        >>> basis = MSplineEval(10)
         >>> transformer_basis = TransformerBasis(basis=basis)
 
         >>> # setting parameters of _basis is allowed
         >>> print(transformer_basis.set_params(n_basis_funcs=8).n_basis_funcs)
         8
         >>> # setting _basis directly is allowed
-        >>> print(type(transformer_basis.set_params(_basis=EvalBSpline(10))._basis))
-        <class 'nemos.basis.basis.EvalBSpline'>
+        >>> print(type(transformer_basis.set_params(_basis=BSplineEval(10))._basis))
+        <class 'nemos.basis.basis.BSplineEval'>
         >>> # mixing is not allowed, this will raise an exception
         >>> try:
-        ...     transformer_basis.set_params(_basis=EvalBSpline(10), n_basis_funcs=2)
+        ...     transformer_basis.set_params(_basis=BSplineEval(10), n_basis_funcs=2)
         ... except ValueError as e:
         ...     print(repr(e))
         ValueError('Set either new _basis object or parameters for existing _basis, not both.')

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -136,13 +136,12 @@ class TransformerBasis:
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalMSpline, TransformerBasis
+        >>> from nemos.basis import ConvMSpline, TransformerBasis
 
         >>> # Example input
         >>> X = np.random.normal(size=(10000, 2))
 
-        >>> # Define and fit tranformation basis
-        >>> basis = EvalMSpline(10, mode="conv", window_size=200)
+        >>> basis = ConvMSpline(10, window_size=200)
         >>> transformer = TransformerBasis(basis)
         >>> # Before calling `fit` the convolution kernel is not set
         >>> transformer.kernel_
@@ -306,7 +305,7 @@ class TransformerBasis:
         8
         >>> # setting _basis directly is allowed
         >>> print(type(transformer_basis.set_params(_basis=EvalBSpline(10))._basis))
-        <class 'nemos.basis.BSplineBasis'>
+        <class 'nemos.basis.basis.EvalBSpline'>
         >>> # mixing is not allowed, this will raise an exception
         >>> try:
         ...     transformer_basis.set_params(_basis=EvalBSpline(10), n_basis_funcs=2)

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -8,7 +8,7 @@ from typing import Optional, Tuple
 from numpy.typing import ArrayLike, NDArray
 
 from ..typing import FeatureMatrix
-from ._basis_mixin import ConvBasisMixin, EvalBasisMixin
+from ._basis_mixin import BasisTransformerMixin, ConvBasisMixin, EvalBasisMixin
 from ._decaying_exponential import OrthExponentialBasis, add_orth_exp_decay_docstring
 from ._raised_cosine_basis import (
     RaisedCosineBasisLinear,
@@ -24,6 +24,7 @@ from ._spline_basis import (
     add_docstrings_cyclic_bspline,
     add_docstrings_mspline,
 )
+from ._transformer_basis import TransformerBasis
 
 __all__ = [
     "EvalMSpline",
@@ -38,6 +39,7 @@ __all__ = [
     "ConvRaisedCosineLog",
     "EvalOrthExponential",
     "ConvOrthExponential",
+    "TransformerBasis",
 ]
 
 
@@ -45,7 +47,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-class EvalBSpline(EvalBasisMixin, BSplineBasis):
+class EvalBSpline(EvalBasisMixin, BSplineBasis, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -61,6 +63,7 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
             order=order,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_docstrings_bspline("split_by_feature")
     def split_by_feature(
@@ -128,7 +131,7 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         return BSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class ConvBSpline(ConvBasisMixin, BSplineBasis):
+class ConvBSpline(ConvBasisMixin, BSplineBasis, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -145,6 +148,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
             order=order,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_docstrings_bspline("split_by_feature")
     def split_by_feature(
@@ -212,7 +216,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         return BSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
+class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -228,6 +232,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
             order=order,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_docstrings_cyclic_bspline("split_by_feature")
     def split_by_feature(
@@ -295,7 +300,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         return CyclicBSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
+class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -312,6 +317,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
             order=order,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_docstrings_cyclic_bspline("split_by_feature")
     def split_by_feature(
@@ -379,7 +385,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         return CyclicBSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class EvalMSpline(EvalBasisMixin, MSplineBasis):
+class EvalMSpline(EvalBasisMixin, MSplineBasis, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -395,6 +401,7 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
             order=order,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_docstrings_mspline("split_by_feature")
     def split_by_feature(
@@ -462,7 +469,7 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         return MSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class ConvMSpline(ConvBasisMixin, MSplineBasis):
+class ConvMSpline(ConvBasisMixin, MSplineBasis, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -479,6 +486,7 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
             order=order,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_docstrings_mspline("split_by_feature")
     def split_by_feature(
@@ -546,7 +554,9 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         return MSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class EvalRaisedCosineLinear(EvalBasisMixin, RaisedCosineBasisLinear):
+class EvalRaisedCosineLinear(
+    EvalBasisMixin, RaisedCosineBasisLinear, BasisTransformerMixin
+):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -562,6 +572,7 @@ class EvalRaisedCosineLinear(EvalBasisMixin, RaisedCosineBasisLinear):
             mode="eval",
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_raised_cosine_linear_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -622,7 +633,9 @@ class EvalRaisedCosineLinear(EvalBasisMixin, RaisedCosineBasisLinear):
         return RaisedCosineBasisLinear.split_by_feature(self, x, axis=axis)
 
 
-class ConvRaisedCosineLinear(ConvBasisMixin, RaisedCosineBasisLinear):
+class ConvRaisedCosineLinear(
+    ConvBasisMixin, RaisedCosineBasisLinear, BasisTransformerMixin
+):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -639,6 +652,7 @@ class ConvRaisedCosineLinear(ConvBasisMixin, RaisedCosineBasisLinear):
             width=width,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_raised_cosine_linear_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -699,7 +713,7 @@ class ConvRaisedCosineLinear(ConvBasisMixin, RaisedCosineBasisLinear):
         return RaisedCosineBasisLinear.split_by_feature(self, x, axis=axis)
 
 
-class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
+class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -719,6 +733,7 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
             mode="eval",
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_raised_cosine_log_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -779,7 +794,7 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
         return RaisedCosineBasisLog.split_by_feature(self, x, axis=axis)
 
 
-class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
+class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -800,6 +815,7 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
             enforce_decay_to_zero=enforce_decay_to_zero,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_raised_cosine_log_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -860,7 +876,7 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
         return RaisedCosineBasisLog.split_by_feature(self, x, axis=axis)
 
 
-class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
+class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis, BasisTransformerMixin):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -907,6 +923,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
             mode="eval",
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_orth_exp_decay_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -971,7 +988,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         return OrthExponentialBasis.split_by_feature(self, x, axis=axis)
 
 
-class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
+class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis, BasisTransformerMixin):
     """
     Examples
     --------
@@ -1004,6 +1021,7 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
             decay_rates=decay_rates,
             label=label,
         )
+        BasisTransformerMixin.__init__(self)
 
     @add_orth_exp_decay_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -47,7 +47,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-class EvalBSpline(EvalBasisMixin, BSplineBasis, BasisTransformerMixin):
+class EvalBSpline(EvalBasisMixin, BSplineBasis):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -63,7 +63,7 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis, BasisTransformerMixin):
             order=order,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_docstrings_bspline("split_by_feature")
     def split_by_feature(
@@ -131,7 +131,7 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis, BasisTransformerMixin):
         return BSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class ConvBSpline(ConvBasisMixin, BSplineBasis, BasisTransformerMixin):
+class ConvBSpline(ConvBasisMixin, BSplineBasis):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -148,7 +148,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis, BasisTransformerMixin):
             order=order,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_docstrings_bspline("split_by_feature")
     def split_by_feature(
@@ -216,7 +216,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis, BasisTransformerMixin):
         return BSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis, BasisTransformerMixin):
+class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -232,7 +232,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis, BasisTransformerMixi
             order=order,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_docstrings_cyclic_bspline("split_by_feature")
     def split_by_feature(
@@ -300,7 +300,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis, BasisTransformerMixi
         return CyclicBSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis, BasisTransformerMixin):
+class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -317,7 +317,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis, BasisTransformerMixi
             order=order,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_docstrings_cyclic_bspline("split_by_feature")
     def split_by_feature(
@@ -385,7 +385,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis, BasisTransformerMixi
         return CyclicBSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class EvalMSpline(EvalBasisMixin, MSplineBasis, BasisTransformerMixin):
+class EvalMSpline(EvalBasisMixin, MSplineBasis):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -401,7 +401,7 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis, BasisTransformerMixin):
             order=order,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_docstrings_mspline("split_by_feature")
     def split_by_feature(
@@ -469,7 +469,7 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis, BasisTransformerMixin):
         return MSplineBasis.evaluate_on_grid(self, n_samples)
 
 
-class ConvMSpline(ConvBasisMixin, MSplineBasis, BasisTransformerMixin):
+class ConvMSpline(ConvBasisMixin, MSplineBasis):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -486,7 +486,7 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis, BasisTransformerMixin):
             order=order,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_docstrings_mspline("split_by_feature")
     def split_by_feature(
@@ -572,7 +572,7 @@ class EvalRaisedCosineLinear(
             mode="eval",
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_raised_cosine_linear_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -652,7 +652,7 @@ class ConvRaisedCosineLinear(
             width=width,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_raised_cosine_linear_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -713,7 +713,7 @@ class ConvRaisedCosineLinear(
         return RaisedCosineBasisLinear.split_by_feature(self, x, axis=axis)
 
 
-class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog, BasisTransformerMixin):
+class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -733,7 +733,7 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog, BasisTransformer
             mode="eval",
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_raised_cosine_log_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -794,7 +794,7 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog, BasisTransformer
         return RaisedCosineBasisLog.split_by_feature(self, x, axis=axis)
 
 
-class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog, BasisTransformerMixin):
+class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -815,7 +815,7 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog, BasisTransformer
             enforce_decay_to_zero=enforce_decay_to_zero,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_raised_cosine_log_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -876,7 +876,7 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog, BasisTransformer
         return RaisedCosineBasisLog.split_by_feature(self, x, axis=axis)
 
 
-class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis, BasisTransformerMixin):
+class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
     def __init__(
         self,
         n_basis_funcs: int,
@@ -923,7 +923,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis, BasisTransformer
             mode="eval",
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_orth_exp_decay_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -988,7 +988,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis, BasisTransformer
         return OrthExponentialBasis.split_by_feature(self, x, axis=axis)
 
 
-class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis, BasisTransformerMixin):
+class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
     """
     Examples
     --------
@@ -1021,7 +1021,7 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis, BasisTransformer
             decay_rates=decay_rates,
             label=label,
         )
-        BasisTransformerMixin.__init__(self)
+
 
     @add_orth_exp_decay_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -8,37 +8,26 @@ from typing import Optional, Tuple
 from numpy.typing import ArrayLike, NDArray
 
 from ..typing import FeatureMatrix
+from ._basis import add_docstring
 from ._basis_mixin import BasisTransformerMixin, ConvBasisMixin, EvalBasisMixin
-from ._decaying_exponential import OrthExponentialBasis, add_orth_exp_decay_docstring
-from ._raised_cosine_basis import (
-    RaisedCosineBasisLinear,
-    RaisedCosineBasisLog,
-    add_raised_cosine_linear_docstring,
-    add_raised_cosine_log_docstring,
-)
-from ._spline_basis import (
-    BSplineBasis,
-    CyclicBSplineBasis,
-    MSplineBasis,
-    add_docstrings_bspline,
-    add_docstrings_cyclic_bspline,
-    add_docstrings_mspline,
-)
+from ._decaying_exponential import OrthExponentialBasis
+from ._raised_cosine_basis import RaisedCosineBasisLinear, RaisedCosineBasisLog
+from ._spline_basis import BSplineBasis, CyclicBSplineBasis, MSplineBasis
 from ._transformer_basis import TransformerBasis
 
 __all__ = [
-    "EvalMSpline",
-    "ConvMSpline",
-    "EvalBSpline",
-    "ConvBSpline",
-    "EvalCyclicBSpline",
-    "ConvCyclicBSpline",
-    "EvalRaisedCosineLinear",
-    "ConvRaisedCosineLinear",
-    "EvalRaisedCosineLog",
-    "ConvRaisedCosineLog",
-    "EvalOrthExponential",
-    "ConvOrthExponential",
+    "MSplineEval",
+    "MSplineConv",
+    "BSplineEval",
+    "BSplineConv",
+    "CyclicBSplineEval",
+    "CyclicBSplineConv",
+    "RaisedCosineLinearEval",
+    "RaisedCosineLinearConv",
+    "RaisedCosineLogEval",
+    "RaisedCosineLogConv",
+    "OrthExponentialEval",
+    "OrthExponentialConv",
     "TransformerBasis",
 ]
 
@@ -47,7 +36,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-class EvalBSpline(EvalBasisMixin, BSplineBasis):
+class BSplineEval(EvalBasisMixin, BSplineBasis):
     """
     B-spline 1-dimensional basis functions.
 
@@ -79,10 +68,10 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
     Examples
     --------
     >>> from numpy import linspace
-    >>> from nemos.basis import EvalBSpline
+    >>> from nemos.basis import BSplineEval
     >>> n_basis_funcs = 5
     >>> order = 3
-    >>> bspline_basis = EvalBSpline(n_basis_funcs, order=order)
+    >>> bspline_basis = BSplineEval(n_basis_funcs, order=order)
     >>> sample_points = linspace(0, 1, 100)
     >>> basis_functions = bspline_basis.compute_features(sample_points)
     """
@@ -92,7 +81,7 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         n_basis_funcs: int,
         order: int = 4,
         bounds: Optional[Tuple[float, float]] = None,
-        label: Optional[str] = "EvalBSpline",
+        label: Optional[str] = "BSplineEval",
     ):
         EvalBasisMixin.__init__(self, bounds=bounds)
         BSplineBasis.__init__(
@@ -103,7 +92,7 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
             label=label,
         )
 
-    @add_docstrings_bspline("split_by_feature")
+    @add_docstring("split_by_feature", BSplineBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -113,9 +102,9 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalBSpline
+        >>> from nemos.basis import BSplineEval
         >>> from nemos.glm import GLM
-        >>> basis = EvalBSpline(n_basis_funcs=6, label="one_input")
+        >>> basis = BSplineEval(n_basis_funcs=6, label="one_input")
         >>> X = basis.compute_features(np.random.randn(20,))
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -123,28 +112,28 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         one_input, shape (20, 1, 6)
 
         """
-        return BSplineBasis.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
-    @add_docstrings_bspline("compute_features")
+    @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalBSpline
+        >>> from nemos.basis import BSplineEval
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = EvalBSpline(10)
+        >>> basis = BSplineEval(10)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return BSplineBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_docstrings_bspline("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", BSplineBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
@@ -153,8 +142,8 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
 
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import EvalBSpline
-        >>> bspline_basis = EvalBSpline(n_basis_funcs=4, order=3)
+        >>> from nemos.basis import BSplineEval
+        >>> bspline_basis = BSplineEval(n_basis_funcs=4, order=3)
         >>> sample_points, basis_values = bspline_basis.evaluate_on_grid(100)
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
@@ -166,10 +155,10 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         Text(0, 0.5, 'Basis Function Value')
         >>> l = plt.legend()
         """
-        return BSplineBasis.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
 
-class ConvBSpline(ConvBasisMixin, BSplineBasis):
+class BSplineConv(ConvBasisMixin, BSplineBasis):
     """
     B-spline 1-dimensional basis functions.
 
@@ -198,10 +187,10 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
     Examples
     --------
     >>> from numpy import linspace
-    >>> from nemos.basis import ConvBSpline
+    >>> from nemos.basis import BSplineConv
     >>> n_basis_funcs = 5
     >>> order = 3
-    >>> bspline_basis = ConvBSpline(n_basis_funcs, order=order, window_size=10)
+    >>> bspline_basis = BSplineConv(n_basis_funcs, order=order, window_size=10)
     >>> sample_points = linspace(0, 1, 100)
     >>> features = bspline_basis.compute_features(sample_points)
     """
@@ -211,7 +200,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         n_basis_funcs: int,
         window_size: int,
         order: int = 4,
-        label: Optional[str] = "ConvBSpline",
+        label: Optional[str] = "BSplineConv",
         conv_kwargs: Optional[dict] = None,
     ):
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
@@ -223,7 +212,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
             label=label,
         )
 
-    @add_docstrings_bspline("split_by_feature")
+    @add_docstring("split_by_feature", BSplineBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -233,9 +222,9 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvBSpline
+        >>> from nemos.basis import BSplineConv
         >>> from nemos.glm import GLM
-        >>> basis = ConvBSpline(n_basis_funcs=6, window_size=10, label="two_inputs")
+        >>> basis = BSplineConv(n_basis_funcs=6, window_size=10, label="two_inputs")
         >>> X_multi = basis.compute_features(np.random.randn(20, 2))
         >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -243,28 +232,28 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         two_inputs, shape (20, 2, 6)
 
         """
-        return BSplineBasis.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
-    @add_docstrings_bspline("compute_features")
+    @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvBSpline
+        >>> from nemos.basis import BSplineConv
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = ConvBSpline(10, window_size=11)
+        >>> basis = BSplineConv(10, window_size=11)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return BSplineBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_docstrings_bspline("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", BSplineBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
@@ -273,8 +262,8 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
 
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import ConvBSpline
-        >>> bspline_basis = ConvBSpline(n_basis_funcs=4, order=3, window_size=10)
+        >>> from nemos.basis import BSplineConv
+        >>> bspline_basis = BSplineConv(n_basis_funcs=4, order=3, window_size=10)
         >>> sample_points, basis_values = bspline_basis.evaluate_on_grid(100)
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
@@ -286,10 +275,10 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         Text(0, 0.5, 'Basis Function Value')
         >>> l = plt.legend()
         """
-        return BSplineBasis.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
 
-class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
+class CyclicBSplineEval(EvalBasisMixin, CyclicBSplineBasis):
     """
     B-spline 1-dimensional basis functions for cyclic splines.
 
@@ -312,10 +301,10 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
     Examples
     --------
     >>> from numpy import linspace
-    >>> from nemos.basis import EvalCyclicBSpline
+    >>> from nemos.basis import CyclicBSplineEval
     >>> n_basis_funcs = 5
     >>> order = 3
-    >>> cyclic_bspline_basis = EvalCyclicBSpline(n_basis_funcs, order=order)
+    >>> cyclic_bspline_basis = CyclicBSplineEval(n_basis_funcs, order=order)
     >>> sample_points = linspace(0, 1, 100)
     >>> features = cyclic_bspline_basis.compute_features(sample_points)
     """
@@ -325,7 +314,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         n_basis_funcs: int,
         order: int = 4,
         bounds: Optional[Tuple[float, float]] = None,
-        label: Optional[str] = "EvalCyclicBSpline",
+        label: Optional[str] = "CyclicBSplineEval",
     ):
         EvalBasisMixin.__init__(self, bounds=bounds)
         CyclicBSplineBasis.__init__(
@@ -336,7 +325,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
             label=label,
         )
 
-    @add_docstrings_cyclic_bspline("split_by_feature")
+    @add_docstring("split_by_feature", CyclicBSplineBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -346,9 +335,9 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalCyclicBSpline
+        >>> from nemos.basis import CyclicBSplineEval
         >>> from nemos.glm import GLM
-        >>> basis = EvalCyclicBSpline(n_basis_funcs=6, label="one_input")
+        >>> basis = CyclicBSplineEval(n_basis_funcs=6, label="one_input")
         >>> X = basis.compute_features(np.random.randn(20,))
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -356,28 +345,28 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         one_input, shape (20, 1, 6)
 
         """
-        return CyclicBSplineBasis.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
-    @add_docstrings_cyclic_bspline("compute_features")
+    @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalCyclicBSpline
+        >>> from nemos.basis import CyclicBSplineEval
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = EvalCyclicBSpline(10)
+        >>> basis = CyclicBSplineEval(10)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return CyclicBSplineBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_docstrings_cyclic_bspline("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", CyclicBSplineBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
@@ -386,8 +375,8 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
 
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import EvalCyclicBSpline
-        >>> cbspline_basis = EvalCyclicBSpline(n_basis_funcs=4, order=3)
+        >>> from nemos.basis import CyclicBSplineEval
+        >>> cbspline_basis = CyclicBSplineEval(n_basis_funcs=4, order=3)
         >>> sample_points, basis_values = cbspline_basis.evaluate_on_grid(100)
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
@@ -399,10 +388,10 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         Text(0, 0.5, 'Basis Function Value')
         >>> l = plt.legend()
         """
-        return CyclicBSplineBasis.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
 
-class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
+class CyclicBSplineConv(ConvBasisMixin, CyclicBSplineBasis):
     """
     B-spline 1-dimensional basis functions for cyclic splines.
 
@@ -423,10 +412,10 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
     Examples
     --------
     >>> from numpy import linspace
-    >>> from nemos.basis import ConvCyclicBSpline
+    >>> from nemos.basis import CyclicBSplineConv
     >>> n_basis_funcs = 5
     >>> order = 3
-    >>> cyclic_bspline_basis = ConvCyclicBSpline(n_basis_funcs, order=order, window_size=10)
+    >>> cyclic_bspline_basis = CyclicBSplineConv(n_basis_funcs, order=order, window_size=10)
     >>> sample_points = linspace(0, 1, 100)
     >>> features = cyclic_bspline_basis.compute_features(sample_points)
     """
@@ -436,7 +425,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         n_basis_funcs: int,
         window_size: int,
         order: int = 4,
-        label: Optional[str] = "ConvCyclicBSpline",
+        label: Optional[str] = "CyclicBSplineConv",
         conv_kwargs: Optional[dict] = None,
     ):
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
@@ -448,7 +437,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
             label=label,
         )
 
-    @add_docstrings_cyclic_bspline("split_by_feature")
+    @add_docstring("split_by_feature", CyclicBSplineBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -458,9 +447,9 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvCyclicBSpline
+        >>> from nemos.basis import CyclicBSplineConv
         >>> from nemos.glm import GLM
-        >>> basis = ConvCyclicBSpline(n_basis_funcs=6, window_size=10, label="two_inputs")
+        >>> basis = CyclicBSplineConv(n_basis_funcs=6, window_size=10, label="two_inputs")
         >>> X_multi = basis.compute_features(np.random.randn(20, 2))
         >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -468,28 +457,28 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         two_inputs, shape (20, 2, 6)
 
         """
-        return CyclicBSplineBasis.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
-    @add_docstrings_cyclic_bspline("compute_features")
+    @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvCyclicBSpline
+        >>> from nemos.basis import CyclicBSplineConv
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = ConvCyclicBSpline(10, window_size=11)
+        >>> basis = CyclicBSplineConv(10, window_size=11)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return CyclicBSplineBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_docstrings_cyclic_bspline("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", CyclicBSplineBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
@@ -498,8 +487,8 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
 
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import ConvCyclicBSpline
-        >>> cbspline_basis = ConvCyclicBSpline(n_basis_funcs=4, order=3, window_size=10)
+        >>> from nemos.basis import CyclicBSplineConv
+        >>> cbspline_basis = CyclicBSplineConv(n_basis_funcs=4, order=3, window_size=10)
         >>> sample_points, basis_values = cbspline_basis.evaluate_on_grid(100)
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
@@ -511,10 +500,10 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         Text(0, 0.5, 'Basis Function Value')
         >>> l = plt.legend()
         """
-        return CyclicBSplineBasis.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
 
-class EvalMSpline(EvalBasisMixin, MSplineBasis):
+class MSplineEval(EvalBasisMixin, MSplineBasis):
     r"""
     M-spline basis functions for modeling and data transformation.
 
@@ -561,10 +550,10 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
     Examples
     --------
     >>> from numpy import linspace
-    >>> from nemos.basis import EvalMSpline
+    >>> from nemos.basis import MSplineEval
     >>> n_basis_funcs = 5
     >>> order = 3
-    >>> mspline_basis = EvalMSpline(n_basis_funcs, order=order)
+    >>> mspline_basis = MSplineEval(n_basis_funcs, order=order)
     >>> sample_points = linspace(0, 1, 100)
     >>> features = mspline_basis.compute_features(sample_points)
     """
@@ -574,7 +563,7 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         n_basis_funcs: int,
         order: int = 4,
         bounds: Optional[Tuple[float, float]] = None,
-        label: Optional[str] = "EvalMSpline",
+        label: Optional[str] = "MSplineEval",
     ):
         EvalBasisMixin.__init__(self, bounds=bounds)
         MSplineBasis.__init__(
@@ -585,7 +574,7 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
             label=label,
         )
 
-    @add_docstrings_mspline("split_by_feature")
+    @add_docstring("split_by_feature", MSplineBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -595,9 +584,9 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalMSpline
+        >>> from nemos.basis import MSplineEval
         >>> from nemos.glm import GLM
-        >>> basis = EvalMSpline(n_basis_funcs=6, label="one_input")
+        >>> basis = MSplineEval(n_basis_funcs=6, label="one_input")
         >>> X = basis.compute_features(np.random.randn(20))
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -607,26 +596,26 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         """
         return MSplineBasis.split_by_feature(self, x, axis=axis)
 
-    @add_docstrings_mspline("compute_features")
+    @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalMSpline
+        >>> from nemos.basis import MSplineEval
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = EvalMSpline(10)
+        >>> basis = MSplineEval(10)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return MSplineBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_docstrings_mspline("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", MSplineBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
@@ -635,8 +624,8 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
 
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import EvalMSpline
-        >>> mspline_basis = EvalMSpline(n_basis_funcs=4, order=3)
+        >>> from nemos.basis import MSplineEval
+        >>> mspline_basis = MSplineEval(n_basis_funcs=4, order=3)
         >>> sample_points, basis_values = mspline_basis.evaluate_on_grid(100)
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
@@ -648,10 +637,10 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         Text(0, 0.5, 'Basis Function Value')
         >>> l = plt.legend()
         """
-        return MSplineBasis.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
 
-class ConvMSpline(ConvBasisMixin, MSplineBasis):
+class MSplineConv(ConvBasisMixin, MSplineBasis):
     r"""
     M-spline basis functions for modeling and data transformation.
 
@@ -696,10 +685,10 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
     Examples
     --------
     >>> from numpy import linspace
-    >>> from nemos.basis import ConvMSpline
+    >>> from nemos.basis import MSplineConv
     >>> n_basis_funcs = 5
     >>> order = 3
-    >>> mspline_basis = ConvMSpline(n_basis_funcs, order=order, window_size=10)
+    >>> mspline_basis = MSplineConv(n_basis_funcs, order=order, window_size=10)
     >>> sample_points = linspace(0, 1, 100)
     >>> features = mspline_basis.compute_features(sample_points)
     """
@@ -709,7 +698,7 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         n_basis_funcs: int,
         window_size: int,
         order: int = 4,
-        label: Optional[str] = "ConvMSpline",
+        label: Optional[str] = "MSplineConv",
         conv_kwargs: Optional[dict] = None,
     ):
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
@@ -721,7 +710,7 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
             label=label,
         )
 
-    @add_docstrings_mspline("split_by_feature")
+    @add_docstring("split_by_feature", MSplineBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -731,9 +720,9 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvMSpline
+        >>> from nemos.basis import MSplineConv
         >>> from nemos.glm import GLM
-        >>> basis = ConvMSpline(n_basis_funcs=6, window_size=10, label="two_inputs")
+        >>> basis = MSplineConv(n_basis_funcs=6, window_size=10, label="two_inputs")
         >>> X_multi = basis.compute_features(np.random.randn(20, 2))
         >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -741,28 +730,28 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         two_inputs, shape (20, 2, 6)
 
         """
-        return MSplineBasis.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
-    @add_docstrings_mspline("compute_features")
+    @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvMSpline
+        >>> from nemos.basis import MSplineConv
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = ConvMSpline(10, window_size=11)
+        >>> basis = MSplineConv(10, window_size=11)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return MSplineBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_docstrings_mspline("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", MSplineBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
@@ -771,8 +760,8 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
 
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import ConvMSpline
-        >>> mspline_basis = ConvMSpline(n_basis_funcs=4, order=3, window_size=10)
+        >>> from nemos.basis import MSplineConv
+        >>> mspline_basis = MSplineConv(n_basis_funcs=4, order=3, window_size=10)
         >>> sample_points, basis_values = mspline_basis.evaluate_on_grid(100)
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
@@ -784,10 +773,10 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         Text(0, 0.5, 'Basis Function Value')
         >>> l = plt.legend()
         """
-        return MSplineBasis.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
 
-class EvalRaisedCosineLinear(
+class RaisedCosineLinearEval(
     EvalBasisMixin, RaisedCosineBasisLinear, BasisTransformerMixin
 ):
     """
@@ -820,9 +809,9 @@ class EvalRaisedCosineLinear(
     Examples
     --------
     >>> import numpy as np
-    >>> from nemos.basis import EvalRaisedCosineLinear
+    >>> from nemos.basis import RaisedCosineLinearEval
     >>> n_basis_funcs = 5
-    >>> raised_cosine_basis = EvalRaisedCosineLinear(n_basis_funcs)
+    >>> raised_cosine_basis = RaisedCosineLinearEval(n_basis_funcs)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
     >>> features = raised_cosine_basis.compute_features(sample_points)
@@ -833,7 +822,7 @@ class EvalRaisedCosineLinear(
         n_basis_funcs: int,
         width: float = 2.0,
         bounds: Optional[Tuple[float, float]] = None,
-        label: Optional[str] = "EvalRaisedCosineLinear",
+        label: Optional[str] = "RaisedCosineLinearEval",
     ):
         EvalBasisMixin.__init__(self, bounds=bounds)
         RaisedCosineBasisLinear.__init__(
@@ -844,43 +833,43 @@ class EvalRaisedCosineLinear(
             label=label,
         )
 
-    @add_raised_cosine_linear_docstring("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", RaisedCosineBasisLinear)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
         --------
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import EvalRaisedCosineLinear
+        >>> from nemos.basis import RaisedCosineLinearEval
         >>> n_basis_funcs = 5
         >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05]) # sample decay rates
         >>> window_size=10
-        >>> ortho_basis = EvalRaisedCosineLinear(n_basis_funcs)
+        >>> ortho_basis = RaisedCosineLinearEval(n_basis_funcs)
         >>> sample_points, basis_values = ortho_basis.evaluate_on_grid(100)
 
         """
-        return RaisedCosineBasisLinear.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
-    @add_raised_cosine_linear_docstring("compute_features")
+    @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalRaisedCosineLinear
+        >>> from nemos.basis import RaisedCosineLinearEval
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = EvalRaisedCosineLinear(10)
+        >>> basis = RaisedCosineLinearEval(10)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return RaisedCosineBasisLinear.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_raised_cosine_linear_docstring("split_by_feature")
+    @add_docstring("split_by_feature", RaisedCosineBasisLinear)
     def split_by_feature(
         self,
         x: NDArray,
@@ -890,9 +879,9 @@ class EvalRaisedCosineLinear(
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalRaisedCosineLinear
+        >>> from nemos.basis import RaisedCosineLinearEval
         >>> from nemos.glm import GLM
-        >>> basis = EvalRaisedCosineLinear(n_basis_funcs=6, label="one_input")
+        >>> basis = RaisedCosineLinearEval(n_basis_funcs=6, label="one_input")
         >>> X = basis.compute_features(np.random.randn(20,))
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -900,10 +889,10 @@ class EvalRaisedCosineLinear(
         one_input, shape (20, 1, 6)
 
         """
-        return RaisedCosineBasisLinear.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
 
-class ConvRaisedCosineLinear(
+class RaisedCosineLinearConv(
     ConvBasisMixin, RaisedCosineBasisLinear, BasisTransformerMixin
 ):
     """
@@ -934,9 +923,9 @@ class ConvRaisedCosineLinear(
     Examples
     --------
     >>> import numpy as np
-    >>> from nemos.basis import ConvRaisedCosineLinear
+    >>> from nemos.basis import RaisedCosineLinearConv
     >>> n_basis_funcs = 5
-    >>> raised_cosine_basis = ConvRaisedCosineLinear(n_basis_funcs, window_size=10)
+    >>> raised_cosine_basis = RaisedCosineLinearConv(n_basis_funcs, window_size=10)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
     >>> features = raised_cosine_basis.compute_features(sample_points)
@@ -947,7 +936,7 @@ class ConvRaisedCosineLinear(
         n_basis_funcs: int,
         window_size: int,
         width: float = 2.0,
-        label: Optional[str] = "ConvRaisedCosineLinear",
+        label: Optional[str] = "RaisedCosineLinearConv",
         conv_kwargs: Optional[dict] = None,
     ):
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
@@ -959,43 +948,43 @@ class ConvRaisedCosineLinear(
             label=label,
         )
 
-    @add_raised_cosine_linear_docstring("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", RaisedCosineBasisLinear)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
         --------
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import ConvRaisedCosineLinear
+        >>> from nemos.basis import RaisedCosineLinearConv
         >>> n_basis_funcs = 5
         >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05]) # sample decay rates
         >>> window_size=10
-        >>> ortho_basis = ConvRaisedCosineLinear(n_basis_funcs, window_size)
+        >>> ortho_basis = RaisedCosineLinearConv(n_basis_funcs, window_size)
         >>> sample_points, basis_values = ortho_basis.evaluate_on_grid(100)
 
         """
-        return RaisedCosineBasisLinear.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
-    @add_raised_cosine_linear_docstring("compute_features")
+    @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvRaisedCosineLinear
+        >>> from nemos.basis import RaisedCosineLinearConv
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = ConvRaisedCosineLinear(10, window_size=100)
+        >>> basis = RaisedCosineLinearConv(10, window_size=100)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return RaisedCosineBasisLinear.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_raised_cosine_linear_docstring("split_by_feature")
+    @add_docstring("split_by_feature", RaisedCosineBasisLinear)
     def split_by_feature(
         self,
         x: NDArray,
@@ -1005,9 +994,9 @@ class ConvRaisedCosineLinear(
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvRaisedCosineLinear
+        >>> from nemos.basis import RaisedCosineLinearConv
         >>> from nemos.glm import GLM
-        >>> basis = ConvRaisedCosineLinear(n_basis_funcs=6, window_size=10, label="two_inputs")
+        >>> basis = RaisedCosineLinearConv(n_basis_funcs=6, window_size=10, label="two_inputs")
         >>> X_multi = basis.compute_features(np.random.randn(20, 2))
         >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -1015,13 +1004,13 @@ class ConvRaisedCosineLinear(
         two_inputs, shape (20, 2, 6)
 
         """
-        return RaisedCosineBasisLinear.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
 
-class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
+class RaisedCosineLogEval(EvalBasisMixin, RaisedCosineBasisLog):
     """Represent log-spaced raised cosine basis functions.
 
-    Similar to ``EvalRaisedCosineLinear`` but the basis functions are log-spaced.
+    Similar to ``RaisedCosineLinearEval`` but the basis functions are log-spaced.
     This implementation is based on the cosine bumps used by Pillow et al. [1]_
     to uniformly tile the internal points of the domain.
 
@@ -1055,9 +1044,9 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
     Examples
     --------
     >>> import numpy as np
-    >>> from nemos.basis import EvalRaisedCosineLog
+    >>> from nemos.basis import RaisedCosineLogEval
     >>> n_basis_funcs = 5
-    >>> raised_cosine_basis = EvalRaisedCosineLog(n_basis_funcs)
+    >>> raised_cosine_basis = RaisedCosineLogEval(n_basis_funcs)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
     >>> features = raised_cosine_basis.compute_features(sample_points)
@@ -1070,7 +1059,7 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
         time_scaling: float = None,
         enforce_decay_to_zero: bool = True,
         bounds: Optional[Tuple[float, float]] = None,
-        label: Optional[str] = "EvalRaisedCosineLog",
+        label: Optional[str] = "RaisedCosineLogEval",
     ):
         EvalBasisMixin.__init__(self, bounds=bounds)
         RaisedCosineBasisLog.__init__(
@@ -1083,43 +1072,43 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
             label=label,
         )
 
-    @add_raised_cosine_log_docstring("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", RaisedCosineBasisLog)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
         --------
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import EvalRaisedCosineLog
+        >>> from nemos.basis import RaisedCosineLogEval
         >>> n_basis_funcs = 5
         >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05]) # sample decay rates
         >>> window_size=10
-        >>> ortho_basis = EvalRaisedCosineLog(n_basis_funcs)
+        >>> ortho_basis = RaisedCosineLogEval(n_basis_funcs)
         >>> sample_points, basis_values = ortho_basis.evaluate_on_grid(100)
 
         """
-        return RaisedCosineBasisLog.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
-    @add_raised_cosine_log_docstring("compute_features")
+    @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalRaisedCosineLog
+        >>> from nemos.basis import RaisedCosineLogEval
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = EvalRaisedCosineLog(10)
+        >>> basis = RaisedCosineLogEval(10)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return RaisedCosineBasisLog.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_raised_cosine_log_docstring("split_by_feature")
+    @add_docstring("split_by_feature", RaisedCosineBasisLog)
     def split_by_feature(
         self,
         x: NDArray,
@@ -1129,9 +1118,9 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalRaisedCosineLog
+        >>> from nemos.basis import RaisedCosineLogEval
         >>> from nemos.glm import GLM
-        >>> basis = EvalRaisedCosineLog(n_basis_funcs=6, label="one_input")
+        >>> basis = RaisedCosineLogEval(n_basis_funcs=6, label="one_input")
         >>> X = basis.compute_features(np.random.randn(20,))
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -1139,13 +1128,13 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
         one_input, shape (20, 1, 6)
 
         """
-        return RaisedCosineBasisLog.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
 
-class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
+class RaisedCosineLogConv(ConvBasisMixin, RaisedCosineBasisLog):
     """Represent log-spaced raised cosine basis functions.
 
-    Similar to ``ConvRaisedCosineLinear`` but the basis functions are log-spaced.
+    Similar to ``RaisedCosineLinearConv`` but the basis functions are log-spaced.
     This implementation is based on the cosine bumps used by Pillow et al. [1]_
     to uniformly tile the internal points of the domain.
 
@@ -1179,9 +1168,9 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
     Examples
     --------
     >>> import numpy as np
-    >>> from nemos.basis import ConvRaisedCosineLog
+    >>> from nemos.basis import RaisedCosineLogConv
     >>> n_basis_funcs = 5
-    >>> raised_cosine_basis = ConvRaisedCosineLog(n_basis_funcs, window_size=10)
+    >>> raised_cosine_basis = RaisedCosineLogConv(n_basis_funcs, window_size=10)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
     >>> features = raised_cosine_basis.compute_features(sample_points)
@@ -1194,7 +1183,7 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
         width: float = 2.0,
         time_scaling: float = None,
         enforce_decay_to_zero: bool = True,
-        label: Optional[str] = "ConvRaisedCosineLog",
+        label: Optional[str] = "RaisedCosineLogConv",
         conv_kwargs: Optional[dict] = None,
     ):
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
@@ -1208,43 +1197,43 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
             label=label,
         )
 
-    @add_raised_cosine_log_docstring("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", RaisedCosineBasisLog)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
         --------
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import ConvRaisedCosineLog
+        >>> from nemos.basis import RaisedCosineLogConv
         >>> n_basis_funcs = 5
         >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05]) # sample decay rates
         >>> window_size=10
-        >>> ortho_basis = ConvRaisedCosineLog(n_basis_funcs, window_size)
+        >>> ortho_basis = RaisedCosineLogConv(n_basis_funcs, window_size)
         >>> sample_points, basis_values = ortho_basis.evaluate_on_grid(100)
 
         """
-        return RaisedCosineBasisLog.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
-    @add_raised_cosine_log_docstring("compute_features")
+    @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvRaisedCosineLog
+        >>> from nemos.basis import RaisedCosineLogConv
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = ConvRaisedCosineLog(10, window_size=100)
+        >>> basis = RaisedCosineLogConv(10, window_size=100)
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return RaisedCosineBasisLog.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_raised_cosine_log_docstring("split_by_feature")
+    @add_docstring("split_by_feature", RaisedCosineBasisLog)
     def split_by_feature(
         self,
         x: NDArray,
@@ -1254,9 +1243,9 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvRaisedCosineLog
+        >>> from nemos.basis import RaisedCosineLogConv
         >>> from nemos.glm import GLM
-        >>> basis = ConvRaisedCosineLog(n_basis_funcs=6, window_size=10, label="two_inputs")
+        >>> basis = RaisedCosineLogConv(n_basis_funcs=6, window_size=10, label="two_inputs")
         >>> X_multi = basis.compute_features(np.random.randn(20, 2))
         >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
@@ -1264,10 +1253,10 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
         two_inputs, shape (20, 2, 6)
 
         """
-        return RaisedCosineBasisLog.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
 
-class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
+class OrthExponentialEval(EvalBasisMixin, OrthExponentialBasis):
     """Set of 1D basis decaying exponential functions numerically orthogonalized.
 
     Parameters
@@ -1288,12 +1277,12 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
     --------
     >>> import numpy as np
     >>> from numpy import linspace
-    >>> from nemos.basis import EvalOrthExponential
+    >>> from nemos.basis import OrthExponentialEval
     >>> X = np.random.normal(size=(1000, 1))
     >>> n_basis_funcs = 5
     >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05])  # sample decay rates
     >>> window_size = 10
-    >>> ortho_basis = EvalOrthExponential(n_basis_funcs, decay_rates)
+    >>> ortho_basis = OrthExponentialEval(n_basis_funcs, decay_rates)
     >>> sample_points = linspace(0, 1, 100)
     >>> # evaluate the basis
     >>> features = ortho_basis.compute_features(sample_points)
@@ -1305,7 +1294,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         n_basis_funcs: int,
         decay_rates: NDArray,
         bounds: Optional[Tuple[float, float]] = None,
-        label: Optional[str] = "EvalOrthExponential",
+        label: Optional[str] = "OrthExponentialEval",
     ):
         EvalBasisMixin.__init__(self, bounds=bounds)
         OrthExponentialBasis.__init__(
@@ -1316,43 +1305,43 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
             label=label,
         )
 
-    @add_orth_exp_decay_docstring("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", OrthExponentialBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
         --------
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import EvalOrthExponential
+        >>> from nemos.basis import OrthExponentialEval
         >>> n_basis_funcs = 5
         >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05]) # sample decay rates
         >>> window_size=10
-        >>> ortho_basis = EvalOrthExponential(n_basis_funcs, decay_rates=decay_rates)
+        >>> ortho_basis = OrthExponentialEval(n_basis_funcs, decay_rates=decay_rates)
         >>> sample_points, basis_values = ortho_basis.evaluate_on_grid(100)
 
         """
-        return OrthExponentialBasis.evaluate_on_grid(self, n_samples=n_samples)
+        return super().evaluate_on_grid(n_samples=n_samples)
 
-    @add_orth_exp_decay_docstring("compute_features")
+    @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalOrthExponential
+        >>> from nemos.basis import OrthExponentialEval
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = EvalOrthExponential(10, decay_rates=np.arange(1, 11))
+        >>> basis = OrthExponentialEval(10, decay_rates=np.arange(1, 11))
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return OrthExponentialBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_orth_exp_decay_docstring("split_by_feature")
+    @add_docstring("split_by_feature", OrthExponentialBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -1362,10 +1351,10 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import EvalOrthExponential
+        >>> from nemos.basis import OrthExponentialEval
         >>> from nemos.glm import GLM
         >>> # Define an additive basis
-        >>> basis = EvalOrthExponential(n_basis_funcs=5, decay_rates=np.arange(1, 6), label="feature")
+        >>> basis = OrthExponentialEval(n_basis_funcs=5, decay_rates=np.arange(1, 6), label="feature")
         >>> # Generate a sample input array and compute features
         >>> x = np.random.randn(20)
         >>> X = basis.compute_features(x)
@@ -1376,10 +1365,10 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         feature: shape (20, 1, 5)
 
         """
-        return OrthExponentialBasis.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)
 
 
-class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
+class OrthExponentialConv(ConvBasisMixin, OrthExponentialBasis):
     """Set of 1D basis decaying exponential functions numerically orthogonalized.
 
     Parameters
@@ -1397,12 +1386,12 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
     Examples
     --------
     >>> import numpy as np
-    >>> from nemos.basis import ConvOrthExponential
+    >>> from nemos.basis import OrthExponentialConv
     >>> X = np.random.normal(size=(1000, 1))
     >>> n_basis_funcs = 5
     >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05])  # sample decay rates
     >>> window_size = 10
-    >>> ortho_basis = ConvOrthExponential(n_basis_funcs, window_size, decay_rates)
+    >>> ortho_basis = OrthExponentialConv(n_basis_funcs, window_size, decay_rates)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
     >>> features = ortho_basis.compute_features(sample_points)
@@ -1413,7 +1402,7 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
         n_basis_funcs: int,
         window_size: int,
         decay_rates: NDArray,
-        label: Optional[str] = "ConvOrthExponential",
+        label: Optional[str] = "OrthExponentialConv",
         conv_kwargs: Optional[dict] = None,
     ):
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
@@ -1425,43 +1414,43 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
             label=label,
         )
 
-    @add_orth_exp_decay_docstring("evaluate_on_grid")
+    @add_docstring("evaluate_on_grid", OrthExponentialBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
         --------
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
-        >>> from nemos.basis import ConvOrthExponential
+        >>> from nemos.basis import OrthExponentialConv
         >>> n_basis_funcs = 5
         >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05]) # sample decay rates
         >>> window_size=10
-        >>> ortho_basis = ConvOrthExponential(n_basis_funcs, window_size, decay_rates=decay_rates)
+        >>> ortho_basis = OrthExponentialConv(n_basis_funcs, window_size, decay_rates=decay_rates)
         >>> sample_points, basis_values = ortho_basis.evaluate_on_grid(100)
 
         """
-        return OrthExponentialBasis.evaluate_on_grid(self, n_samples)
+        return super().evaluate_on_grid(n_samples)
 
-    @add_orth_exp_decay_docstring("compute_features")
+    @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvOrthExponential
+        >>> from nemos.basis import OrthExponentialConv
 
         >>> # Generate data
         >>> num_samples = 1000
         >>> X = np.random.normal(size=(num_samples, ))  # raw time series
-        >>> basis = ConvOrthExponential(10, window_size=100, decay_rates=np.arange(1, 11))
+        >>> basis = OrthExponentialConv(10, window_size=100, decay_rates=np.arange(1, 11))
         >>> features = basis.compute_features(X)  # basis transformed time series
         >>> features.shape
         (1000, 10)
 
         """
-        return OrthExponentialBasis.compute_features(self, xi)
+        return super().compute_features(xi)
 
-    @add_orth_exp_decay_docstring("split_by_feature")
+    @add_docstring("split_by_feature", OrthExponentialBasis)
     def split_by_feature(
         self,
         x: NDArray,
@@ -1471,9 +1460,9 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
         Examples
         --------
         >>> import numpy as np
-        >>> from nemos.basis import ConvOrthExponential
+        >>> from nemos.basis import OrthExponentialConv
         >>> from nemos.glm import GLM
-        >>> basis = ConvOrthExponential(
+        >>> basis = OrthExponentialConv(
         ...     n_basis_funcs=6,
         ...     decay_rates=np.arange(1, 7),
         ...     window_size=10,
@@ -1486,4 +1475,4 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
         two_inputs, shape (20, 2, 6)
 
         """
-        return OrthExponentialBasis.split_by_feature(self, x, axis=axis)
+        return super().split_by_feature(x, axis=axis)

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -84,8 +84,9 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
 
         References
         ----------
-        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline Techniques.
-            Mathematics and Visualization. Springer, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-04919-8_5
+        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline
+            Techniques. Mathematics and Visualization. Springer, Berlin, Heidelberg.
+            https://doi.org/10.1007/978-3-662-04919-8_5
 
         Examples
         --------
@@ -208,8 +209,9 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
 
         References
         ----------
-        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline Techniques.
-            Mathematics and Visualization. Springer, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-04919-8_5
+        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In:
+            Bézier and B-Spline Techniques. Mathematics and Visualization. Springer, Berlin, Heidelberg.
+            https://doi.org/10.1007/978-3-662-04919-8_5
 
         Examples
         --------
@@ -579,8 +581,8 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         Notes
         -----
         ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
-        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain (y-axis) values
-        will shrink by a factor of :math:`1/\alpha`.
+        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain
+        (y-axis) values will shrink by a factor of :math:`1/\alpha`.
         For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
         If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
 
@@ -714,8 +716,8 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         Notes
         -----
         ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
-        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain (y-axis) values
-        will shrink by a factor of :math:`1/\alpha`.
+        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain
+        (y-axis) values will shrink by a factor of :math:`1/\alpha`.
         For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
         If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
 
@@ -844,6 +846,7 @@ class EvalRaisedCosineLinear(
     >>> # convolve the basis
     >>> basis_functions = raised_cosine_basis.compute_features(sample_points)
     """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -957,6 +960,7 @@ class ConvRaisedCosineLinear(
     >>> # convolve the basis
     >>> basis_functions = raised_cosine_basis.compute_features(sample_points)
     """
+
     def __init__(
         self,
         n_basis_funcs: int,

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -221,7 +221,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         >>> order = 3
         >>> bspline_basis = ConvBSpline(n_basis_funcs, order=order, window_size=10)
         >>> sample_points = linspace(0, 1, 100)
-        >>> basis_functions = bspline_basis.compute_features(sample_points)
+        >>> features = bspline_basis.compute_features(sample_points)
         """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         BSplineBasis.__init__(
@@ -340,7 +340,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         >>> order = 3
         >>> cyclic_bspline_basis = EvalCyclicBSpline(n_basis_funcs, order=order)
         >>> sample_points = linspace(0, 1, 100)
-        >>> basis_functions = cyclic_bspline_basis.compute_features(sample_points)
+        >>> features = cyclic_bspline_basis.compute_features(sample_points)
         """
         EvalBasisMixin.__init__(self, bounds=bounds)
         CyclicBSplineBasis.__init__(
@@ -458,7 +458,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         >>> order = 3
         >>> cyclic_bspline_basis = ConvCyclicBSpline(n_basis_funcs, order=order, window_size=10)
         >>> sample_points = linspace(0, 1, 100)
-        >>> basis_functions = cyclic_bspline_basis.compute_features(sample_points)
+        >>> features = cyclic_bspline_basis.compute_features(sample_points)
         """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         CyclicBSplineBasis.__init__(
@@ -594,7 +594,7 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         >>> order = 3
         >>> mspline_basis = EvalMSpline(n_basis_funcs, order=order)
         >>> sample_points = linspace(0, 1, 100)
-        >>> basis_functions = mspline_basis.compute_features(sample_points)
+        >>> features = mspline_basis.compute_features(sample_points)
         """
         EvalBasisMixin.__init__(self, bounds=bounds)
         MSplineBasis.__init__(
@@ -729,7 +729,7 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         >>> order = 3
         >>> mspline_basis = ConvMSpline(n_basis_funcs, order=order, window_size=10)
         >>> sample_points = linspace(0, 1, 100)
-        >>> basis_functions = mspline_basis.compute_features(sample_points)
+        >>> features = mspline_basis.compute_features(sample_points)
         """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         MSplineBasis.__init__(
@@ -844,7 +844,7 @@ class EvalRaisedCosineLinear(
     >>> raised_cosine_basis = EvalRaisedCosineLinear(n_basis_funcs)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
-    >>> basis_functions = raised_cosine_basis.compute_features(sample_points)
+    >>> features = raised_cosine_basis.compute_features(sample_points)
     """
 
     def __init__(
@@ -958,7 +958,7 @@ class ConvRaisedCosineLinear(
     >>> raised_cosine_basis = ConvRaisedCosineLinear(n_basis_funcs, window_size=10)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
-    >>> basis_functions = raised_cosine_basis.compute_features(sample_points)
+    >>> features = raised_cosine_basis.compute_features(sample_points)
     """
 
     def __init__(
@@ -1088,7 +1088,7 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
         >>> raised_cosine_basis = EvalRaisedCosineLog(n_basis_funcs)
         >>> sample_points = np.random.randn(100)
         >>> # convolve the basis
-        >>> basis_functions = raised_cosine_basis.compute_features(sample_points)
+        >>> features = raised_cosine_basis.compute_features(sample_points)
         """
         EvalBasisMixin.__init__(self, bounds=bounds)
         RaisedCosineBasisLog.__init__(
@@ -1212,7 +1212,7 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
         >>> raised_cosine_basis = ConvRaisedCosineLog(n_basis_funcs, window_size=10)
         >>> sample_points = np.random.randn(100)
         >>> # convolve the basis
-        >>> basis_functions = raised_cosine_basis.compute_features(sample_points)
+        >>> features = raised_cosine_basis.compute_features(sample_points)
         """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         RaisedCosineBasisLog.__init__(
@@ -1320,7 +1320,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         >>> ortho_basis = EvalOrthExponential(n_basis_funcs, decay_rates)
         >>> sample_points = linspace(0, 1, 100)
         >>> # evaluate the basis
-        >>> basis_functions = ortho_basis.compute_features(sample_points)
+        >>> features = ortho_basis.compute_features(sample_points)
 
         """
         EvalBasisMixin.__init__(self, bounds=bounds)
@@ -1421,7 +1421,7 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
     >>> ortho_basis = ConvOrthExponential(n_basis_funcs, window_size, decay_rates)
     >>> sample_points = np.random.randn(100)
     >>> # convolve the basis
-    >>> basis_functions = ortho_basis.compute_features(sample_points)
+    >>> features = ortho_basis.compute_features(sample_points)
     """
 
     def __init__(

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -48,6 +48,50 @@ def __dir__() -> list[str]:
 
 
 class EvalBSpline(EvalBasisMixin, BSplineBasis):
+    """
+    B-spline 1-dimensional basis functions.
+
+    Implementation of the one-dimensional BSpline basis [1]_.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        Number of basis functions.
+    order :
+        Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
+        The B-splines have (order-2) continuous derivatives at each interior knot.
+        The higher this number, the smoother the basis representation will be.
+    bounds :
+        The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
+        minimum and the maximum of the samples provided when evaluating the basis.
+        If a sample is outside the bounds, the basis will return NaN.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    Attributes
+    ----------
+    order :
+        Spline order.
+
+
+    References
+    ----------
+    .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline
+        Techniques. Mathematics and Visualization. Springer, Berlin, Heidelberg.
+        https://doi.org/10.1007/978-3-662-04919-8_5
+
+    Examples
+    --------
+    >>> from numpy import linspace
+    >>> from nemos.basis import EvalBSpline
+    >>> n_basis_funcs = 5
+    >>> order = 3
+    >>> bspline_basis = EvalBSpline(n_basis_funcs, order=order)
+    >>> sample_points = linspace(0, 1, 100)
+    >>> basis_functions = bspline_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -55,49 +99,6 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalBSpline",
     ):
-        """
-        B-spline 1-dimensional basis functions.
-
-        Implementation of the one-dimensional BSpline basis [1]_.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            Number of basis functions.
-        order :
-            Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
-            The B-splines have (order-2) continuous derivatives at each interior knot.
-            The higher this number, the smoother the basis representation will be.
-        bounds :
-            The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
-            minimum and the maximum of the samples provided when evaluating the basis.
-            If a sample is outside the bounds, the basis will return NaN.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        Attributes
-        ----------
-        order :
-            Spline order.
-
-
-        References
-        ----------
-        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline
-            Techniques. Mathematics and Visualization. Springer, Berlin, Heidelberg.
-            https://doi.org/10.1007/978-3-662-04919-8_5
-
-        Examples
-        --------
-        >>> from numpy import linspace
-        >>> from nemos.basis import EvalBSpline
-        >>> n_basis_funcs = 5
-        >>> order = 3
-        >>> bspline_basis = EvalBSpline(n_basis_funcs, order=order)
-        >>> sample_points = linspace(0, 1, 100)
-        >>> basis_functions = bspline_basis.compute_features(sample_points)
-        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         BSplineBasis.__init__(
             self,
@@ -174,6 +175,48 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
 
 
 class ConvBSpline(ConvBasisMixin, BSplineBasis):
+    """
+    B-spline 1-dimensional basis functions.
+
+    Implementation of the one-dimensional BSpline basis [1]_.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        Number of basis functions.
+    window_size :
+        The window size for convolution in number of samples.
+    order :
+        Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
+        The B-splines have (order-2) continuous derivatives at each interior knot.
+        The higher this number, the smoother the basis representation will be.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    Attributes
+    ----------
+    order :
+        Spline order.
+
+
+    References
+    ----------
+    .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In:
+        Bézier and B-Spline Techniques. Mathematics and Visualization. Springer, Berlin, Heidelberg.
+        https://doi.org/10.1007/978-3-662-04919-8_5
+
+    Examples
+    --------
+    >>> from numpy import linspace
+    >>> from nemos.basis import ConvBSpline
+    >>> n_basis_funcs = 5
+    >>> order = 3
+    >>> bspline_basis = ConvBSpline(n_basis_funcs, order=order, window_size=10)
+    >>> sample_points = linspace(0, 1, 100)
+    >>> features = bspline_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -182,47 +225,6 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         label: Optional[str] = "ConvBSpline",
         conv_kwargs: Optional[dict] = None,
     ):
-        """
-        B-spline 1-dimensional basis functions.
-
-        Implementation of the one-dimensional BSpline basis [1]_.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            Number of basis functions.
-        window_size :
-            The window size for convolution in number of samples.
-        order :
-            Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
-            The B-splines have (order-2) continuous derivatives at each interior knot.
-            The higher this number, the smoother the basis representation will be.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        Attributes
-        ----------
-        order :
-            Spline order.
-
-
-        References
-        ----------
-        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In:
-            Bézier and B-Spline Techniques. Mathematics and Visualization. Springer, Berlin, Heidelberg.
-            https://doi.org/10.1007/978-3-662-04919-8_5
-
-        Examples
-        --------
-        >>> from numpy import linspace
-        >>> from nemos.basis import ConvBSpline
-        >>> n_basis_funcs = 5
-        >>> order = 3
-        >>> bspline_basis = ConvBSpline(n_basis_funcs, order=order, window_size=10)
-        >>> sample_points = linspace(0, 1, 100)
-        >>> features = bspline_basis.compute_features(sample_points)
-        """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         BSplineBasis.__init__(
             self,
@@ -299,6 +301,43 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
 
 
 class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
+    """
+    B-spline 1-dimensional basis functions for cyclic splines.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        Number of basis functions.
+    order :
+        Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
+        The B-splines have (order-2) continuous derivatives at each interior knot.
+        The higher this number, the smoother the basis representation will be.
+    bounds :
+        The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
+        minimum and the maximum of the samples provided when evaluating the basis.
+        If a sample is outside the bounds, the basis will return NaN.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    Attributes
+    ----------
+    n_basis_funcs :
+        Number of basis functions, int.
+    order :
+        Order of the splines used in basis functions, int.
+
+    Examples
+    --------
+    >>> from numpy import linspace
+    >>> from nemos.basis import EvalCyclicBSpline
+    >>> n_basis_funcs = 5
+    >>> order = 3
+    >>> cyclic_bspline_basis = EvalCyclicBSpline(n_basis_funcs, order=order)
+    >>> sample_points = linspace(0, 1, 100)
+    >>> features = cyclic_bspline_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -306,42 +345,6 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalCyclicBSpline",
     ):
-        """
-        B-spline 1-dimensional basis functions for cyclic splines.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            Number of basis functions.
-        order :
-            Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
-            The B-splines have (order-2) continuous derivatives at each interior knot.
-            The higher this number, the smoother the basis representation will be.
-        bounds :
-            The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
-            minimum and the maximum of the samples provided when evaluating the basis.
-            If a sample is outside the bounds, the basis will return NaN.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        Attributes
-        ----------
-        n_basis_funcs :
-            Number of basis functions, int.
-        order :
-            Order of the splines used in basis functions, int.
-
-        Examples
-        --------
-        >>> from numpy import linspace
-        >>> from nemos.basis import EvalCyclicBSpline
-        >>> n_basis_funcs = 5
-        >>> order = 3
-        >>> cyclic_bspline_basis = EvalCyclicBSpline(n_basis_funcs, order=order)
-        >>> sample_points = linspace(0, 1, 100)
-        >>> features = cyclic_bspline_basis.compute_features(sample_points)
-        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         CyclicBSplineBasis.__init__(
             self,
@@ -418,6 +421,41 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
 
 
 class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
+    """
+    B-spline 1-dimensional basis functions for cyclic splines.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        Number of basis functions.
+    window_size :
+        The window size for convolution in number of samples.
+    order :
+        Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
+        The B-splines have (order-2) continuous derivatives at each interior knot.
+        The higher this number, the smoother the basis representation will be.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    Attributes
+    ----------
+    n_basis_funcs :
+        Number of basis functions, int.
+    order :
+        Order of the splines used in basis functions, int.
+
+    Examples
+    --------
+    >>> from numpy import linspace
+    >>> from nemos.basis import ConvCyclicBSpline
+    >>> n_basis_funcs = 5
+    >>> order = 3
+    >>> cyclic_bspline_basis = ConvCyclicBSpline(n_basis_funcs, order=order, window_size=10)
+    >>> sample_points = linspace(0, 1, 100)
+    >>> features = cyclic_bspline_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -426,40 +464,6 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         label: Optional[str] = "ConvCyclicBSpline",
         conv_kwargs: Optional[dict] = None,
     ):
-        """
-        B-spline 1-dimensional basis functions for cyclic splines.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            Number of basis functions.
-        window_size :
-            The window size for convolution in number of samples.
-        order :
-            Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
-            The B-splines have (order-2) continuous derivatives at each interior knot.
-            The higher this number, the smoother the basis representation will be.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        Attributes
-        ----------
-        n_basis_funcs :
-            Number of basis functions, int.
-        order :
-            Order of the splines used in basis functions, int.
-
-        Examples
-        --------
-        >>> from numpy import linspace
-        >>> from nemos.basis import ConvCyclicBSpline
-        >>> n_basis_funcs = 5
-        >>> order = 3
-        >>> cyclic_bspline_basis = ConvCyclicBSpline(n_basis_funcs, order=order, window_size=10)
-        >>> sample_points = linspace(0, 1, 100)
-        >>> features = cyclic_bspline_basis.compute_features(sample_points)
-        """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         CyclicBSplineBasis.__init__(
             self,
@@ -536,6 +540,60 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
 
 
 class EvalMSpline(EvalBasisMixin, MSplineBasis):
+    r"""
+    M-spline basis functions for modeling and data transformation.
+
+    M-splines [1]_ are a type of spline basis function used for smooth curve fitting
+    and data representation. They are positive and integrate to one, making them
+    suitable for probabilistic models and density estimation. The order of an
+    M-spline defines its smoothness, with higher orders resulting in smoother
+    splines.
+
+    This class provides functionality to create M-spline basis functions, allowing
+    for flexible and smooth modeling of data. It inherits from the ``SplineBasis``
+    abstract class, providing specific implementations for M-splines.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        The number of basis functions to generate. More basis functions allow for
+        more flexible data modeling but can lead to overfitting.
+    order :
+        The order of the splines used in basis functions. Must be between [1,
+        n_basis_funcs]. Default is 2. Higher order splines have more continuous
+        derivatives at each interior knot, resulting in smoother basis functions.
+    bounds :
+        The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
+        minimum and the maximum of the samples provided when evaluating the basis.
+        If a sample is outside the bounds, the basis will return NaN.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    References
+    ----------
+    .. [1] Ramsay, J. O. (1988). Monotone regression splines in action. Statistical science,
+        3(4), 425-441.
+
+    Notes
+    -----
+    ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
+    (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain
+    (y-axis) values will shrink by a factor of :math:`1/\alpha`.
+    For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
+    If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
+
+    Examples
+    --------
+    >>> from numpy import linspace
+    >>> from nemos.basis import EvalMSpline
+    >>> n_basis_funcs = 5
+    >>> order = 3
+    >>> mspline_basis = EvalMSpline(n_basis_funcs, order=order)
+    >>> sample_points = linspace(0, 1, 100)
+    >>> features = mspline_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -543,59 +601,6 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalMSpline",
     ):
-        r"""
-        M-spline basis functions for modeling and data transformation.
-
-        M-splines [1]_ are a type of spline basis function used for smooth curve fitting
-        and data representation. They are positive and integrate to one, making them
-        suitable for probabilistic models and density estimation. The order of an
-        M-spline defines its smoothness, with higher orders resulting in smoother
-        splines.
-
-        This class provides functionality to create M-spline basis functions, allowing
-        for flexible and smooth modeling of data. It inherits from the ``SplineBasis``
-        abstract class, providing specific implementations for M-splines.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            The number of basis functions to generate. More basis functions allow for
-            more flexible data modeling but can lead to overfitting.
-        order :
-            The order of the splines used in basis functions. Must be between [1,
-            n_basis_funcs]. Default is 2. Higher order splines have more continuous
-            derivatives at each interior knot, resulting in smoother basis functions.
-        bounds :
-            The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
-            minimum and the maximum of the samples provided when evaluating the basis.
-            If a sample is outside the bounds, the basis will return NaN.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        References
-        ----------
-        .. [1] Ramsay, J. O. (1988). Monotone regression splines in action. Statistical science,
-            3(4), 425-441.
-
-        Notes
-        -----
-        ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
-        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain
-        (y-axis) values will shrink by a factor of :math:`1/\alpha`.
-        For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
-        If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
-
-        Examples
-        --------
-        >>> from numpy import linspace
-        >>> from nemos.basis import EvalMSpline
-        >>> n_basis_funcs = 5
-        >>> order = 3
-        >>> mspline_basis = EvalMSpline(n_basis_funcs, order=order)
-        >>> sample_points = linspace(0, 1, 100)
-        >>> features = mspline_basis.compute_features(sample_points)
-        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         MSplineBasis.__init__(
             self,
@@ -672,6 +677,58 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
 
 
 class ConvMSpline(ConvBasisMixin, MSplineBasis):
+    r"""
+    M-spline basis functions for modeling and data transformation.
+
+    M-splines [1]_ are a type of spline basis function used for smooth curve fitting
+    and data representation. They are positive and integrate to one, making them
+    suitable for probabilistic models and density estimation. The order of an
+    M-spline defines its smoothness, with higher orders resulting in smoother
+    splines.
+
+    This class provides functionality to create M-spline basis functions, allowing
+    for flexible and smooth modeling of data. It inherits from the ``SplineBasis``
+    abstract class, providing specific implementations for M-splines.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        The number of basis functions to generate. More basis functions allow for
+        more flexible data modeling but can lead to overfitting.
+    order :
+        The order of the splines used in basis functions. Must be between [1,
+        n_basis_funcs]. Default is 2. Higher order splines have more continuous
+        derivatives at each interior knot, resulting in smoother basis functions.
+    window_size :
+        The window size for convolution in number of samples.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    References
+    ----------
+    .. [1] Ramsay, J. O. (1988). Monotone regression splines in action. Statistical science,
+        3(4), 425-441.
+
+    Notes
+    -----
+    ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
+    (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain
+    (y-axis) values will shrink by a factor of :math:`1/\alpha`.
+    For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
+    If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
+
+    Examples
+    --------
+    >>> from numpy import linspace
+    >>> from nemos.basis import ConvMSpline
+    >>> n_basis_funcs = 5
+    >>> order = 3
+    >>> mspline_basis = ConvMSpline(n_basis_funcs, order=order, window_size=10)
+    >>> sample_points = linspace(0, 1, 100)
+    >>> features = mspline_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -680,57 +737,6 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         label: Optional[str] = "ConvMSpline",
         conv_kwargs: Optional[dict] = None,
     ):
-        r"""
-        M-spline basis functions for modeling and data transformation.
-
-        M-splines [1]_ are a type of spline basis function used for smooth curve fitting
-        and data representation. They are positive and integrate to one, making them
-        suitable for probabilistic models and density estimation. The order of an
-        M-spline defines its smoothness, with higher orders resulting in smoother
-        splines.
-
-        This class provides functionality to create M-spline basis functions, allowing
-        for flexible and smooth modeling of data. It inherits from the ``SplineBasis``
-        abstract class, providing specific implementations for M-splines.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            The number of basis functions to generate. More basis functions allow for
-            more flexible data modeling but can lead to overfitting.
-        order :
-            The order of the splines used in basis functions. Must be between [1,
-            n_basis_funcs]. Default is 2. Higher order splines have more continuous
-            derivatives at each interior knot, resulting in smoother basis functions.
-        window_size :
-            The window size for convolution in number of samples.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        References
-        ----------
-        .. [1] Ramsay, J. O. (1988). Monotone regression splines in action. Statistical science,
-            3(4), 425-441.
-
-        Notes
-        -----
-        ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
-        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain
-        (y-axis) values will shrink by a factor of :math:`1/\alpha`.
-        For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
-        If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
-
-        Examples
-        --------
-        >>> from numpy import linspace
-        >>> from nemos.basis import ConvMSpline
-        >>> n_basis_funcs = 5
-        >>> order = 3
-        >>> mspline_basis = ConvMSpline(n_basis_funcs, order=order, window_size=10)
-        >>> sample_points = linspace(0, 1, 100)
-        >>> features = mspline_basis.compute_features(sample_points)
-        """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         MSplineBasis.__init__(
             self,
@@ -1038,6 +1044,50 @@ class ConvRaisedCosineLinear(
 
 
 class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
+    """Represent log-spaced raised cosine basis functions.
+
+    Similar to ``EvalRaisedCosineLinear`` but the basis functions are log-spaced.
+    This implementation is based on the cosine bumps used by Pillow et al. [1]_
+    to uniformly tile the internal points of the domain.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        The number of basis functions.
+    width :
+        Width of the raised cosine.
+    time_scaling :
+        Non-negative hyper-parameter controlling the logarithmic stretch magnitude, with
+        larger values resulting in more stretching. As this approaches 0, the
+        transformation becomes linear.
+    enforce_decay_to_zero:
+        If set to True, the algorithm first constructs a basis with ``n_basis_funcs + ceil(width)`` elements
+        and subsequently trims off the extra basis elements. This ensures that the final basis element
+        decays to 0.
+    window_size :
+        The window size for convolution. Required if mode is 'conv'.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    References
+    ----------
+    .. [1] Pillow, J. W., Paninski, L., Uzzel, V. J., Simoncelli, E. P., & J.,
+       C. E. (2005). Prediction and decoding of retinal ganglion cell responses
+       with a probabilistic spiking model. Journal of Neuroscience, 25(47),
+       11003–11013.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from nemos.basis import EvalRaisedCosineLog
+    >>> n_basis_funcs = 5
+    >>> raised_cosine_basis = EvalRaisedCosineLog(n_basis_funcs)
+    >>> sample_points = np.random.randn(100)
+    >>> # convolve the basis
+    >>> features = raised_cosine_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -1047,49 +1097,6 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalRaisedCosineLog",
     ):
-        """Represent log-spaced raised cosine basis functions.
-
-        Similar to ``EvalRaisedCosineLinear`` but the basis functions are log-spaced.
-        This implementation is based on the cosine bumps used by Pillow et al. [1]_
-        to uniformly tile the internal points of the domain.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            The number of basis functions.
-        width :
-            Width of the raised cosine.
-        time_scaling :
-            Non-negative hyper-parameter controlling the logarithmic stretch magnitude, with
-            larger values resulting in more stretching. As this approaches 0, the
-            transformation becomes linear.
-        enforce_decay_to_zero:
-            If set to True, the algorithm first constructs a basis with ``n_basis_funcs + ceil(width)`` elements
-            and subsequently trims off the extra basis elements. This ensures that the final basis element
-            decays to 0.
-        window_size :
-            The window size for convolution. Required if mode is 'conv'.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        References
-        ----------
-        .. [1] Pillow, J. W., Paninski, L., Uzzel, V. J., Simoncelli, E. P., & J.,
-           C. E. (2005). Prediction and decoding of retinal ganglion cell responses
-           with a probabilistic spiking model. Journal of Neuroscience, 25(47),
-           11003–11013.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from nemos.basis import EvalRaisedCosineLog
-        >>> n_basis_funcs = 5
-        >>> raised_cosine_basis = EvalRaisedCosineLog(n_basis_funcs)
-        >>> sample_points = np.random.randn(100)
-        >>> # convolve the basis
-        >>> features = raised_cosine_basis.compute_features(sample_points)
-        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         RaisedCosineBasisLog.__init__(
             self,
@@ -1161,6 +1168,50 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
 
 
 class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
+    """Represent log-spaced raised cosine basis functions.
+
+    Similar to ``ConvRaisedCosineLinear`` but the basis functions are log-spaced.
+    This implementation is based on the cosine bumps used by Pillow et al. [1]_
+    to uniformly tile the internal points of the domain.
+
+    Parameters
+    ----------
+    n_basis_funcs :
+        The number of basis functions.
+    width :
+        Width of the raised cosine.
+    time_scaling :
+        Non-negative hyper-parameter controlling the logarithmic stretch magnitude, with
+        larger values resulting in more stretching. As this approaches 0, the
+        transformation becomes linear.
+    enforce_decay_to_zero:
+        If set to True, the algorithm first constructs a basis with ``n_basis_funcs + ceil(width)`` elements
+        and subsequently trims off the extra basis elements. This ensures that the final basis element
+        decays to 0.
+    window_size :
+        The window size for convolution. Required if mode is 'conv'.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    References
+    ----------
+    .. [1] Pillow, J. W., Paninski, L., Uzzel, V. J., Simoncelli, E. P., & J.,
+       C. E. (2005). Prediction and decoding of retinal ganglion cell responses
+       with a probabilistic spiking model. Journal of Neuroscience, 25(47),
+       11003–11013.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from nemos.basis import ConvRaisedCosineLog
+    >>> n_basis_funcs = 5
+    >>> raised_cosine_basis = ConvRaisedCosineLog(n_basis_funcs, window_size=10)
+    >>> sample_points = np.random.randn(100)
+    >>> # convolve the basis
+    >>> features = raised_cosine_basis.compute_features(sample_points)
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -1171,49 +1222,6 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
         label: Optional[str] = "ConvRaisedCosineLog",
         conv_kwargs: Optional[dict] = None,
     ):
-        """Represent log-spaced raised cosine basis functions.
-
-        Similar to ``ConvRaisedCosineLinear`` but the basis functions are log-spaced.
-        This implementation is based on the cosine bumps used by Pillow et al. [1]_
-        to uniformly tile the internal points of the domain.
-
-        Parameters
-        ----------
-        n_basis_funcs :
-            The number of basis functions.
-        width :
-            Width of the raised cosine.
-        time_scaling :
-            Non-negative hyper-parameter controlling the logarithmic stretch magnitude, with
-            larger values resulting in more stretching. As this approaches 0, the
-            transformation becomes linear.
-        enforce_decay_to_zero:
-            If set to True, the algorithm first constructs a basis with ``n_basis_funcs + ceil(width)`` elements
-            and subsequently trims off the extra basis elements. This ensures that the final basis element
-            decays to 0.
-        window_size :
-            The window size for convolution. Required if mode is 'conv'.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        References
-        ----------
-        .. [1] Pillow, J. W., Paninski, L., Uzzel, V. J., Simoncelli, E. P., & J.,
-           C. E. (2005). Prediction and decoding of retinal ganglion cell responses
-           with a probabilistic spiking model. Journal of Neuroscience, 25(47),
-           11003–11013.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from nemos.basis import ConvRaisedCosineLog
-        >>> n_basis_funcs = 5
-        >>> raised_cosine_basis = ConvRaisedCosineLog(n_basis_funcs, window_size=10)
-        >>> sample_points = np.random.randn(100)
-        >>> # convolve the basis
-        >>> features = raised_cosine_basis.compute_features(sample_points)
-        """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         RaisedCosineBasisLog.__init__(
             self,
@@ -1285,6 +1293,38 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
 
 
 class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
+    """Set of 1D basis decaying exponential functions numerically orthogonalized.
+
+    Parameters
+    ----------
+    n_basis_funcs
+        Number of basis functions.
+    decay_rates :
+        Decay rates of the exponentials, shape ``(n_basis_funcs,)``.
+    bounds :
+        The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
+        minimum and the maximum of the samples provided when evaluating the basis.
+        If a sample is outside the bounds, the basis will return NaN.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from numpy import linspace
+    >>> from nemos.basis import EvalOrthExponential
+    >>> X = np.random.normal(size=(1000, 1))
+    >>> n_basis_funcs = 5
+    >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05])  # sample decay rates
+    >>> window_size = 10
+    >>> ortho_basis = EvalOrthExponential(n_basis_funcs, decay_rates)
+    >>> sample_points = linspace(0, 1, 100)
+    >>> # evaluate the basis
+    >>> features = ortho_basis.compute_features(sample_points)
+
+    """
+
     def __init__(
         self,
         n_basis_funcs: int,
@@ -1292,37 +1332,6 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalOrthExponential",
     ):
-        """Set of 1D basis decaying exponential functions numerically orthogonalized.
-
-        Parameters
-        ----------
-        n_basis_funcs
-            Number of basis functions.
-        decay_rates :
-            Decay rates of the exponentials, shape ``(n_basis_funcs,)``.
-        bounds :
-            The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
-            minimum and the maximum of the samples provided when evaluating the basis.
-            If a sample is outside the bounds, the basis will return NaN.
-        label :
-            The label of the basis, intended to be descriptive of the task variable being processed.
-            For example: velocity, position, spike_counts.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from numpy import linspace
-        >>> from nemos.basis import EvalOrthExponential
-        >>> X = np.random.normal(size=(1000, 1))
-        >>> n_basis_funcs = 5
-        >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05])  # sample decay rates
-        >>> window_size = 10
-        >>> ortho_basis = EvalOrthExponential(n_basis_funcs, decay_rates)
-        >>> sample_points = linspace(0, 1, 100)
-        >>> # evaluate the basis
-        >>> features = ortho_basis.compute_features(sample_points)
-
-        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         OrthExponentialBasis.__init__(
             self,

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -55,6 +55,44 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalBSpline",
     ):
+        """
+        B-spline 1-dimensional basis functions.
+
+        Implementation of the one-dimensional BSpline basis [1]_.
+
+        Parameters
+        ----------
+        n_basis_funcs :
+            Number of basis functions.
+        order :
+            Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
+            The B-splines have (order-2) continuous derivatives at each interior knot.
+            The higher this number, the smoother the basis representation will be.
+        label :
+            The label of the basis, intended to be descriptive of the task variable being processed.
+            For example: velocity, position, spike_counts.
+
+        Attributes
+        ----------
+        order :
+            Spline order.
+
+
+        References
+        ----------
+        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline Techniques.
+            Mathematics and Visualization. Springer, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-04919-8_5
+
+        Examples
+        --------
+        >>> from numpy import linspace
+        >>> from nemos.basis import EvalBSpline
+        >>> n_basis_funcs = 5
+        >>> order = 3
+        >>> bspline_basis = EvalBSpline(n_basis_funcs, order=order)
+        >>> sample_points = linspace(0, 1, 100)
+        >>> basis_functions = bspline_basis(sample_points)
+        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         BSplineBasis.__init__(
             self,
@@ -139,6 +177,46 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         label: Optional[str] = "ConvBSpline",
         conv_kwargs: Optional[dict] = None,
     ):
+        """
+        B-spline 1-dimensional basis functions.
+
+        Implementation of the one-dimensional BSpline basis [1]_.
+
+        Parameters
+        ----------
+        n_basis_funcs :
+            Number of basis functions.
+        window_size :
+            The window size for convolution in number of samples.
+        order :
+            Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
+            The B-splines have (order-2) continuous derivatives at each interior knot.
+            The higher this number, the smoother the basis representation will be.
+        label :
+            The label of the basis, intended to be descriptive of the task variable being processed.
+            For example: velocity, position, spike_counts.
+
+        Attributes
+        ----------
+        order :
+            Spline order.
+
+
+        References
+        ----------
+        .. [1] Prautzsch, H., Boehm, W., Paluszny, M. (2002). B-spline representation. In: Bézier and B-Spline Techniques.
+            Mathematics and Visualization. Springer, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-04919-8_5
+
+        Examples
+        --------
+        >>> from numpy import linspace
+        >>> from nemos.basis import ConvBSpline
+        >>> n_basis_funcs = 5
+        >>> order = 3
+        >>> bspline_basis = ConvBSpline(n_basis_funcs, order=order, window_size=10)
+        >>> sample_points = linspace(0, 1, 100)
+        >>> basis_functions = bspline_basis(sample_points)
+        """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         BSplineBasis.__init__(
             self,
@@ -222,6 +300,38 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalCyclicBSpline",
     ):
+        """
+        B-spline 1-dimensional basis functions for cyclic splines.
+
+        Parameters
+        ----------
+        n_basis_funcs :
+            Number of basis functions.
+        order :
+            Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
+            The B-splines have (order-2) continuous derivatives at each interior knot.
+            The higher this number, the smoother the basis representation will be.
+        label :
+            The label of the basis, intended to be descriptive of the task variable being processed.
+            For example: velocity, position, spike_counts.
+
+        Attributes
+        ----------
+        n_basis_funcs :
+            Number of basis functions, int.
+        order :
+            Order of the splines used in basis functions, int.
+
+        Examples
+        --------
+        >>> from numpy import linspace
+        >>> from nemos.basis import EvalCyclicBSpline
+        >>> n_basis_funcs = 5
+        >>> order = 3
+        >>> cyclic_bspline_basis = EvalCyclicBSpline(n_basis_funcs, order=order)
+        >>> sample_points = linspace(0, 1, 100)
+        >>> basis_functions = cyclic_bspline_basis(sample_points)
+        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         CyclicBSplineBasis.__init__(
             self,
@@ -306,6 +416,40 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         label: Optional[str] = "ConvCyclicBSpline",
         conv_kwargs: Optional[dict] = None,
     ):
+        """
+        B-spline 1-dimensional basis functions for cyclic splines.
+
+        Parameters
+        ----------
+        n_basis_funcs :
+            Number of basis functions.
+        window_size :
+            The window size for convolution in number of samples.
+        order :
+            Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
+            The B-splines have (order-2) continuous derivatives at each interior knot.
+            The higher this number, the smoother the basis representation will be.
+        label :
+            The label of the basis, intended to be descriptive of the task variable being processed.
+            For example: velocity, position, spike_counts.
+
+        Attributes
+        ----------
+        n_basis_funcs :
+            Number of basis functions, int.
+        order :
+            Order of the splines used in basis functions, int.
+
+        Examples
+        --------
+        >>> from numpy import linspace
+        >>> from nemos.basis import ConvCyclicBSpline
+        >>> n_basis_funcs = 5
+        >>> order = 3
+        >>> cyclic_bspline_basis = ConvCyclicBSpline(n_basis_funcs, order=order, window_size=10)
+        >>> sample_points = linspace(0, 1, 100)
+        >>> basis_functions = cyclic_bspline_basis.compute_features(sample_points)
+        """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         CyclicBSplineBasis.__init__(
             self,
@@ -389,6 +533,55 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         bounds: Optional[Tuple[float, float]] = None,
         label: Optional[str] = "EvalMSpline",
     ):
+        r"""
+        M-spline basis functions for modeling and data transformation.
+
+        M-splines [1]_ are a type of spline basis function used for smooth curve fitting
+        and data representation. They are positive and integrate to one, making them
+        suitable for probabilistic models and density estimation. The order of an
+        M-spline defines its smoothness, with higher orders resulting in smoother
+        splines.
+
+        This class provides functionality to create M-spline basis functions, allowing
+        for flexible and smooth modeling of data. It inherits from the ``SplineBasis``
+        abstract class, providing specific implementations for M-splines.
+
+        Parameters
+        ----------
+        n_basis_funcs :
+            The number of basis functions to generate. More basis functions allow for
+            more flexible data modeling but can lead to overfitting.
+        order :
+            The order of the splines used in basis functions. Must be between [1,
+            n_basis_funcs]. Default is 2. Higher order splines have more continuous
+            derivatives at each interior knot, resulting in smoother basis functions.
+        label :
+            The label of the basis, intended to be descriptive of the task variable being processed.
+            For example: velocity, position, spike_counts.
+
+        References
+        ----------
+        .. [1] Ramsay, J. O. (1988). Monotone regression splines in action. Statistical science,
+            3(4), 425-441.
+
+        Notes
+        -----
+        ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
+        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain (y-axis) values
+        will shrink by a factor of :math:`1/\alpha`.
+        For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
+        If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
+
+        Examples
+        --------
+        >>> from numpy import linspace
+        >>> from nemos.basis import EvalMSpline
+        >>> n_basis_funcs = 5
+        >>> order = 3
+        >>> mspline_basis = EvalMSpline(n_basis_funcs, order=order)
+        >>> sample_points = linspace(0, 1, 100)
+        >>> basis_functions = mspline_basis(sample_points)
+        """
         EvalBasisMixin.__init__(self, bounds=bounds)
         MSplineBasis.__init__(
             self,
@@ -473,6 +666,57 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
         label: Optional[str] = "ConvMSpline",
         conv_kwargs: Optional[dict] = None,
     ):
+        r"""
+        M-spline basis functions for modeling and data transformation.
+
+        M-splines [1]_ are a type of spline basis function used for smooth curve fitting
+        and data representation. They are positive and integrate to one, making them
+        suitable for probabilistic models and density estimation. The order of an
+        M-spline defines its smoothness, with higher orders resulting in smoother
+        splines.
+
+        This class provides functionality to create M-spline basis functions, allowing
+        for flexible and smooth modeling of data. It inherits from the ``SplineBasis``
+        abstract class, providing specific implementations for M-splines.
+
+        Parameters
+        ----------
+        n_basis_funcs :
+            The number of basis functions to generate. More basis functions allow for
+            more flexible data modeling but can lead to overfitting.
+        order :
+            The order of the splines used in basis functions. Must be between [1,
+            n_basis_funcs]. Default is 2. Higher order splines have more continuous
+            derivatives at each interior knot, resulting in smoother basis functions.
+        window_size :
+            The window size for convolution in number of samples.
+        label :
+            The label of the basis, intended to be descriptive of the task variable being processed.
+            For example: velocity, position, spike_counts.
+
+        References
+        ----------
+        .. [1] Ramsay, J. O. (1988). Monotone regression splines in action. Statistical science,
+            3(4), 425-441.
+
+        Notes
+        -----
+        ``MSplines`` must integrate to 1 over their domain (the area under the curve is 1). Therefore, if the domain
+        (x-axis) of an MSpline basis is expanded by a factor of :math:`\alpha`, the values on the co-domain (y-axis) values
+        will shrink by a factor of :math:`1/\alpha`.
+        For example, over the standard bounds of (0, 1), the maximum value of the MSpline is 18.
+        If we set the bounds to (0, 2), the maximum value will be 9, i.e., 18 / 2.
+
+        Examples
+        --------
+        >>> from numpy import linspace
+        >>> from nemos.basis import ConvMSpline
+        >>> n_basis_funcs = 5
+        >>> order = 3
+        >>> mspline_basis = ConvMSpline(n_basis_funcs, order=order, window_size=10)
+        >>> sample_points = linspace(0, 1, 100)
+        >>> basis_functions = mspline_basis(sample_points)
+        """
         ConvBasisMixin.__init__(self, window_size=window_size, conv_kwargs=conv_kwargs)
         MSplineBasis.__init__(
             self,

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -64,7 +64,6 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
             label=label,
         )
 
-
     @add_docstrings_bspline("split_by_feature")
     def split_by_feature(
         self,
@@ -149,7 +148,6 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
             label=label,
         )
 
-
     @add_docstrings_bspline("split_by_feature")
     def split_by_feature(
         self,
@@ -232,7 +230,6 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
             order=order,
             label=label,
         )
-
 
     @add_docstrings_cyclic_bspline("split_by_feature")
     def split_by_feature(
@@ -318,7 +315,6 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
             label=label,
         )
 
-
     @add_docstrings_cyclic_bspline("split_by_feature")
     def split_by_feature(
         self,
@@ -401,7 +397,6 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
             order=order,
             label=label,
         )
-
 
     @add_docstrings_mspline("split_by_feature")
     def split_by_feature(
@@ -486,7 +481,6 @@ class ConvMSpline(ConvBasisMixin, MSplineBasis):
             order=order,
             label=label,
         )
-
 
     @add_docstrings_mspline("split_by_feature")
     def split_by_feature(
@@ -573,7 +567,6 @@ class EvalRaisedCosineLinear(
             label=label,
         )
 
-
     @add_raised_cosine_linear_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
@@ -652,7 +645,6 @@ class ConvRaisedCosineLinear(
             width=width,
             label=label,
         )
-
 
     @add_raised_cosine_linear_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -734,7 +726,6 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
             label=label,
         )
 
-
     @add_raised_cosine_log_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
@@ -815,7 +806,6 @@ class ConvRaisedCosineLog(ConvBasisMixin, RaisedCosineBasisLog):
             enforce_decay_to_zero=enforce_decay_to_zero,
             label=label,
         )
-
 
     @add_raised_cosine_log_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -924,7 +914,6 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
             label=label,
         )
 
-
     @add_orth_exp_decay_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
@@ -1021,7 +1010,6 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
             decay_rates=decay_rates,
             label=label,
         )
-
 
     @add_orth_exp_decay_docstring("evaluate_on_grid")
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -177,6 +177,12 @@ class BSplineConv(ConvBasisMixin, BSplineBasis):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
+    conv_kwargs:
+        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor`;
+        These arguments are used to change the default behavior of the convolution.
+        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
+        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
+        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -408,6 +414,12 @@ class CyclicBSplineConv(ConvBasisMixin, CyclicBSplineBasis):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
+    conv_kwargs:
+        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor`;
+        These arguments are used to change the default behavior of the convolution.
+        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
+        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
+        that the convolution axis is ``axis=0``.
 
     Examples
     --------
@@ -668,6 +680,12 @@ class MSplineConv(ConvBasisMixin, MSplineBasis):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
+    conv_kwargs:
+        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor`;
+        These arguments are used to change the default behavior of the convolution.
+        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
+        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
+        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -912,6 +930,12 @@ class RaisedCosineLinearConv(
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
+    conv_kwargs:
+        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor`;
+        These arguments are used to change the default behavior of the convolution.
+        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
+        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
+        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -1033,6 +1057,12 @@ class RaisedCosineLogEval(EvalBasisMixin, RaisedCosineBasisLog):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
+    conv_kwargs:
+        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor`;
+        These arguments are used to change the default behavior of the convolution.
+        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
+        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
+        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -1157,6 +1187,12 @@ class RaisedCosineLogConv(ConvBasisMixin, RaisedCosineBasisLog):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
+    conv_kwargs:
+        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor`;
+        These arguments are used to change the default behavior of the convolution.
+        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
+        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
+        that the convolution axis is ``axis=0``.
 
     References
     ----------
@@ -1382,6 +1418,12 @@ class OrthExponentialConv(ConvBasisMixin, OrthExponentialBasis):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
+    conv_kwargs:
+        Additional keyword arguments passed to :func:`nemos.convolve.create_convolutional_predictor`;
+        These arguments are used to change the default behavior of the convolution.
+        For example, changing the ``predictor_causality``, which by default is set to ``"causal"``.
+        Note that one cannot change the default value for the ``axis`` parameter. Basis assumes
+        that the convolution axis is ``axis=0``.
 
     Examples
     --------

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -888,7 +888,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         --------
         >>> import numpy as np
         >>> from numpy import linspace
-        >>> from nemos.basis import ConvOrthExponential
+        >>> from nemos.basis import EvalOrthExponential
         >>> X = np.random.normal(size=(1000, 1))
         >>> n_basis_funcs = 5
         >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05])  # sample decay rates

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -76,12 +76,12 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         >>> import numpy as np
         >>> from nemos.basis import EvalBSpline
         >>> from nemos.glm import GLM
-        >>> basis = EvalBSpline(n_basis_funcs=6, label="two_inputs")
-        >>> X_multi = basis.compute_features(np.random.randn(20, 2))
-        >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
+        >>> basis = EvalBSpline(n_basis_funcs=6, label="one_input")
+        >>> X = basis.compute_features(np.random.randn(20,))
+        >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        two_inputs, shape (20, 2, 6)
+        one_input, shape (20, 1, 6)
 
         """
         return BSplineBasis.split_by_feature(self, x, axis=axis)
@@ -120,7 +120,7 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
         >>> plt.title('B-Spline Basis Functions')
-        Text(0.5, 1.0, 'M-Spline Basis Functions')
+        Text(0.5, 1.0, 'B-Spline Basis Functions')
         >>> plt.xlabel('Domain')
         Text(0.5, 0, 'Domain')
         >>> plt.ylabel('Basis Function Value')
@@ -204,7 +204,7 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
         >>> plt.title('B-Spline Basis Functions')
-        Text(0.5, 1.0, 'M-Spline Basis Functions')
+        Text(0.5, 1.0, 'B-Spline Basis Functions')
         >>> plt.xlabel('Domain')
         Text(0.5, 0, 'Domain')
         >>> plt.ylabel('Basis Function Value')
@@ -243,12 +243,12 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         >>> import numpy as np
         >>> from nemos.basis import EvalCyclicBSpline
         >>> from nemos.glm import GLM
-        >>> basis = EvalCyclicBSpline(n_basis_funcs=6, label="two_inputs")
-        >>> X_multi = basis.compute_features(np.random.randn(20, 2))
-        >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
+        >>> basis = EvalCyclicBSpline(n_basis_funcs=6, label="one_input")
+        >>> X = basis.compute_features(np.random.randn(20,))
+        >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        two_inputs, shape (20, 2, 6)
+        one_input, shape (20, 1, 6)
 
         """
         return CyclicBSplineBasis.split_by_feature(self, x, axis=axis)
@@ -287,7 +287,7 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
         >>> plt.title('Cyclic B-Spline Basis Functions')
-        Text(0.5, 1.0, 'M-Spline Basis Functions')
+        Text(0.5, 1.0, 'Cyclic B-Spline Basis Functions')
         >>> plt.xlabel('Domain')
         Text(0.5, 0, 'Domain')
         >>> plt.ylabel('Basis Function Value')
@@ -371,7 +371,7 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
         >>> for i in range(4):
         ...     p = plt.plot(sample_points, basis_values[:, i], label=f'Function {i+1}')
         >>> plt.title('Cyclic B-Spline Basis Functions')
-        Text(0.5, 1.0, 'M-Spline Basis Functions')
+        Text(0.5, 1.0, 'Cyclic B-Spline Basis Functions')
         >>> plt.xlabel('Domain')
         Text(0.5, 0, 'Domain')
         >>> plt.ylabel('Basis Function Value')
@@ -410,12 +410,12 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
         >>> import numpy as np
         >>> from nemos.basis import EvalMSpline
         >>> from nemos.glm import GLM
-        >>> basis = EvalMSpline(n_basis_funcs=6, label="two_inputs")
-        >>> X_multi = basis.compute_features(np.random.randn(20, 2))
-        >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
+        >>> basis = EvalMSpline(n_basis_funcs=6, label="one_input")
+        >>> X = basis.compute_features(np.random.randn(20))
+        >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        two_inputs, shape (20, 2, 6)
+        one_input, shape (20, 1, 6)
 
         """
         return MSplineBasis.split_by_feature(self, x, axis=axis)
@@ -615,12 +615,12 @@ class EvalRaisedCosineLinear(
         >>> import numpy as np
         >>> from nemos.basis import EvalRaisedCosineLinear
         >>> from nemos.glm import GLM
-        >>> basis = EvalRaisedCosineLinear(n_basis_funcs=6, label="two_inputs")
-        >>> X_multi = basis.compute_features(np.random.randn(20, 2))
-        >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
+        >>> basis = EvalRaisedCosineLinear(n_basis_funcs=6, label="one_input")
+        >>> X = basis.compute_features(np.random.randn(20,))
+        >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        two_inputs, shape (20, 2, 6)
+        one_input, shape (20, 1, 6)
 
         """
         return RaisedCosineBasisLinear.split_by_feature(self, x, axis=axis)
@@ -774,12 +774,12 @@ class EvalRaisedCosineLog(EvalBasisMixin, RaisedCosineBasisLog):
         >>> import numpy as np
         >>> from nemos.basis import EvalRaisedCosineLog
         >>> from nemos.glm import GLM
-        >>> basis = EvalRaisedCosineLog(n_basis_funcs=6, label="two_inputs")
-        >>> X_multi = basis.compute_features(np.random.randn(20, 2))
-        >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
+        >>> basis = EvalRaisedCosineLog(n_basis_funcs=6, label="one_input")
+        >>> X = basis.compute_features(np.random.randn(20,))
+        >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        two_inputs, shape (20, 2, 6)
+        one_input, shape (20, 1, 6)
 
         """
         return RaisedCosineBasisLog.split_by_feature(self, x, axis=axis)
@@ -963,7 +963,7 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
         >>> from nemos.basis import EvalOrthExponential
         >>> from nemos.glm import GLM
         >>> # Define an additive basis
-        >>> basis = EvalOrthExponential(n_basis_funcs=5, label="feature")
+        >>> basis = EvalOrthExponential(n_basis_funcs=5, decay_rates=np.arange(1, 6), label="feature")
         >>> # Generate a sample input array and compute features
         >>> x = np.random.randn(20)
         >>> X = basis.compute_features(x)
@@ -1059,7 +1059,7 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
         >>> import numpy as np
         >>> from nemos.basis import ConvOrthExponential
         >>> from nemos.glm import GLM
-        >>> basis = ConvOrthExponential(n_basis_funcs=6, window_size=10, label="two_inputs")
+        >>> basis = ConvOrthExponential(n_basis_funcs=6, decay_rates=np.arange(1, 7), window_size=10, label="two_inputs")
         >>> X_multi = basis.compute_features(np.random.randn(20, 2))
         >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -68,6 +68,10 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
             Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
             The B-splines have (order-2) continuous derivatives at each interior knot.
             The higher this number, the smoother the basis representation will be.
+        bounds :
+            The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
+            minimum and the maximum of the samples provided when evaluating the basis.
+            If a sample is outside the bounds, the basis will return NaN.
         label :
             The label of the basis, intended to be descriptive of the task variable being processed.
             For example: velocity, position, spike_counts.
@@ -311,6 +315,10 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
             Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
             The B-splines have (order-2) continuous derivatives at each interior knot.
             The higher this number, the smoother the basis representation will be.
+        bounds :
+            The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
+            minimum and the maximum of the samples provided when evaluating the basis.
+            If a sample is outside the bounds, the basis will return NaN.
         label :
             The label of the basis, intended to be descriptive of the task variable being processed.
             For example: velocity, position, spike_counts.
@@ -555,6 +563,10 @@ class EvalMSpline(EvalBasisMixin, MSplineBasis):
             The order of the splines used in basis functions. Must be between [1,
             n_basis_funcs]. Default is 2. Higher order splines have more continuous
             derivatives at each interior knot, resulting in smoother basis functions.
+        bounds :
+            The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
+            minimum and the maximum of the samples provided when evaluating the basis.
+            If a sample is outside the bounds, the basis will return NaN.
         label :
             The label of the basis, intended to be descriptive of the task variable being processed.
             For example: velocity, position, spike_counts.
@@ -1222,7 +1234,20 @@ class EvalOrthExponential(EvalBasisMixin, OrthExponentialBasis):
 
 
 class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
-    """
+    """Set of 1D basis decaying exponential functions numerically orthogonalized.
+
+    Parameters
+    ----------
+    n_basis_funcs
+        Number of basis functions.
+    window_size :
+        The window size for convolution in number of samples.
+    decay_rates :
+        Decay rates of the exponentials, shape ``(n_basis_funcs,)``.
+    label :
+        The label of the basis, intended to be descriptive of the task variable being processed.
+        For example: velocity, position, spike_counts.
+
     Examples
     --------
     >>> import numpy as np

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from ..typing import FeatureMatrix
 from ._basis import add_docstring
-from ._basis_mixin import BasisTransformerMixin, ConvBasisMixin, EvalBasisMixin
+from ._basis_mixin import ConvBasisMixin, EvalBasisMixin
 from ._decaying_exponential import OrthExponentialBasis
 from ._raised_cosine_basis import RaisedCosineBasisLinear, RaisedCosineBasisLog
 from ._spline_basis import BSplineBasis, CyclicBSplineBasis, MSplineBasis
@@ -794,9 +794,7 @@ class MSplineConv(ConvBasisMixin, MSplineBasis):
         return super().evaluate_on_grid(n_samples)
 
 
-class RaisedCosineLinearEval(
-    EvalBasisMixin, RaisedCosineBasisLinear
-):
+class RaisedCosineLinearEval(EvalBasisMixin, RaisedCosineBasisLinear):
     """
     Represent linearly-spaced raised cosine basis functions.
 
@@ -910,9 +908,7 @@ class RaisedCosineLinearEval(
         return super().split_by_feature(x, axis=axis)
 
 
-class RaisedCosineLinearConv(
-    ConvBasisMixin, RaisedCosineBasisLinear
-):
+class RaisedCosineLinearConv(ConvBasisMixin, RaisedCosineBasisLinear):
     """
     Represent linearly-spaced raised cosine basis functions.
 

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -795,7 +795,7 @@ class MSplineConv(ConvBasisMixin, MSplineBasis):
 
 
 class RaisedCosineLinearEval(
-    EvalBasisMixin, RaisedCosineBasisLinear, BasisTransformerMixin
+    EvalBasisMixin, RaisedCosineBasisLinear
 ):
     """
     Represent linearly-spaced raised cosine basis functions.
@@ -911,7 +911,7 @@ class RaisedCosineLinearEval(
 
 
 class RaisedCosineLinearConv(
-    ConvBasisMixin, RaisedCosineBasisLinear, BasisTransformerMixin
+    ConvBasisMixin, RaisedCosineBasisLinear
 ):
     """
     Represent linearly-spaced raised cosine basis functions.

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -69,11 +69,6 @@ class EvalBSpline(EvalBasisMixin, BSplineBasis):
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
 
-    Attributes
-    ----------
-    order :
-        Spline order.
-
 
     References
     ----------
@@ -193,12 +188,6 @@ class ConvBSpline(ConvBasisMixin, BSplineBasis):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-
-    Attributes
-    ----------
-    order :
-        Spline order.
-
 
     References
     ----------
@@ -320,13 +309,6 @@ class EvalCyclicBSpline(EvalBasisMixin, CyclicBSplineBasis):
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
 
-    Attributes
-    ----------
-    n_basis_funcs :
-        Number of basis functions, int.
-    order :
-        Order of the splines used in basis functions, int.
-
     Examples
     --------
     >>> from numpy import linspace
@@ -437,13 +419,6 @@ class ConvCyclicBSpline(ConvBasisMixin, CyclicBSplineBasis):
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
-
-    Attributes
-    ----------
-    n_basis_funcs :
-        Number of basis functions, int.
-    order :
-        Order of the splines used in basis functions, int.
 
     Examples
     --------

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -1059,7 +1059,12 @@ class ConvOrthExponential(ConvBasisMixin, OrthExponentialBasis):
         >>> import numpy as np
         >>> from nemos.basis import ConvOrthExponential
         >>> from nemos.glm import GLM
-        >>> basis = ConvOrthExponential(n_basis_funcs=6, decay_rates=np.arange(1, 7), window_size=10, label="two_inputs")
+        >>> basis = ConvOrthExponential(
+        ...     n_basis_funcs=6,
+        ...     decay_rates=np.arange(1, 7),
+        ...     window_size=10,
+        ...     label="two_inputs"
+        ... )
         >>> X_multi = basis.compute_features(np.random.randn(20, 2))
         >>> split_features_multi = basis.split_by_feature(X_multi, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():

--- a/src/nemos/identifiability_constraints.py
+++ b/src/nemos/identifiability_constraints.py
@@ -216,10 +216,10 @@ def apply_identifiability_constraints(
     --------
     >>> import numpy as np
     >>> from nemos.identifiability_constraints import apply_identifiability_constraints
-    >>> from nemos.basis import BSplineBasis
+    >>> from nemos.basis import EvalBSpline
     >>> from nemos.glm import GLM
     >>> # define a feature matrix
-    >>> bas = BSplineBasis(5) + BSplineBasis(6)
+    >>> bas = EvalBSpline(5) + EvalBSpline(6)
     >>> feature_matrix = bas.compute_features(np.random.randn(100), np.random.randn(100))
     >>> # apply constraints
     >>> constrained_x, kept_columns = apply_identifiability_constraints(feature_matrix)
@@ -281,10 +281,10 @@ def apply_identifiability_constraints_by_basis_component(
     --------
     >>> import numpy as np
     >>> from nemos.identifiability_constraints import apply_identifiability_constraints_by_basis_component
-    >>> from nemos.basis import BSplineBasis
+    >>> from nemos.basis import EvalBSpline
     >>> from nemos.glm import GLM
     >>> # define a feature matrix
-    >>> bas = BSplineBasis(5) + BSplineBasis(6)
+    >>> bas = EvalBSpline(5) + EvalBSpline(6)
     >>> feature_matrix = bas.compute_features(np.random.randn(100), np.random.randn(100))
     >>> # apply constraints
     >>> constrained_x, kept_columns = apply_identifiability_constraints_by_basis_component(bas, feature_matrix)

--- a/src/nemos/identifiability_constraints.py
+++ b/src/nemos/identifiability_constraints.py
@@ -216,10 +216,10 @@ def apply_identifiability_constraints(
     --------
     >>> import numpy as np
     >>> from nemos.identifiability_constraints import apply_identifiability_constraints
-    >>> from nemos.basis import EvalBSpline
+    >>> from nemos.basis import BSplineEval
     >>> from nemos.glm import GLM
     >>> # define a feature matrix
-    >>> bas = EvalBSpline(5) + EvalBSpline(6)
+    >>> bas = BSplineEval(5) + BSplineEval(6)
     >>> feature_matrix = bas.compute_features(np.random.randn(100), np.random.randn(100))
     >>> # apply constraints
     >>> constrained_x, kept_columns = apply_identifiability_constraints(feature_matrix)
@@ -281,10 +281,10 @@ def apply_identifiability_constraints_by_basis_component(
     --------
     >>> import numpy as np
     >>> from nemos.identifiability_constraints import apply_identifiability_constraints_by_basis_component
-    >>> from nemos.basis import EvalBSpline
+    >>> from nemos.basis import BSplineEval
     >>> from nemos.glm import GLM
     >>> # define a feature matrix
-    >>> bas = EvalBSpline(5) + EvalBSpline(6)
+    >>> bas = BSplineEval(5) + BSplineEval(6)
     >>> feature_matrix = bas.compute_features(np.random.randn(100), np.random.randn(100))
     >>> # apply constraints
     >>> constrained_x, kept_columns = apply_identifiability_constraints_by_basis_component(bas, feature_matrix)

--- a/src/nemos/simulation.py
+++ b/src/nemos/simulation.py
@@ -151,11 +151,11 @@ def regress_filter(coupling_filters: NDArray, eval_basis: NDArray) -> NDArray:
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from nemos.simulation import regress_filter, difference_of_gammas
-    >>> from nemos.basis import RaisedCosineBasisLog
+    >>> from nemos.basis import EvalRaisedCosineLog
     >>> filter_duration = 100
     >>> n_basis_funcs = 20
     >>> filter_bank = difference_of_gammas(filter_duration).reshape(filter_duration, 1, 1)
-    >>> _, basis = RaisedCosineBasisLog(10).evaluate_on_grid(filter_duration)
+    >>> _, basis = EvalRaisedCosineLog(10).evaluate_on_grid(filter_duration)
     >>> weights = regress_filter(filter_bank, basis)[0, 0]
     >>> print("Weights shape:", weights.shape)
     Weights shape: (10,)
@@ -275,7 +275,7 @@ def simulate_recurrent(
     >>> feedforward_input = np.random.normal(size=(1000, n_neurons, 1))
     >>> coupling_basis = np.random.normal(size=(coupling_duration, 10))
     >>> coupling_coef = np.random.normal(size=(n_neurons, n_neurons, 10))
-    >>> intercept = -8 * np.ones(n_neurons)
+    >>> intercept = -9 * np.ones(n_neurons)
     >>> init_spikes = np.zeros((coupling_duration, n_neurons))
     >>> random_key = jax.random.key(123)
     >>> spikes, rates = simulate_recurrent(

--- a/src/nemos/simulation.py
+++ b/src/nemos/simulation.py
@@ -151,11 +151,11 @@ def regress_filter(coupling_filters: NDArray, eval_basis: NDArray) -> NDArray:
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from nemos.simulation import regress_filter, difference_of_gammas
-    >>> from nemos.basis import EvalRaisedCosineLog
+    >>> from nemos.basis import RaisedCosineLogEval
     >>> filter_duration = 100
     >>> n_basis_funcs = 20
     >>> filter_bank = difference_of_gammas(filter_duration).reshape(filter_duration, 1, 1)
-    >>> _, basis = EvalRaisedCosineLog(10).evaluate_on_grid(filter_duration)
+    >>> _, basis = RaisedCosineLogEval(10).evaluate_on_grid(filter_duration)
     >>> weights = regress_filter(filter_bank, basis)[0, 0]
     >>> print("Weights shape:", weights.shape)
     Weights shape: (10,)

--- a/src/nemos/typing.py
+++ b/src/nemos/typing.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import jaxopt
 import pynapple as nap
 from jax.typing import ArrayLike
-from statsmodels.tools.typing import NDArray
+from numpy.typing import NDArray
 
 from .pytrees import FeaturePytree
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,7 +286,7 @@ def coupled_model_simulate():
             )
     # shrink the filters for simulation stability
     coupling_filter_bank *= 0.8
-    basis = nmo.basis.EvalRaisedCosineLog(20)
+    basis = nmo.basis.RaisedCosineLogEval(20)
 
     # approximate the coupling filters in terms of the basis function
     _, coupling_basis = basis.evaluate_on_grid(coupling_filter_bank.shape[0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,7 +286,7 @@ def coupled_model_simulate():
             )
     # shrink the filters for simulation stability
     coupling_filter_bank *= 0.8
-    basis = nmo.basis.RaisedCosineBasisLog(20)
+    basis = nmo.basis.EvalRaisedCosineLog(20)
 
     # approximate the coupling filters in terms of the basis function
     _, coupling_basis = basis.evaluate_on_grid(coupling_filter_bank.shape[0])

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -132,7 +132,7 @@ def test_all_basis_are_tested() -> None:
         ("evaluate_on_grid", "The number of points in the uniformly spaced grid"),
         (
             "compute_features",
-            "Apply the basis transformation to the input data|Convolve basis functions with input time series",
+            "Apply the basis transformation to the input data|Convolve basis functions with input time series|Evaluate basis at sample points",
         ),
         (
             "split_by_feature",

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1073,7 +1073,7 @@ class TestSharedMethods:
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
-                TypeError, match="takes 2 positional arguments but \d were given"
+                TypeError, match=r"takes 2 positional arguments but \d were given"
             )
         else:
             expectation = does_not_raise()

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -979,14 +979,14 @@ class TestSharedMethods:
             (
                 "conv",
                 -1,
-                pytest.raises(ValueError, match="You must provide a window_siz"),
+                pytest.raises(ValueError, match="`window_size` must be a positive integer"),
             ),
             (
                 "conv",
                 None,
                 pytest.raises(
                     ValueError,
-                    match="You must provide a window_siz",
+                    match="You must provide a window_size",
                 ),
             ),
             (

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -2167,13 +2167,9 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "samples", [[[0], []], [[], [0]], [[0], [0]], [[0, 0], [0, 0]]]
     )
-    @pytest.mark.parametrize(" ws", [3, None])
+    @pytest.mark.parametrize(" ws", [3])
     def test_non_empty_samples(self, samples,  ws):
-        if mode == "conv" and len(samples[0]) < 2:
-            return
-        basis_obj = basis.EvalMSpline(5,  window_size=ws) * basis.EvalMSpline(
-            5,  window_size=ws
-        )
+        basis_obj = basis.EvalMSpline(5) * basis.EvalRaisedCosineLinear(5)
         if any(tuple(len(s) == 0 for s in samples)):
             with pytest.raises(
                 ValueError, match="All sample provided must be non empty"
@@ -2204,9 +2200,9 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("sample_size", [10, 1000])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
-    @pytest.mark.parametrize("window_size", [None, 10])
+    @pytest.mark.parametrize("window_size", [10])
     def test_compute_features_returns_expected_number_of_basis(
-        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size
+        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size, class_specific_params
     ):
         """
         Test whether the evaluation of the `MultiplicativeBasis` results in a number of basis
@@ -2214,10 +2210,10 @@ class TestMultiplicativeBasis(CombinedBasis):
         """
         # define the two basis
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
 
         basis_obj = basis_a_obj * basis_b_obj
@@ -2237,19 +2233,19 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_b", [5, 6])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
-    @pytest.mark.parametrize("window_size", [None, 10])
+    @pytest.mark.parametrize("window_size", [10])
     def test_sample_size_of_compute_features_matches_that_of_input(
-        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size
+        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size, class_specific_params
     ):
         """
         Test whether the output sample size from the `MultiplicativeBasis` fit_transform function
         matches the input sample size.
         """
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         eval_basis = basis_obj.compute_features(
@@ -2267,19 +2263,19 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_input", [0, 1, 2, 3, 10, 30])
     @pytest.mark.parametrize("n_basis_a", [5, 6])
     @pytest.mark.parametrize("n_basis_b", [5, 6])
-    @pytest.mark.parametrize("window_size", [None, 10])
+    @pytest.mark.parametrize("window_size", [10])
     def test_number_of_required_inputs_compute_features(
-        self, n_input, n_basis_a, n_basis_b, basis_a, basis_b, window_size
+        self, n_input, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
     ):
         """
         Test whether the number of required inputs for the `compute_features` function matches
         the sum of the number of input samples from the two bases.
         """
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         required_dim = (
@@ -2301,13 +2297,13 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [6])
     def test_evaluate_on_grid_meshgrid_size(
-        self, sample_size, n_basis_a, n_basis_b, basis_a, basis_b
+        self, sample_size, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
     ):
         """
         Test whether the resulting meshgrid size matches the sample size input.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
+        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
+        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
         basis_obj = basis_a_obj * basis_b_obj
         res = basis_obj.evaluate_on_grid(
             *[sample_size] * basis_obj._n_input_dimensionality
@@ -2321,13 +2317,13 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [6])
     def test_evaluate_on_grid_basis_size(
-        self, sample_size, n_basis_a, n_basis_b, basis_a, basis_b
+        self, sample_size, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
     ):
         """
         Test whether the number sample size output by evaluate_on_grid matches the sample size of the input.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
+        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
+        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
         basis_obj = basis_a_obj * basis_b_obj
         eval_basis = basis_obj.evaluate_on_grid(
             *[sample_size] * basis_obj._n_input_dimensionality
@@ -2340,14 +2336,14 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [6])
     def test_evaluate_on_grid_input_number(
-        self, n_input, basis_a, basis_b, n_basis_a, n_basis_b
+        self, n_input, basis_a, basis_b, n_basis_a, n_basis_b, class_specific_params
     ):
         """
         Test whether the number of inputs provided to `evaluate_on_grid` matches
         the sum of the number of input samples required from each of the basis objects.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
+        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
+        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
         basis_obj = basis_a_obj * basis_b_obj
         inputs = [20] * n_input
         required_dim = (
@@ -2362,19 +2358,19 @@ class TestMultiplicativeBasis(CombinedBasis):
         with expectation:
             basis_obj.evaluate_on_grid(*inputs)
 
-    @pytest.mark.parametrize("basis_a", [basis.EvalMSpline])
-    @pytest.mark.parametrize("basis_b", [basis.OrthExponentialBasis])
+    @pytest.mark.parametrize("basis_a", list_all_basis_classes())
+    @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [6])
     @pytest.mark.parametrize("sample_size_a", [11, 12])
     @pytest.mark.parametrize("sample_size_b", [11, 12])
     def test_inconsistent_sample_sizes(
-        self, basis_a, basis_b, n_basis_a, n_basis_b, sample_size_a, sample_size_b
+        self, basis_a, basis_b, n_basis_a, n_basis_b, sample_size_a, sample_size_b, class_specific_params
     ):
         """Test that the inputs of inconsistent sample sizes result in an exception when compute_features is called"""
         raise_exception = sample_size_a != sample_size_b
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b)
+        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
+        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
         basis_obj = basis_a_obj * basis_b_obj
         if raise_exception:
             with pytest.raises(
@@ -2395,7 +2391,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     def test_pynapple_support_compute_features(
-        self, basis_a, basis_b, n_basis_a, n_basis_b, sample_size
+        self, basis_a, basis_b, n_basis_a, n_basis_b, sample_size, class_specific_params
     ):
         iset = nap.IntervalSet(start=[0, 0.5], end=[0.49999, 1])
         inp = nap.Tsd(
@@ -2404,8 +2400,8 @@ class TestMultiplicativeBasis(CombinedBasis):
             time_support=iset,
         )
         basis_prod = self.instantiate_basis(
-            n_basis_a, basis_a
-        ) * self.instantiate_basis(n_basis_b, basis_b)
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        ) * self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
         out = basis_prod.compute_features(*([inp] * basis_prod._n_input_dimensionality))
         assert isinstance(out, nap.TsdFrame)
         assert np.all(out.time_support.values == inp.time_support.values)
@@ -2416,15 +2412,15 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     @pytest.mark.parametrize("num_input", [0, 1, 2, 3, 4, 5])
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [3])
     def test_call_input_num(
-        self, n_basis_a, n_basis_b, basis_a, basis_b, num_input,  window_size
+        self, n_basis_a, n_basis_b, basis_a, basis_b, num_input,  window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         if num_input == basis_obj._n_input_dimensionality:
@@ -2443,7 +2439,7 @@ class TestMultiplicativeBasis(CombinedBasis):
             (np.linspace(0, 1, 10)[:, None], pytest.raises(ValueError)),
         ],
     )
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
@@ -2458,52 +2454,53 @@ class TestMultiplicativeBasis(CombinedBasis):
 
         window_size,
         expectation,
+        class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         with expectation:
             basis_obj(*([inp] * basis_obj._n_input_dimensionality))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_sample_axis(
-        self, n_basis_a, n_basis_b, basis_a, basis_b, time_axis_shape,  window_size
+        self, n_basis_a, n_basis_b, basis_a, basis_b, time_axis_shape,  window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         inp = [np.linspace(0, 1, time_axis_shape)] * basis_obj._n_input_dimensionality
         assert basis_obj(*inp).shape[0] == time_axis_shape
 
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_call_nan(self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size):
+    def test_call_nan(self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params):
         if (
             basis_a == basis.OrthExponentialBasis
             or basis_b == basis.OrthExponentialBasis
         ):
             return
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         inp = [np.linspace(0, 1, 10)] * basis_obj._n_input_dimensionality
@@ -2515,39 +2512,39 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_call_equivalent_in_conv(self, n_basis_a, n_basis_b, basis_a, basis_b):
+    def test_call_equivalent_in_conv(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, "eval", window_size=None
+            n_basis_a, basis_a, class_specific_params, window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=None
+            n_basis_b, basis_b, class_specific_params,  window_size=10
         )
         bas_eva = basis_a_obj * basis_b_obj
 
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=8
+            n_basis_a, basis_a, class_specific_params,  window_size=8
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=8
+            n_basis_b, basis_b, class_specific_params,  window_size=8
         )
         bas_con = basis_a_obj * basis_b_obj
 
         x = [np.linspace(0, 1, 10)] * bas_con._n_input_dimensionality
         assert np.all(bas_con(*x) == bas_eva(*x))
 
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_pynapple_support(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size
+        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         x = np.linspace(0, 1, 10)
@@ -2559,37 +2556,37 @@ class TestMultiplicativeBasis(CombinedBasis):
         assert np.all(y == y_nap.d)
         assert np.all(y_nap.t == x_nap[0].t)
 
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [6, 7])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_basis_number(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size
+        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
         assert bas(*x).shape[1] == basis_a_obj.n_basis_funcs * basis_b_obj.n_basis_funcs
 
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_non_empty(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size
+        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         with pytest.raises(ValueError, match="All sample provided must"):
@@ -2603,7 +2600,7 @@ class TestMultiplicativeBasis(CombinedBasis):
             (0.1, 2, does_not_raise()),
         ],
     )
-    @pytest.mark.parametrize(" window_size", [None, 3])
+    @pytest.mark.parametrize(" window_size", [ 3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
@@ -2619,6 +2616,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         expectation,
 
         window_size,
+        class_specific_params
     ):
         if expectation == "check":
             if (
@@ -2631,10 +2629,10 @@ class TestMultiplicativeBasis(CombinedBasis):
             else:
                 expectation = does_not_raise()
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params,  window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params,  window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         with expectation:
@@ -2644,15 +2642,15 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_fit_kernel(self, n_basis_a, n_basis_b, basis_a, basis_b):
+    def test_fit_kernel(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=10
+            n_basis_a, basis_a, class_specific_params,  window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=10
+            n_basis_b, basis_b, class_specific_params,  window_size=10
         )
         bas = basis_a_obj * basis_b_obj
-        bas._set_kernel(None)
+        bas._set_kernel()
 
         def check_kernel(basis_obj):
             has_kern = []
@@ -2671,25 +2669,27 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_transform_fails(self, n_basis_a, n_basis_b, basis_a, basis_b):
+    def test_transform_fails(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a,  window_size=10
+            n_basis_a, basis_a, class_specific_params,  window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b,  window_size=10
+            n_basis_b, basis_b, class_specific_params,  window_size=10
         )
         bas = basis_a_obj * basis_b_obj
-        with pytest.raises(
-            ValueError, match="You must call `_set_kernel` before `_compute_features`"
-        ):
+        if "Eval" in  basis_a.__name__ and "Eval" in  basis_b.__name__:
+            context = does_not_raise()
+        else:
+            context = pytest.raises(ValueError, match="You must call `_set_kernel` before `_compute_features`")
+        with context:
             x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
             bas._compute_features(*x)
 
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_output_features(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.RaisedCosineBasisLinear(10,  window_size=10)
-        bas2 = basis.BSplineBasis(11,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
+        bas2 = basis.ConvBSpline(11,  window_size=10)
         bas_add = bas1 * bas2
         assert bas_add.n_output_features is None
         bas_add.compute_features(
@@ -2700,8 +2700,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.RaisedCosineBasisLinear(10,  window_size=10)
-        bas2 = basis.BSplineBasis(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
+        bas2 = basis.ConvBSpline(10,  window_size=10)
         bas_add = bas1 * bas2
         assert bas_add.n_basis_input is None
         bas_add.compute_features(
@@ -2719,8 +2719,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         ],
     )
     def test_expected_input_number(self, n_input, expectation):
-        bas1 = basis.RaisedCosineBasisLinear(10,  window_size=10)
-        bas2 = basis.BSplineBasis(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
+        bas2 = basis.ConvBSpline(10,  window_size=10)
         bas = bas1 * bas2
         x = np.random.randn(20, 2), np.random.randn(20, 3)
         bas.compute_features(*x)
@@ -2730,8 +2730,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_n_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.RaisedCosineBasisLinear(10,  window_size=10)
-        bas2 = basis.BSplineBasis(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
+        bas2 = basis.ConvBSpline(10,  window_size=10)
         bas_prod = bas1 * bas2
         bas_prod.compute_features(
             np.ones((20, n_basis_input1)), np.ones((20, n_basis_input2))

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -11,13 +11,18 @@ import jax.numpy
 import numpy as np
 import pynapple as nap
 import pytest
-
 import utils_testing
 from sklearn.base import clone as sk_clone
 
 import nemos.basis.basis as basis
 import nemos.convolve as convolve
-from nemos.basis._basis import AdditiveBasis, Basis, MultiplicativeBasis, add_docstring, TransformerBasis
+from nemos.basis._basis import (
+    AdditiveBasis,
+    Basis,
+    MultiplicativeBasis,
+    TransformerBasis,
+    add_docstring,
+)
 from nemos.basis._decaying_exponential import OrthExponentialBasis
 from nemos.basis._raised_cosine_basis import (
     RaisedCosineBasisLinear,
@@ -33,23 +38,31 @@ def class_specific_params():
     eval_params = ["bounds"]
     conv_params = ["window_size", "conv_kwargs"]
     return dict(
-        EvalBSpline = shared_params + eval_params + ["order"],
-        ConvBSpline = shared_params + conv_params + ["order"],
-        EvalMSpline = shared_params + eval_params + ["order"],
-        ConvMSpline = shared_params + conv_params +["order"],
-        EvalCyclicBSpline = shared_params + eval_params + ["order"],
-        ConvCyclicBSpline = shared_params + conv_params +["order"],
-        EvalRaisedCosineLinear= shared_params + eval_params + ["width"],
-        ConvRaisedCosineLinear=shared_params + conv_params +["width"],
-        EvalRaisedCosineLog= shared_params + eval_params + ["width", "time_scaling", "enforce_decay_to_zero"],
-        ConvRaisedCosineLog= shared_params + conv_params +["width", "time_scaling", "enforce_decay_to_zero"],
-        EvalOrthExponential= shared_params + eval_params + ["decay_rates"],
-        ConvOrthExponential = shared_params + conv_params +["decay_rates"]
+        EvalBSpline=shared_params + eval_params + ["order"],
+        ConvBSpline=shared_params + conv_params + ["order"],
+        EvalMSpline=shared_params + eval_params + ["order"],
+        ConvMSpline=shared_params + conv_params + ["order"],
+        EvalCyclicBSpline=shared_params + eval_params + ["order"],
+        ConvCyclicBSpline=shared_params + conv_params + ["order"],
+        EvalRaisedCosineLinear=shared_params + eval_params + ["width"],
+        ConvRaisedCosineLinear=shared_params + conv_params + ["width"],
+        EvalRaisedCosineLog=shared_params
+        + eval_params
+        + ["width", "time_scaling", "enforce_decay_to_zero"],
+        ConvRaisedCosineLog=shared_params
+        + conv_params
+        + ["width", "time_scaling", "enforce_decay_to_zero"],
+        EvalOrthExponential=shared_params + eval_params + ["decay_rates"],
+        ConvOrthExponential=shared_params + conv_params + ["decay_rates"],
     )
 
 
 def trim_kwargs(cls, kwargs, class_specific_params):
-    return {key: value for key, value in kwargs.items() if key in class_specific_params[cls.__name__]}
+    return {
+        key: value
+        for key, value in kwargs.items()
+        if key in class_specific_params[cls.__name__]
+    }
 
 
 def extra_decay_rates(cls, n_basis):
@@ -73,6 +86,7 @@ def list_all_basis_classes(filter_basis="all") -> list[type]:
     if filter_basis != "all":
         all_basis = [a for a in all_basis if filter_basis in a.__name__]
     return all_basis
+
 
 def test_all_basis_are_tested() -> None:
     """Meta-test.
@@ -296,8 +310,8 @@ class BasisFuncsTesting(abc.ABC):
         {"eval": basis.EvalBSpline, "conv": basis.ConvBSpline},
         {"eval": basis.EvalCyclicBSpline, "conv": basis.ConvCyclicBSpline},
         {"eval": basis.EvalMSpline, "conv": basis.ConvMSpline},
-        {"eval": basis.EvalOrthExponential, "conv": basis.ConvOrthExponential}
-    ]
+        {"eval": basis.EvalOrthExponential, "conv": basis.ConvOrthExponential},
+    ],
 )
 class TestSharedMethods:
 
@@ -306,23 +320,23 @@ class TestSharedMethods:
         [
             (0.5, 0, 1, does_not_raise()),
             (
-                    -0.5,
-                    0,
-                    1,
-                    pytest.raises(ValueError, match="All the samples lie outside"),
+                -0.5,
+                0,
+                1,
+                pytest.raises(ValueError, match="All the samples lie outside"),
             ),
             (np.linspace(-1, 1, 10), 0, 1, does_not_raise()),
             (
-                    np.linspace(-1, 0, 10),
-                    0,
-                    1,
-                    pytest.warns(UserWarning, match="More than 90% of the samples"),
+                np.linspace(-1, 0, 10),
+                0,
+                1,
+                pytest.warns(UserWarning, match="More than 90% of the samples"),
             ),
             (
-                    np.linspace(1, 2, 10),
-                    0,
-                    1,
-                    pytest.warns(UserWarning, match="More than 90% of the samples"),
+                np.linspace(1, 2, 10),
+                0,
+                1,
+                pytest.warns(UserWarning, match="More than 90% of the samples"),
             ),
         ],
     )
@@ -345,10 +359,9 @@ class TestSharedMethods:
     def test_attr_setter(self, attribute, value, cls):
         bas = cls["eval"](n_basis_funcs=5, **extra_decay_rates(cls["eval"], 5))
         with pytest.raises(
-                AttributeError, match=rf"can't set attribute|property '{attribute}' of"
+            AttributeError, match=rf"can't set attribute|property '{attribute}' of"
         ):
             setattr(bas, attribute, value)
-
 
     @pytest.mark.parametrize(
         "n_input, expectation",
@@ -360,7 +373,9 @@ class TestSharedMethods:
         ],
     )
     def test_expected_input_number(self, n_input, expectation, cls):
-        bas = cls["conv"](n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["eval"], 5))
+        bas = cls["conv"](
+            n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["eval"], 5)
+        )
         x = np.random.randn(20, 2)
         bas.compute_features(x)
         with expectation:
@@ -371,49 +386,66 @@ class TestSharedMethods:
         [
             (dict(), does_not_raise()),
             (
-                    dict(axis=0),
-                    pytest.raises(ValueError, match="Setting the `axis` parameter is not allowed"),
+                dict(axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (
-                    dict(axis=1),
-                    pytest.raises(ValueError, match="Setting the `axis` parameter is not allowed"),
+                dict(axis=1),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (dict(shift=True), does_not_raise()),
             (
-                    dict(shift=True, axis=0),
-                    pytest.raises(ValueError, match="Setting the `axis` parameter is not allowed"),
+                dict(shift=True, axis=0),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
             ),
             (
-                    dict(shifts=True),
-                    pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+                dict(shifts=True),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
             (dict(shift=True, predictor_causality="causal"), does_not_raise()),
             (
-                    dict(shift=True, time_series=np.arange(10)),
-                    pytest.raises(ValueError, match="Unrecognized keyword arguments"),
+                dict(shift=True, time_series=np.arange(10)),
+                pytest.raises(ValueError, match="Unrecognized keyword arguments"),
             ),
         ],
     )
     def test_init_conv_kwargs(self, conv_kwargs, expectation, cls):
         with expectation:
-            cls["conv"](n_basis_funcs=5, window_size=200, conv_kwargs=conv_kwargs, **extra_decay_rates(cls["eval"], 5))
+            cls["conv"](
+                n_basis_funcs=5,
+                window_size=200,
+                conv_kwargs=conv_kwargs,
+                **extra_decay_rates(cls["eval"], 5),
+            )
 
     @pytest.mark.parametrize("label", [None, "label"])
     def test_init_label(self, label, cls):
-        bas = cls["eval"](n_basis_funcs=5, label=label, **extra_decay_rates(cls["eval"], 5))
+        bas = cls["eval"](
+            n_basis_funcs=5, label=label, **extra_decay_rates(cls["eval"], 5)
+        )
         expected_label = str(label) if label is not None else cls["eval"].__name__
         assert bas.label == expected_label
 
     @pytest.mark.parametrize("n_input", [1, 2, 3])
     def test_set_num_output_features(self, n_input, cls):
-        bas = cls["conv"](n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["conv"], 5))
+        bas = cls["conv"](
+            n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["conv"], 5)
+        )
         assert bas.n_output_features is None
         bas.compute_features(np.random.randn(20, n_input))
         assert bas.n_output_features == n_input * bas.n_basis_funcs
 
     @pytest.mark.parametrize("n_input", [1, 2, 3])
     def test_set_num_basis_input(self, n_input, cls):
-        bas = cls["conv"](n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["conv"], 5))
+        bas = cls["conv"](
+            n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["conv"], 5)
+        )
         assert bas.n_basis_input is None
         bas.compute_features(np.random.randn(20, n_input))
         assert bas.n_basis_input == (n_input,)
@@ -423,14 +455,31 @@ class TestSharedMethods:
         "samples, vmin, vmax, expectation",
         [
             (0.5, 0, 1, does_not_raise()),
-            (-0.5, 0, 1, pytest.raises(ValueError, match="All the samples lie outside")),
+            (
+                -0.5,
+                0,
+                1,
+                pytest.raises(ValueError, match="All the samples lie outside"),
+            ),
             (np.linspace(-1, 1, 10), 0, 1, does_not_raise()),
-            (np.linspace(-1, 0, 10), 0, 1, pytest.warns(UserWarning, match="More than 90% of the samples")),
-            (np.linspace(1, 2, 10), 0, 1, pytest.warns(UserWarning, match="More than 90% of the samples")),
+            (
+                np.linspace(-1, 0, 10),
+                0,
+                1,
+                pytest.warns(UserWarning, match="More than 90% of the samples"),
+            ),
+            (
+                np.linspace(1, 2, 10),
+                0,
+                1,
+                pytest.warns(UserWarning, match="More than 90% of the samples"),
+            ),
         ],
     )
     def test_compute_features_vmin_vmax(self, samples, vmin, vmax, expectation, cls):
-        basis_obj = cls["eval"](5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5))
+        basis_obj = cls["eval"](
+            5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5)
+        )
         with expectation:
             basis_obj.compute_features(samples)
 
@@ -443,9 +492,15 @@ class TestSharedMethods:
             ((1, 3), np.arange(5), [0, 4], 1, 3),
         ],
     )
-    def test_vmin_vmax_eval_on_grid_affects_x(self, bounds, samples, nan_idx, mn, mx, cls):
-        bas_no_range = cls["eval"](n_basis_funcs=5, bounds=None, **extra_decay_rates(cls["eval"], 5))
-        bas = cls["eval"](n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5))
+    def test_vmin_vmax_eval_on_grid_affects_x(
+        self, bounds, samples, nan_idx, mn, mx, cls
+    ):
+        bas_no_range = cls["eval"](
+            n_basis_funcs=5, bounds=None, **extra_decay_rates(cls["eval"], 5)
+        )
+        bas = cls["eval"](
+            n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5)
+        )
         x1, _ = bas.evaluate_on_grid(10)
         x2, _ = bas_no_range.evaluate_on_grid(10)
         assert np.allclose(x1, x2 * (mx - mn) + mn)
@@ -458,12 +513,18 @@ class TestSharedMethods:
             (1, 3, np.arange(5), [0, 4]),
         ],
     )
-    def test_vmin_vmax_eval_on_grid_no_effect_on_eval(self, vmin, vmax, samples, nan_idx, cls):
+    def test_vmin_vmax_eval_on_grid_no_effect_on_eval(
+        self, vmin, vmax, samples, nan_idx, cls
+    ):
         # MSPline integrates to 1 on domain so must be excluded from this check
-        if "MSpline" in  cls["eval"].__name__:
+        if "MSpline" in cls["eval"].__name__:
             return
-        bas_no_range = cls["eval"](n_basis_funcs=5, bounds=None, **extra_decay_rates(cls["eval"], 5))
-        bas = cls["eval"](n_basis_funcs=5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5))
+        bas_no_range = cls["eval"](
+            n_basis_funcs=5, bounds=None, **extra_decay_rates(cls["eval"], 5)
+        )
+        bas = cls["eval"](
+            n_basis_funcs=5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5)
+        )
         _, out1 = bas.evaluate_on_grid(10)
         _, out2 = bas_no_range.evaluate_on_grid(10)
         assert np.allclose(out1, out2)
@@ -479,16 +540,18 @@ class TestSharedMethods:
             ((1, "a"), pytest.raises(TypeError, match="Could not convert")),
             (("a", "a"), pytest.raises(TypeError, match="Could not convert")),
             (
-                    (1, 2, 3),
-                    pytest.raises(
-                        ValueError, match="The provided `bounds` must be of length two"
-                    ),
+                (1, 2, 3),
+                pytest.raises(
+                    ValueError, match="The provided `bounds` must be of length two"
+                ),
             ),
         ],
     )
     def test_vmin_vmax_init(self, bounds, expectation, cls):
         with expectation:
-            bas = cls["eval"](n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5))
+            bas = cls["eval"](
+                n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5)
+            )
             assert bounds == bas.bounds if bounds else bas.bounds is None
 
     @pytest.mark.parametrize(
@@ -502,16 +565,18 @@ class TestSharedMethods:
             ((1, "a"), pytest.raises(TypeError, match="Could not convert")),
             (("a", "a"), pytest.raises(TypeError, match="Could not convert")),
             (
-                    (1, 2, 3),
-                    pytest.raises(
-                        ValueError, match="The provided `bounds` must be of length two"
-                    ),
+                (1, 2, 3),
+                pytest.raises(
+                    ValueError, match="The provided `bounds` must be of length two"
+                ),
             ),
         ],
     )
     def test_vmin_vmax_init(self, bounds, expectation, cls):
         with expectation:
-            bas = cls["eval"](n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5))
+            bas = cls["eval"](
+                n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5)
+            )
             assert bounds == bas.bounds if bounds else bas.bounds is None
 
     @pytest.mark.parametrize(
@@ -525,31 +590,43 @@ class TestSharedMethods:
             ((1, "a"), pytest.raises(TypeError, match="Could not convert")),
             (("a", "a"), pytest.raises(TypeError, match="Could not convert")),
             (
-                    (2, 1),
-                    pytest.raises(
-                        ValueError, match=r"Invalid bound \(2, 1\). Lower bound is greater"
-                    ),
+                (2, 1),
+                pytest.raises(
+                    ValueError, match=r"Invalid bound \(2, 1\). Lower bound is greater"
+                ),
             ),
         ],
     )
     def test_vmin_vmax_setter(self, bounds, expectation, cls):
-        bas = cls["eval"](n_basis_funcs=5, bounds=(1, 3), **extra_decay_rates(cls["eval"], 5))
+        bas = cls["eval"](
+            n_basis_funcs=5, bounds=(1, 3), **extra_decay_rates(cls["eval"], 5)
+        )
         with expectation:
             bas.set_params(bounds=bounds)
             assert bounds == bas.bounds if bounds else bas.bounds is None
 
     @pytest.mark.parametrize("n_basis", [6, 7])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
-    def test_call_basis_number(self, n_basis, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
+    def test_call_basis_number(self, n_basis, mode, kwargs, cls):
 
-        bas = cls[mode](n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis))
+        bas = cls[mode](
+            n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
+        )
         x = np.linspace(0, 1, 10)
         assert bas(x).shape[1] == n_basis
 
     @pytest.mark.parametrize("n_basis", [6])
     def test_call_equivalent_in_conv(self, n_basis, cls):
-        bas_con = cls["conv"](n_basis_funcs=n_basis, window_size=10, **extra_decay_rates(cls["conv"], n_basis))
-        bas_eval = cls["eval"](n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis))
+        bas_con = cls["conv"](
+            n_basis_funcs=n_basis,
+            window_size=10,
+            **extra_decay_rates(cls["conv"], n_basis),
+        )
+        bas_eval = cls["eval"](
+            n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis)
+        )
         x = np.linspace(0, 1, 10)
         assert np.all(bas_con(x) == bas_eval(x))
 
@@ -561,10 +638,14 @@ class TestSharedMethods:
             (2, pytest.raises(TypeError, match="Input dimensionality mismatch")),
         ],
     )
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
     @pytest.mark.parametrize("n_basis", [6])
-    def test_call_input_num(self, num_input, n_basis, mode, kwargs, expectation,cls):
-        bas = cls[mode](n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis))
+    def test_call_input_num(self, num_input, n_basis, mode, kwargs, expectation, cls):
+        bas = cls[mode](
+            n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
+        )
         with expectation:
             bas(*([np.linspace(0, 1, 10)] * num_input))
 
@@ -576,9 +657,13 @@ class TestSharedMethods:
         ],
     )
     @pytest.mark.parametrize("n_basis", [6])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
-    def test_call_input_shape(self, inp, mode, kwargs, expectation,n_basis,cls):
-        bas = cls[mode](n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis))
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
+    def test_call_input_shape(self, inp, mode, kwargs, expectation, n_basis, cls):
+        bas = cls[mode](
+            n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
+        )
         with expectation:
             bas(inp)
 
@@ -587,34 +672,44 @@ class TestSharedMethods:
         [
             (np.array([0, 1, 2, 3, 4, 5]), does_not_raise()),
             (
-                    np.array(["a", "1", "2", "3", "4", "5"]),
-                    pytest.raises(TypeError, match="Input samples must"),
+                np.array(["a", "1", "2", "3", "4", "5"]),
+                pytest.raises(TypeError, match="Input samples must"),
             ),
         ],
     )
     @pytest.mark.parametrize("n_basis", [6])
-    def test_call_input_type(self, samples, expectation, n_basis,cls):
-        bas = cls["eval"](n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis))  # Only eval mode is relevant here
+    def test_call_input_type(self, samples, expectation, n_basis, cls):
+        bas = cls["eval"](
+            n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis)
+        )  # Only eval mode is relevant here
         with expectation:
             bas(samples)
 
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
-    def test_call_nan(self, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
+    def test_call_nan(self, mode, kwargs, cls):
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
         x = np.linspace(0, 1, 10)
         x[3] = np.nan
         assert all(np.isnan(bas(x)[3]))
 
     @pytest.mark.parametrize("n_basis", [6, 7])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
-    def test_call_non_empty(self, n_basis, mode, kwargs,cls):
-        bas = cls[mode](n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis))
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
+    def test_call_non_empty(self, n_basis, mode, kwargs, cls):
+        bas = cls[mode](
+            n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
+        )
         with pytest.raises(ValueError, match="All sample provided must"):
             bas(np.array([]))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
-    def test_call_sample_axis(self, time_axis_shape, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
+    def test_call_sample_axis(self, time_axis_shape, mode, kwargs, cls):
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
         assert bas(np.linspace(0, 1, time_axis_shape)).shape[0] == time_axis_shape
 
@@ -625,8 +720,10 @@ class TestSharedMethods:
             (-2, 2, does_not_raise()),
         ],
     )
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
-    def test_call_sample_range(self, mn, mx, expectation, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
+    def test_call_sample_range(self, mn, mx, expectation, mode, kwargs, cls):
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
         with expectation:
             bas(np.linspace(mn, mx, 10))
@@ -635,13 +732,30 @@ class TestSharedMethods:
         "kwargs, input1_shape, expectation",
         [
             (dict(), (10,), does_not_raise()),
-            (dict(axis=0), (10,), pytest.raises(ValueError, match="Setting the `axis` parameter is not allowed")),
-            (dict(axis=1), (2, 10), pytest.raises(ValueError, match="Setting the `axis` parameter is not allowed")),
+            (
+                dict(axis=0),
+                (10,),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
+            (
+                dict(axis=1),
+                (2, 10),
+                pytest.raises(
+                    ValueError, match="Setting the `axis` parameter is not allowed"
+                ),
+            ),
         ],
     )
-    def test_compute_features_axis(self, kwargs, input1_shape, expectation,cls):
+    def test_compute_features_axis(self, kwargs, input1_shape, expectation, cls):
         with expectation:
-            basis_obj = cls["conv"](n_basis_funcs=5, window_size=5, conv_kwargs=kwargs, **extra_decay_rates(cls["conv"], 5))
+            basis_obj = cls["conv"](
+                n_basis_funcs=5,
+                window_size=5,
+                conv_kwargs=kwargs,
+                **extra_decay_rates(cls["conv"], 5),
+            )
             basis_obj.compute_features(np.ones(input1_shape))
 
     @pytest.mark.parametrize("n_basis_funcs", [4, 5])
@@ -662,28 +776,29 @@ class TestSharedMethods:
         ],
     )
     def test_compute_features_conv_input(
-            self,
-            n_basis_funcs,
-            time_scaling,
-            enforce_decay,
-            window_size,
-            input_shape,
-            expected_n_input,
-            order,
-            width,
-            cls,
-            class_specific_params,
-        ):
+        self,
+        n_basis_funcs,
+        time_scaling,
+        enforce_decay,
+        window_size,
+        input_shape,
+        expected_n_input,
+        order,
+        width,
+        cls,
+        class_specific_params,
+    ):
         x = np.ones(input_shape)
 
         kwargs = dict(
             n_basis_funcs=n_basis_funcs,
-            decay_rates=np.arange(1, n_basis_funcs+1),
+            decay_rates=np.arange(1, n_basis_funcs + 1),
             time_scaling=time_scaling,
             window_size=window_size,
             enforce_decay_to_zero=enforce_decay,
             order=order,
-            width=width,)
+            width=width,
+        )
 
         # figure out which kwargs needs to be removed
         kwargs = trim_kwargs(cls["conv"], kwargs, class_specific_params)
@@ -692,8 +807,10 @@ class TestSharedMethods:
         out = basis_obj.compute_features(x)
         assert out.shape[1] == expected_n_input * basis_obj.n_basis_funcs
 
-    @pytest.mark.parametrize("eval_input", [0, [0], (0,), np.array([0]), jax.numpy.array([0])])
-    def test_compute_features_input(self, eval_input,cls):
+    @pytest.mark.parametrize(
+        "eval_input", [0, [0], (0,), np.array([0]), jax.numpy.array([0])]
+    )
+    def test_compute_features_input(self, eval_input, cls):
         # orth exp needs more inputs (orthogonalizaiton impossible otherwise)
         if "OrthExp" in cls["eval"].__name__:
             return
@@ -704,9 +821,15 @@ class TestSharedMethods:
         "args, sample_size",
         [[{"n_basis_funcs": n_basis}, 100] for n_basis in [6, 10, 13]],
     )
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 30})])
-    def test_compute_features_returns_expected_number_of_basis(self, args, sample_size, mode, kwargs,cls):
-        basis_obj = cls[mode](**args, **kwargs, **extra_decay_rates(cls[mode], args["n_basis_funcs"]))
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 30})]
+    )
+    def test_compute_features_returns_expected_number_of_basis(
+        self, args, sample_size, mode, kwargs, cls
+    ):
+        basis_obj = cls[mode](
+            **args, **kwargs, **extra_decay_rates(cls[mode], args["n_basis_funcs"])
+        )
         eval_basis = basis_obj.compute_features(np.linspace(0, 1, sample_size))
         assert eval_basis.shape[1] == args["n_basis_funcs"], (
             "Dimensions do not agree: The number of basis should match the first dimension "
@@ -718,31 +841,77 @@ class TestSharedMethods:
         "samples, vmin, vmax, expectation",
         [
             (0.5, 0, 1, does_not_raise()),
-            (-0.5, 0, 1, pytest.raises(ValueError, match="All the samples lie outside")),
+            (
+                -0.5,
+                0,
+                1,
+                pytest.raises(ValueError, match="All the samples lie outside"),
+            ),
             (np.linspace(-1, 1, 10), 0, 1, does_not_raise()),
-            (np.linspace(-1, 0, 10), 0, 1, pytest.warns(UserWarning, match="More than 90% of the samples")),
-            (np.linspace(1, 2, 10), 0, 1, pytest.warns(UserWarning, match="More than 90% of the samples")),
+            (
+                np.linspace(-1, 0, 10),
+                0,
+                1,
+                pytest.warns(UserWarning, match="More than 90% of the samples"),
+            ),
+            (
+                np.linspace(1, 2, 10),
+                0,
+                1,
+                pytest.warns(UserWarning, match="More than 90% of the samples"),
+            ),
         ],
     )
-    def test_compute_features_vmin_vmax(self, samples, vmin, vmax, expectation,cls):
+    def test_compute_features_vmin_vmax(self, samples, vmin, vmax, expectation, cls):
         if "OrthExp" in cls["eval"].__name__ and not hasattr(samples, "shape"):
             return
-        basis_obj = cls["eval"](5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5))
+        basis_obj = cls["eval"](
+            5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5)
+        )
         with expectation:
             basis_obj.compute_features(samples)
 
     @pytest.mark.parametrize(
         "bounds, samples, exception",
         [
-            (None, np.arange(5), pytest.raises(TypeError, match="got an unexpected keyword argument 'bounds'")),
-            ((0, 3), np.arange(5), pytest.raises(TypeError, match="got an unexpected keyword argument 'bounds'")),
-            ((1, 4), np.arange(5), pytest.raises(TypeError, match="got an unexpected keyword argument 'bounds'")),
-            ((1, 3), np.arange(5), pytest.raises(TypeError, match="got an unexpected keyword argument 'bounds'")),
+            (
+                None,
+                np.arange(5),
+                pytest.raises(
+                    TypeError, match="got an unexpected keyword argument 'bounds'"
+                ),
+            ),
+            (
+                (0, 3),
+                np.arange(5),
+                pytest.raises(
+                    TypeError, match="got an unexpected keyword argument 'bounds'"
+                ),
+            ),
+            (
+                (1, 4),
+                np.arange(5),
+                pytest.raises(
+                    TypeError, match="got an unexpected keyword argument 'bounds'"
+                ),
+            ),
+            (
+                (1, 3),
+                np.arange(5),
+                pytest.raises(
+                    TypeError, match="got an unexpected keyword argument 'bounds'"
+                ),
+            ),
         ],
     )
     def test_vmin_vmax_mode_conv(self, bounds, samples, exception, cls):
         with exception:
-            cls["conv"](n_basis_funcs=5, window_size=10, bounds=bounds, **extra_decay_rates(cls["conv"], 5))
+            cls["conv"](
+                n_basis_funcs=5,
+                window_size=10,
+                bounds=bounds,
+                **extra_decay_rates(cls["conv"], 5),
+            )
 
     @pytest.mark.parametrize(
         "vmin, vmax, samples, nan_idx",
@@ -755,7 +924,9 @@ class TestSharedMethods:
     )
     def test_vmin_vmax_range(self, vmin, vmax, samples, nan_idx, cls):
         bounds = None if vmin is None else (vmin, vmax)
-        bas = cls["eval"](n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5))
+        bas = cls["eval"](
+            n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5)
+        )
         out = bas.compute_features(samples)
         assert np.all(np.isnan(out[nan_idx]))
         valid_idx = list(set(samples).difference(nan_idx))
@@ -772,25 +943,31 @@ class TestSharedMethods:
             ((1, "a"), pytest.raises(TypeError, match="Could not convert")),
             (("a", "a"), pytest.raises(TypeError, match="Could not convert")),
             (
-                    (2, 1),
-                    pytest.raises(
-                        ValueError, match=r"Invalid bound \(2, 1\). Lower bound is greater"
-                    ),
+                (2, 1),
+                pytest.raises(
+                    ValueError, match=r"Invalid bound \(2, 1\). Lower bound is greater"
+                ),
             ),
         ],
     )
-    def test_vmin_vmax_setter(self, bounds, expectation,cls):
-        bas = cls["eval"](n_basis_funcs=5, bounds=(1, 3), **extra_decay_rates(cls["eval"], 5))
+    def test_vmin_vmax_setter(self, bounds, expectation, cls):
+        bas = cls["eval"](
+            n_basis_funcs=5, bounds=(1, 3), **extra_decay_rates(cls["eval"], 5)
+        )
         with expectation:
             bas.set_params(bounds=bounds)
             assert bounds == bas.bounds if bounds else bas.bounds is None
 
-    def test_conv_kwargs_error(self,cls):
-        with pytest.raises(TypeError, match="got an unexpected keyword argument 'test'"):
+    def test_conv_kwargs_error(self, cls):
+        with pytest.raises(
+            TypeError, match="got an unexpected keyword argument 'test'"
+        ):
             cls["eval"](n_basis_funcs=5, test="hi", **extra_decay_rates(cls["eval"], 5))
 
-    def test_convolution_is_performed(self,cls):
-        bas = cls["conv"](n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["conv"], 5))
+    def test_convolution_is_performed(self, cls):
+        bas = cls["conv"](
+            n_basis_funcs=5, window_size=10, **extra_decay_rates(cls["conv"], 5)
+        )
         x = np.random.normal(size=100)
         conv = bas.compute_features(x)
         conv_2 = convolve.create_convolutional_predictor(bas.kernel_, x)
@@ -799,30 +976,42 @@ class TestSharedMethods:
         assert np.all(np.isnan(conv_2[~valid]))
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_evaluate_on_grid_basis_size(self, sample_size, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_evaluate_on_grid_basis_size(self, sample_size, mode, kwargs, cls):
         if "OrthExp" in cls["eval"].__name__:
             return
-        basis_obj = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
+        basis_obj = cls[mode](
+            n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5)
+        )
         if sample_size <= 0:
-            with pytest.raises(ValueError, match=r"All sample counts provided must be greater"):
+            with pytest.raises(
+                ValueError, match=r"All sample counts provided must be greater"
+            ):
                 basis_obj.evaluate_on_grid(sample_size)
         else:
             _, eval_basis = basis_obj.evaluate_on_grid(sample_size)
             assert eval_basis.shape[0] == sample_size
 
     @pytest.mark.parametrize("n_input", [0, 1, 2])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_evaluate_on_grid_input_number(self, n_input, mode, kwargs,cls):
-        basis_obj = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_evaluate_on_grid_input_number(self, n_input, mode, kwargs, cls):
+        basis_obj = cls[mode](
+            n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5)
+        )
         inputs = [10] * n_input
         if n_input == 0:
             expectation = pytest.raises(
-                TypeError, match=r"evaluate_on_grid\(\) missing 1 required positional argument",
+                TypeError,
+                match=r"evaluate_on_grid\(\) missing 1 required positional argument",
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
-                TypeError, match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
+                TypeError,
+                match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
             )
         else:
             expectation = does_not_raise()
@@ -831,25 +1020,35 @@ class TestSharedMethods:
             basis_obj.evaluate_on_grid(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_evaluate_on_grid_meshgrid_size(self, sample_size, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_evaluate_on_grid_meshgrid_size(self, sample_size, mode, kwargs, cls):
         if "OrthExp" in cls["eval"].__name__:
             return
-        basis_obj = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
+        basis_obj = cls[mode](
+            n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5)
+        )
         if sample_size <= 0:
-            with pytest.raises(ValueError, match=r"All sample counts provided must be greater"):
+            with pytest.raises(
+                ValueError, match=r"All sample counts provided must be greater"
+            ):
                 basis_obj.evaluate_on_grid(sample_size)
         else:
             grid, _ = basis_obj.evaluate_on_grid(sample_size)
             assert grid.shape[0] == sample_size
 
     def test_fit_kernel(self, cls):
-        bas = cls["conv"](n_basis_funcs=5, window_size=30,  **extra_decay_rates(cls["conv"], 5))
+        bas = cls["conv"](
+            n_basis_funcs=5, window_size=30, **extra_decay_rates(cls["conv"], 5)
+        )
         bas._set_kernel()
         assert bas.kernel_ is not None
 
-    def test_fit_kernel_shape(self,cls):
-        bas = cls["conv"](n_basis_funcs=5, window_size=30, **extra_decay_rates(cls["conv"], 5))
+    def test_fit_kernel_shape(self, cls):
+        bas = cls["conv"](
+            n_basis_funcs=5, window_size=30, **extra_decay_rates(cls["conv"], 5)
+        )
         bas._set_kernel()
         assert bas.kernel_.shape == (30, 5)
 
@@ -858,40 +1057,46 @@ class TestSharedMethods:
         [
             ("conv", 2, does_not_raise()),
             (
-                    "conv",
-                    -1,
-                    pytest.raises(ValueError, match="`window_size` must be a positive "),
+                "conv",
+                -1,
+                pytest.raises(ValueError, match="`window_size` must be a positive "),
             ),
             (
-                    "conv",
-                    None,
-                    pytest.raises(
-                        ValueError,
-                        match="If the basis is in `conv` mode, you must provide a ",
-                    ),
+                "conv",
+                None,
+                pytest.raises(
+                    ValueError,
+                    match="If the basis is in `conv` mode, you must provide a ",
+                ),
             ),
             (
-                    "conv",
-                    1.5,
-                    pytest.raises(ValueError, match="`window_size` must be a positive "),
+                "conv",
+                1.5,
+                pytest.raises(ValueError, match="`window_size` must be a positive "),
             ),
-            ("eval", None, pytest.raises(
-                TypeError,
-                match=r"got an unexpected keyword argument 'window_size'",
-            )),
             (
-                    "eval",
-                    10,
-                    pytest.raises(
-                        TypeError,
-                        match=r"got an unexpected keyword argument 'window_size'",
-                    ),
+                "eval",
+                None,
+                pytest.raises(
+                    TypeError,
+                    match=r"got an unexpected keyword argument 'window_size'",
+                ),
+            ),
+            (
+                "eval",
+                10,
+                pytest.raises(
+                    TypeError,
+                    match=r"got an unexpected keyword argument 'window_size'",
+                ),
             ),
         ],
     )
-    def test_init_window_size(self, mode, ws, expectation,cls):
+    def test_init_window_size(self, mode, ws, expectation, cls):
         with expectation:
-            cls[mode](n_basis_funcs=5, window_size=ws, **extra_decay_rates(cls[mode], 5))
+            cls[mode](
+                n_basis_funcs=5, window_size=ws, **extra_decay_rates(cls[mode], 5)
+            )
 
     # @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     # @pytest.mark.parametrize("order", [1, 2, 3, 4, 5])
@@ -911,35 +1116,55 @@ class TestSharedMethods:
     #         cls[mode](n_basis_funcs=n_basis_funcs, **kwargs)
 
     @pytest.mark.parametrize("samples", [[], [0], [0, 0]])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_non_empty_samples(self, samples, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_non_empty_samples(self, samples, mode, kwargs, cls):
         if "OrthExp" in cls["eval"].__name__:
             return
         if mode == "conv" and len(samples) == 1:
             return
         if len(samples) == 0:
-            with pytest.raises(ValueError, match="All sample provided must be non empty"):
-                cls[mode](5, **kwargs, **extra_decay_rates(cls[mode], 5)).compute_features(samples)
+            with pytest.raises(
+                ValueError, match="All sample provided must be non empty"
+            ):
+                cls[mode](
+                    5, **kwargs, **extra_decay_rates(cls[mode], 5)
+                ).compute_features(samples)
         else:
-            cls[mode](5, **kwargs, **extra_decay_rates(cls[mode], 5)).compute_features(samples)
+            cls[mode](5, **kwargs, **extra_decay_rates(cls[mode], 5)).compute_features(
+                samples
+            )
 
     @pytest.mark.parametrize("n_input", [0, 1, 2, 3])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 6})])
-    def test_number_of_required_inputs_compute_features(self, n_input, mode, kwargs,cls):
-        basis_obj = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 6})]
+    )
+    def test_number_of_required_inputs_compute_features(
+        self, n_input, mode, kwargs, cls
+    ):
+        basis_obj = cls[mode](
+            n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5)
+        )
         inputs = [np.linspace(0, 1, 20)] * n_input
         if n_input == 0:
-            expectation = pytest.raises(TypeError, match="missing 1 required positional argument")
+            expectation = pytest.raises(
+                TypeError, match="missing 1 required positional argument"
+            )
         elif n_input != basis_obj._n_input_dimensionality:
-            expectation = pytest.raises(TypeError, match="takes 2 positional arguments but \d were given")
+            expectation = pytest.raises(
+                TypeError, match="takes 2 positional arguments but \d were given"
+            )
         else:
             expectation = does_not_raise()
 
         with expectation:
             basis_obj.compute_features(*inputs)
 
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
-    def test_pynapple_support(self, mode, kwargs,cls):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
+    )
+    def test_pynapple_support(self, mode, kwargs, cls):
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
         x = np.linspace(0, 1, 10)
         x_nap = nap.Tsd(t=np.arange(10), d=x)
@@ -951,22 +1176,32 @@ class TestSharedMethods:
 
     @pytest.mark.parametrize("sample_size", [30])
     @pytest.mark.parametrize("n_basis", [5])
-    def test_pynapple_support_compute_features(self, n_basis, sample_size,cls):
+    def test_pynapple_support_compute_features(self, n_basis, sample_size, cls):
         iset = nap.IntervalSet(start=[0, 0.5], end=[0.49999, 1])
         inp = nap.Tsd(
             t=np.linspace(0, 1, sample_size),
             d=np.linspace(0, 1, sample_size),
             time_support=iset,
         )
-        out = cls["eval"](n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis)).compute_features(inp)
+        out = cls["eval"](
+            n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis)
+        ).compute_features(inp)
         assert isinstance(out, nap.TsdFrame)
         assert np.all(out.time_support.values == inp.time_support.values)
 
     @pytest.mark.parametrize("sample_size", [100, 1000])
     @pytest.mark.parametrize("n_basis_funcs", [5, 10, 80])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 90})])
-    def test_sample_size_of_compute_features_matches_that_of_input(self, n_basis_funcs, sample_size, mode, kwargs,cls):
-        basis_obj = cls[mode](n_basis_funcs=n_basis_funcs, **kwargs, **extra_decay_rates(cls[mode], n_basis_funcs))
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 90})]
+    )
+    def test_sample_size_of_compute_features_matches_that_of_input(
+        self, n_basis_funcs, sample_size, mode, kwargs, cls
+    ):
+        basis_obj = cls[mode](
+            n_basis_funcs=n_basis_funcs,
+            **kwargs,
+            **extra_decay_rates(cls[mode], n_basis_funcs),
+        )
         eval_basis = basis_obj.compute_features(np.linspace(0, 1, sample_size))
         assert eval_basis.shape[0] == sample_size, (
             f"Dimensions do not agree: The sample size of the output should match the input sample size. "
@@ -977,17 +1212,26 @@ class TestSharedMethods:
         "mode, expectation",
         [
             ("eval", does_not_raise()),
-            ("conv", pytest.raises(TypeError, match="got an unexpected keyword argument 'bounds'")),
+            (
+                "conv",
+                pytest.raises(
+                    TypeError, match="got an unexpected keyword argument 'bounds'"
+                ),
+            ),
         ],
     )
-    def test_set_bounds(self, mode, expectation,cls):
+    def test_set_bounds(self, mode, expectation, cls):
         kwargs = {"bounds": (1, 2)}
         with expectation:
             cls[mode](n_basis_funcs=10, **kwargs, **extra_decay_rates(cls[mode], 10))
 
         if mode == "conv":
-            bas = cls["conv"](n_basis_funcs=10, window_size=20, **extra_decay_rates(cls[mode], 10))
-            with pytest.raises(ValueError, match="Invalid parameter 'bounds' for estimator"):
+            bas = cls["conv"](
+                n_basis_funcs=10, window_size=20, **extra_decay_rates(cls[mode], 10)
+            )
+            with pytest.raises(
+                ValueError, match="Invalid parameter 'bounds' for estimator"
+            ):
                 bas.set_params(bounds=(1, 2))
 
     @pytest.mark.parametrize(
@@ -1004,17 +1248,19 @@ class TestSharedMethods:
         ],
     )
     def test_set_params(
-            self,
-            enforce_decay_to_zero,
-            time_scaling,
-            width,
-            window_size,
-            n_basis_funcs,
-            bounds,
-            mode: Literal["eval", "conv"],
-            order, decay_rates, conv_kwargs,
-            cls,
-            class_specific_params
+        self,
+        enforce_decay_to_zero,
+        time_scaling,
+        width,
+        window_size,
+        n_basis_funcs,
+        bounds,
+        mode: Literal["eval", "conv"],
+        order,
+        decay_rates,
+        conv_kwargs,
+        cls,
+        class_specific_params,
     ):
         """Test the read-only and read/write property of the parameters."""
         pars = dict(
@@ -1028,12 +1274,14 @@ class TestSharedMethods:
             decay_rates=decay_rates,
             conv_kwargs=conv_kwargs,
         )
-        pars = {key: value for key, value in pars.items() if key in class_specific_params[cls[mode].__name__]}
+        pars = {
+            key: value
+            for key, value in pars.items()
+            if key in class_specific_params[cls[mode].__name__]
+        }
 
         keys = list(pars.keys())
-        bas = cls[mode](
-            **pars
-        )
+        bas = cls[mode](**pars)
         for i in range(len(pars)):
             for j in range(i + 1, len(pars)):
                 par_set = {keys[i]: pars[keys[i]], keys[j]: pars[keys[j]]}
@@ -1044,32 +1292,43 @@ class TestSharedMethods:
         "mode, expectation",
         [
             ("conv", does_not_raise()),
-            ("eval", pytest.raises(TypeError, match="got an unexpected keyword argument 'window_size'")),
+            (
+                "eval",
+                pytest.raises(
+                    TypeError, match="got an unexpected keyword argument 'window_size'"
+                ),
+            ),
         ],
     )
-    def test_set_window_size(self, mode, expectation,cls):
+    def test_set_window_size(self, mode, expectation, cls):
         kwargs = {"window_size": 10}
         with expectation:
             cls[mode](n_basis_funcs=10, **kwargs, **extra_decay_rates(cls[mode], 10))
 
         if mode == "conv":
-            bas = cls["conv"](n_basis_funcs=10, window_size=10, **extra_decay_rates(cls["conv"], 10))
+            bas = cls["conv"](
+                n_basis_funcs=10, window_size=10, **extra_decay_rates(cls["conv"], 10)
+            )
             with pytest.raises(ValueError, match="If the basis is in `conv` mode"):
                 bas.set_params(window_size=None)
 
         if mode == "eval":
             bas = cls["eval"](n_basis_funcs=10, **extra_decay_rates(cls["eval"], 10))
-            with pytest.raises(ValueError, match="Invalid parameter 'window_size' for estimator"):
+            with pytest.raises(
+                ValueError, match="Invalid parameter 'window_size' for estimator"
+            ):
                 bas.set_params(window_size=10)
 
-    def test_transform_fails(self,cls):
-        bas = cls["conv"](n_basis_funcs=5, window_size=3, **extra_decay_rates(cls["conv"], 5))
+    def test_transform_fails(self, cls):
+        bas = cls["conv"](
+            n_basis_funcs=5, window_size=3, **extra_decay_rates(cls["conv"], 5)
+        )
         with pytest.raises(
-                ValueError, match="You must call `_set_kernel` before `_compute_features`"
+            ValueError, match="You must call `_set_kernel` before `_compute_features`"
         ):
             bas._compute_features(np.linspace(0, 1, 10))
 
-    def test_transformer_get_params(self,cls):
+    def test_transformer_get_params(self, cls):
         bas = cls["eval"](n_basis_funcs=5, **extra_decay_rates(cls["eval"], 5))
         bas_transformer = bas.to_transformer()
         params_transf = bas_transformer.get_params()
@@ -1083,11 +1342,15 @@ class TestSharedMethods:
 
 class TestRaisedCosineLogBasis:
     cls = {"eval": basis.EvalRaisedCosineLog, "conv": basis.ConvRaisedCosineLog}
+
     @pytest.mark.parametrize("width", [1.5, 2, 2.5])
     def test_decay_to_zero_basis_number_match(self, width):
         n_basis_funcs = 10
         _, ev = self.cls["conv"](
-            n_basis_funcs=n_basis_funcs, width=width, enforce_decay_to_zero=True, window_size=5
+            n_basis_funcs=n_basis_funcs,
+            width=width,
+            enforce_decay_to_zero=True,
+            window_size=5,
         ).evaluate_on_grid(2)
         assert ev.shape[1] == n_basis_funcs, (
             "Basis function number mismatch. "
@@ -1095,11 +1358,16 @@ class TestRaisedCosineLogBasis:
         )
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, mode, kwargs):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_minimum_number_of_basis_required_is_matched(
+        self, n_basis_funcs, mode, kwargs
+    ):
         if n_basis_funcs < 2:
             with pytest.raises(
-                    ValueError, match=f"Object class {self.cls[mode].__name__} requires >= 2 basis elements.",
+                ValueError,
+                match=f"Object class {self.cls[mode].__name__} requires >= 2 basis elements.",
             ):
                 self.cls[mode](n_basis_funcs=n_basis_funcs, **kwargs)
         else:
@@ -1110,13 +1378,33 @@ class TestRaisedCosineLogBasis:
         [
             (10, does_not_raise()),
             (10.5, does_not_raise()),
-            (0.5, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
-            (10.3, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
-            (-10, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
+            (
+                0.5,
+                pytest.raises(
+                    ValueError,
+                    match=r"Invalid raised cosine width\. 2\*width must be a positive",
+                ),
+            ),
+            (
+                10.3,
+                pytest.raises(
+                    ValueError,
+                    match=r"Invalid raised cosine width\. 2\*width must be a positive",
+                ),
+            ),
+            (
+                -10,
+                pytest.raises(
+                    ValueError,
+                    match=r"Invalid raised cosine width\. 2\*width must be a positive",
+                ),
+            ),
             (None, pytest.raises(TypeError, match="'<=' not supported between")),
         ],
     )
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})])
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})]
+    )
     def test_set_width(self, width, expectation, mode, kwargs):
         basis_obj = self.cls[mode](n_basis_funcs=5, **kwargs)
         with expectation:
@@ -1137,7 +1425,7 @@ class TestRaisedCosineLogBasis:
             )
             _, log_ev = basis_log.evaluate_on_grid(100)
             corr[idx] = (lin_ev.flatten() @ log_ev.flatten()) / (
-                    np.linalg.norm(lin_ev.flatten()) * np.linalg.norm(log_ev.flatten())
+                np.linalg.norm(lin_ev.flatten()) * np.linalg.norm(log_ev.flatten())
             )
         assert np.all(
             np.diff(corr) < 0
@@ -1146,13 +1434,25 @@ class TestRaisedCosineLogBasis:
     @pytest.mark.parametrize(
         "time_scaling, expectation",
         [
-            (-1, pytest.raises(ValueError, match="Only strictly positive time_scaling are allowed")),
-            (0, pytest.raises(ValueError, match="Only strictly positive time_scaling are allowed")),
+            (
+                -1,
+                pytest.raises(
+                    ValueError, match="Only strictly positive time_scaling are allowed"
+                ),
+            ),
+            (
+                0,
+                pytest.raises(
+                    ValueError, match="Only strictly positive time_scaling are allowed"
+                ),
+            ),
             (0.1, does_not_raise()),
             (10, does_not_raise()),
         ],
     )
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})])
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})]
+    )
     def test_time_scaling_values(self, time_scaling, expectation, mode, kwargs):
         with expectation:
             self.cls[mode](n_basis_funcs=5, time_scaling=time_scaling, **kwargs)
@@ -1169,7 +1469,9 @@ class TestRaisedCosineLogBasis:
             (2.1, pytest.raises(ValueError, match="Invalid raised cosine width. ")),
         ],
     )
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
     def test_width_values(self, width, expectation, mode, kwargs):
         with expectation:
             self.cls[mode](n_basis_funcs=5, width=width, **kwargs)
@@ -1179,11 +1481,16 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
     cls = {"eval": basis.EvalRaisedCosineLinear, "conv": basis.ConvRaisedCosineLinear}
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, mode, kwargs):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_minimum_number_of_basis_required_is_matched(
+        self, n_basis_funcs, mode, kwargs
+    ):
         if n_basis_funcs < 2:
             with pytest.raises(
-                    ValueError, match=f"Object class {self.cls[mode].__name__} requires >= 2 basis elements.",
+                ValueError,
+                match=f"Object class {self.cls[mode].__name__} requires >= 2 basis elements.",
             ):
                 self.cls[mode](n_basis_funcs=n_basis_funcs, **kwargs)
         else:
@@ -1194,8 +1501,20 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
         [
             (10, does_not_raise()),
             (10.5, does_not_raise()),
-            (0.5, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
-            (-10, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
+            (
+                0.5,
+                pytest.raises(
+                    ValueError,
+                    match=r"Invalid raised cosine width\. 2\*width must be a positive",
+                ),
+            ),
+            (
+                -10,
+                pytest.raises(
+                    ValueError,
+                    match=r"Invalid raised cosine width\. 2\*width must be a positive",
+                ),
+            ),
         ],
     )
     def test_set_width(self, width, expectation):
@@ -1217,7 +1536,9 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
             (2.1, pytest.raises(ValueError, match="Invalid raised cosine width. ")),
         ],
     )
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})])
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})]
+    )
     def test_width_values(self, width, expectation, mode, kwargs):
         """
         Test allowable widths: integer multiple of 1/2, greater than 1.
@@ -1235,8 +1556,12 @@ class TestMSplineBasis(BasisFuncsTesting):
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     @pytest.mark.parametrize("order", [-1, 0, 1, 2, 3, 4, 5])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, order, mode, kwargs):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_minimum_number_of_basis_required_is_matched(
+        self, n_basis_funcs, order, mode, kwargs
+    ):
         """
         Verifies that the minimum number of basis functions and order required (i.e., at least 1)
         and order < #basis are enforced.
@@ -1244,9 +1569,9 @@ class TestMSplineBasis(BasisFuncsTesting):
         raise_exception = (order < 1) | (n_basis_funcs < 1) | (order > n_basis_funcs)
         if raise_exception:
             with pytest.raises(
-                    ValueError,
-                    match=r"Spline order must be positive!|"
-                          rf"{self.cls[mode].__name__} `order` parameter cannot be larger than",
+                ValueError,
+                match=r"Spline order must be positive!|"
+                rf"{self.cls[mode].__name__} `order` parameter cannot be larger than",
             ):
                 basis_obj = self.cls[mode](
                     n_basis_funcs=n_basis_funcs, order=order, **kwargs
@@ -1283,11 +1608,11 @@ class TestMSplineBasis(BasisFuncsTesting):
             (1, does_not_raise()),
             (2, does_not_raise()),
             (
-                    10,
-                    pytest.raises(
-                        ValueError,
-                        match=r"[a-z]+|[A-Z]+ `order` parameter cannot be larger",
-                    ),
+                10,
+                pytest.raises(
+                    ValueError,
+                    match=r"[a-z]+|[A-Z]+ `order` parameter cannot be larger",
+                ),
             ),
         ],
     )
@@ -1316,7 +1641,7 @@ class TestMSplineBasis(BasisFuncsTesting):
         ],
     )
     def test_vmin_vmax_eval_on_grid_scaling_effect_on_eval(
-            self, bounds, samples, nan_idx, scaling
+        self, bounds, samples, nan_idx, scaling
     ):
         """
         Check that the MSpline has the expected scaling property.
@@ -1345,9 +1670,12 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         raise_exception = len(set(decay_rates)) != len(decay_rates)
         if raise_exception:
             with pytest.raises(
-                    ValueError, match=r"Two or more rates are repeated! Repeating rates will"
+                ValueError,
+                match=r"Two or more rates are repeated! Repeating rates will",
             ):
-                self.cls["eval"](n_basis_funcs=len(decay_rates), decay_rates=decay_rates)
+                self.cls["eval"](
+                    n_basis_funcs=len(decay_rates), decay_rates=decay_rates
+                )
         else:
             self.cls["eval"](n_basis_funcs=len(decay_rates), decay_rates=decay_rates)
 
@@ -1363,15 +1691,19 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         decay_rates = np.asarray(decay_rates, dtype=float)
         if raise_exception:
             with pytest.raises(
-                    ValueError, match="The number of basis functions must match the"
+                ValueError, match="The number of basis functions must match the"
             ):
                 self.cls["eval"](n_basis_funcs=n_basis_funcs, decay_rates=decay_rates)
         else:
             self.cls["eval"](n_basis_funcs=n_basis_funcs, decay_rates=decay_rates)
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 30})])
-    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, mode, kwargs):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 30})]
+    )
+    def test_minimum_number_of_basis_required_is_matched(
+        self, n_basis_funcs, mode, kwargs
+    ):
         """
         Tests whether the class instance has a minimum number of basis functions.
         """
@@ -1379,8 +1711,8 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
         decay_rates = np.arange(1, 1 + n_basis_funcs) if n_basis_funcs > 0 else []
         if raise_exception:
             with pytest.raises(
-                    ValueError,
-                    match=f"Object class {self.cls[mode].__name__} requires >= 1 basis elements.",
+                ValueError,
+                match=f"Object class {self.cls[mode].__name__} requires >= 1 basis elements.",
             ):
                 self.cls[mode](
                     n_basis_funcs=n_basis_funcs,
@@ -1400,8 +1732,12 @@ class TestBSplineBasis(BasisFuncsTesting):
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     @pytest.mark.parametrize("order", [1, 2, 3, 4, 5])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, order, mode, kwargs):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_minimum_number_of_basis_required_is_matched(
+        self, n_basis_funcs, order, mode, kwargs
+    ):
         """
         Verifies that the minimum number of basis functions and order required (i.e., at least 1) and
         order < #basis are enforced.
@@ -1409,8 +1745,8 @@ class TestBSplineBasis(BasisFuncsTesting):
         raise_exception = order > n_basis_funcs
         if raise_exception:
             with pytest.raises(
-                    ValueError,
-                    match=rf"{self.cls[mode].__name__} `order` parameter cannot be larger than",
+                ValueError,
+                match=rf"{self.cls[mode].__name__} `order` parameter cannot be larger than",
             ):
                 basis_obj = self.cls[mode](
                     n_basis_funcs=n_basis_funcs,
@@ -1452,11 +1788,11 @@ class TestBSplineBasis(BasisFuncsTesting):
             (1, does_not_raise()),
             (2, does_not_raise()),
             (
-                    10,
-                    pytest.raises(
-                        ValueError,
-                        match=r"[a-z]+|[A-Z]+ `order` parameter cannot be larger",
-                    ),
+                10,
+                pytest.raises(
+                    ValueError,
+                    match=r"[a-z]+|[A-Z]+ `order` parameter cannot be larger",
+                ),
             ),
         ],
     )
@@ -1469,7 +1805,9 @@ class TestBSplineBasis(BasisFuncsTesting):
     @pytest.mark.parametrize(
         "sample_range", [(0, 1), (0.1, 0.9), (-0.5, 1), (0, 1.5), (-0.5, 1.5)]
     )
-    def test_samples_range_matches_compute_features_requirements(self, sample_range: tuple):
+    def test_samples_range_matches_compute_features_requirements(
+        self, sample_range: tuple
+    ):
         """
         Verifies that the compute_features() method can handle input range.
         """
@@ -1482,8 +1820,12 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     @pytest.mark.parametrize("order", [2, 3, 4, 5])
-    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
-    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, order, mode, kwargs):
+    @pytest.mark.parametrize(
+        "mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})]
+    )
+    def test_minimum_number_of_basis_required_is_matched(
+        self, n_basis_funcs, order, mode, kwargs
+    ):
         """
         Verifies that the minimum number of basis functions and order required (i.e., at least 1)
         and order < #basis are enforced.
@@ -1491,8 +1833,8 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
         raise_exception = order > n_basis_funcs
         if raise_exception:
             with pytest.raises(
-                    ValueError,
-                    match=rf"{self.cls[mode].__name__} `order` parameter cannot be larger than",
+                ValueError,
+                match=rf"{self.cls[mode].__name__} `order` parameter cannot be larger than",
             ):
                 basis_obj = self.cls[mode](
                     n_basis_funcs=n_basis_funcs,
@@ -1517,7 +1859,7 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
         raise_exception = order == 1
         if raise_exception:
             with pytest.raises(
-                    ValueError, match=r"Order >= 2 required for cyclic B-spline"
+                ValueError, match=r"Order >= 2 required for cyclic B-spline"
             ):
                 basis_obj = self.cls["eval"](n_basis_funcs=n_basis_funcs, order=order)
                 basis_obj.compute_features(np.linspace(0, 1, 10))
@@ -1550,11 +1892,11 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
             (1, does_not_raise()),
             (2, does_not_raise()),
             (
-                    10,
-                    pytest.raises(
-                        ValueError,
-                        match=r"[a-z]+|[A-Z]+ `order` parameter cannot be larger",
-                    ),
+                10,
+                pytest.raises(
+                    ValueError,
+                    match=r"[a-z]+|[A-Z]+ `order` parameter cannot be larger",
+                ),
             ),
         ],
     )
@@ -1570,7 +1912,9 @@ class TestCyclicBSplineBasis(BasisFuncsTesting):
     @pytest.mark.parametrize(
         "sample_range", [(0, 1), (0.1, 0.9), (-0.5, 1), (0, 1.5), (-0.5, 1.5)]
     )
-    def test_samples_range_matches_compute_features_requirements(self, sample_range: tuple):
+    def test_samples_range_matches_compute_features_requirements(
+        self, sample_range: tuple
+    ):
         """
         Verifies that the compute_features() method can handle input ranges.
         """
@@ -1589,46 +1933,57 @@ class CombinedBasis(BasisFuncsTesting):
     cls = None
 
     @staticmethod
-    def instantiate_basis(n_basis, basis_class, class_specific_params, window_size=10, **kwargs):
+    def instantiate_basis(
+        n_basis, basis_class, class_specific_params, window_size=10, **kwargs
+    ):
         """Instantiate and return two basis of the type specified."""
 
         # Set non-optional args
         default_kwargs = {
             "n_basis_funcs": n_basis,
             "window_size": window_size,
-            "decay_rates": np.arange(1, 1 + n_basis)
+            "decay_rates": np.arange(1, 1 + n_basis),
         }
         repeated_keys = set(default_kwargs.keys()).intersection(kwargs.keys())
         if repeated_keys:
-            raise ValueError("Cannot set `n_basis_funcs, window_size, decay_rates` with kwargs")
+            raise ValueError(
+                "Cannot set `n_basis_funcs, window_size, decay_rates` with kwargs"
+            )
 
         # Merge with provided  extra kwargs
         kwargs = {**default_kwargs, **kwargs}
 
-
         if basis_class == AdditiveBasis:
-            kwargs_mspline = trim_kwargs(basis.EvalMSpline, kwargs, class_specific_params)
-            kwargs_raised_cosine = trim_kwargs(basis.ConvRaisedCosineLinear, kwargs, class_specific_params)
+            kwargs_mspline = trim_kwargs(
+                basis.EvalMSpline, kwargs, class_specific_params
+            )
+            kwargs_raised_cosine = trim_kwargs(
+                basis.ConvRaisedCosineLinear, kwargs, class_specific_params
+            )
             b1 = basis.EvalMSpline(**kwargs_mspline)
             b2 = basis.RaisedCosineBasisLinear(**kwargs_raised_cosine)
             basis_obj = b1 + b2
         elif basis_class == MultiplicativeBasis:
-            kwargs_mspline = trim_kwargs(basis.EvalMSpline, kwargs, class_specific_params)
-            kwargs_raised_cosine = trim_kwargs(basis.ConvRaisedCosineLinear, kwargs, class_specific_params)
+            kwargs_mspline = trim_kwargs(
+                basis.EvalMSpline, kwargs, class_specific_params
+            )
+            kwargs_raised_cosine = trim_kwargs(
+                basis.ConvRaisedCosineLinear, kwargs, class_specific_params
+            )
             b1 = basis.EvalMSpline(**kwargs_mspline)
             b2 = basis.RaisedCosineBasisLinear(**kwargs_raised_cosine)
             basis_obj = b1 * b2
         else:
-            basis_obj = basis_class(**trim_kwargs(basis_class, kwargs, class_specific_params))
+            basis_obj = basis_class(
+                **trim_kwargs(basis_class, kwargs, class_specific_params)
+            )
         return basis_obj
 
 
 class TestAdditiveBasis(CombinedBasis):
     cls = AdditiveBasis
 
-    @pytest.mark.parametrize(
-        "samples", [[[0], []], [[], [0]], [[0, 0], [0, 0]]]
-    )
+    @pytest.mark.parametrize("samples", [[[0], []], [[], [0]], [[0, 0], [0, 0]]])
     @pytest.mark.parametrize("base_cls", [basis.EvalBSpline, basis.ConvBSpline])
     def test_non_empty_samples(self, base_cls, samples, class_specific_params):
         kwargs = {"window_size": 2, "n_basis_funcs": 5}
@@ -1666,7 +2021,14 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("window_size", [10])
     def test_compute_features_returns_expected_number_of_basis(
-        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        sample_size,
+        basis_a,
+        basis_b,
+        window_size,
+        class_specific_params,
     ):
         """
         Test whether the evaluation of the `AdditiveBasis` results in a number of basis
@@ -1698,16 +2060,23 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("window_size", [10])
     def test_sample_size_of_compute_features_matches_that_of_input(
-        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        sample_size,
+        basis_a,
+        basis_b,
+        window_size,
+        class_specific_params,
     ):
         """
         Test whether the output sample size from `AdditiveBasis` compute_features function matches input sample size.
         """
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj + basis_b_obj
         eval_basis = basis_obj.compute_features(
@@ -1728,17 +2097,24 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_b", [5, 6])
     @pytest.mark.parametrize("window_size", [10])
     def test_number_of_required_inputs_compute_features(
-        self, n_input, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
+        self,
+        n_input,
+        n_basis_a,
+        n_basis_b,
+        basis_a,
+        basis_b,
+        window_size,
+        class_specific_params,
     ):
         """
         Test whether the number of required inputs for the `compute_features` function matches
         the sum of the number of input samples from the two bases.
         """
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj + basis_b_obj
         required_dim = (
@@ -1765,8 +2141,12 @@ class TestAdditiveBasis(CombinedBasis):
         """
         Test whether the resulting meshgrid size matches the sample size input.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        basis_a_obj = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        )
+        basis_b_obj = self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         basis_obj = basis_a_obj + basis_b_obj
         res = basis_obj.evaluate_on_grid(
             *[sample_size] * basis_obj._n_input_dimensionality
@@ -1785,8 +2165,12 @@ class TestAdditiveBasis(CombinedBasis):
         """
         Test whether the number sample size output by evaluate_on_grid matches the sample size of the input.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        basis_a_obj = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        )
+        basis_b_obj = self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         basis_obj = basis_a_obj + basis_b_obj
         eval_basis = basis_obj.evaluate_on_grid(
             *[sample_size] * basis_obj._n_input_dimensionality
@@ -1805,8 +2189,12 @@ class TestAdditiveBasis(CombinedBasis):
         Test whether the number of inputs provided to `evaluate_on_grid` matches
         the sum of the number of input samples required from each of the basis objects.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        basis_a_obj = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        )
+        basis_b_obj = self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         basis_obj = basis_a_obj + basis_b_obj
         inputs = [20] * n_input
         required_dim = (
@@ -1835,10 +2223,11 @@ class TestAdditiveBasis(CombinedBasis):
             d=np.linspace(0, 1, sample_size),
             time_support=iset,
         )
-        basis_add = (self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10) +
-                     self.instantiate_basis(
+        basis_add = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        ) + self.instantiate_basis(
             n_basis_b, basis_b, class_specific_params, window_size=10
-        ))
+        )
         # compute_features the basis over pynapple Tsd objects
         out = basis_add.compute_features(*([inp] * basis_add._n_input_dimensionality))
         # check type
@@ -1854,13 +2243,20 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("num_input", [0, 1, 2, 3, 4, 5])
     @pytest.mark.parametrize(" window_size", [3])
     def test_call_input_num(
-        self, n_basis_a, n_basis_b, basis_a, basis_b, num_input,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        basis_a,
+        basis_b,
+        num_input,
+        window_size,
+        class_specific_params,
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj + basis_b_obj
         if num_input == basis_obj._n_input_dimensionality:
@@ -1896,10 +2292,10 @@ class TestAdditiveBasis(CombinedBasis):
         class_specific_params,
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj + basis_b_obj
         with expectation:
@@ -1912,13 +2308,20 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_sample_axis(
-        self, n_basis_a, n_basis_b, basis_a, basis_b, time_axis_shape,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        basis_a,
+        basis_b,
+        time_axis_shape,
+        window_size,
+        class_specific_params,
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj + basis_b_obj
         inp = [np.linspace(0, 1, time_axis_shape)] * basis_obj._n_input_dimensionality
@@ -1929,17 +2332,19 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_call_nan(self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params):
+    def test_call_nan(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
+    ):
         if (
             basis_a == basis.OrthExponentialBasis
             or basis_b == basis.OrthExponentialBasis
         ):
             return
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj + basis_b_obj
         inp = [np.linspace(0, 1, 10)] * basis_obj._n_input_dimensionality
@@ -1951,20 +2356,22 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_call_equivalent_in_conv(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
+    def test_call_equivalent_in_conv(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
+    ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=3
+            n_basis_a, basis_a, class_specific_params, window_size=3
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=3
+            n_basis_b, basis_b, class_specific_params, window_size=3
         )
         bas_eva = basis_a_obj + basis_b_obj
 
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=8
+            n_basis_a, basis_a, class_specific_params, window_size=8
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=8
+            n_basis_b, basis_b, class_specific_params, window_size=8
         )
         bas_con = basis_a_obj + basis_b_obj
 
@@ -1977,13 +2384,13 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_pynapple_support(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj + basis_b_obj
         x = np.linspace(0, 1, 10)
@@ -2001,13 +2408,13 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [6, 7])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_basis_number(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj + basis_b_obj
         x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
@@ -2019,13 +2426,13 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_non_empty(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj + basis_b_obj
         with pytest.raises(ValueError, match="All sample provided must"):
@@ -2053,9 +2460,8 @@ class TestAdditiveBasis(CombinedBasis):
         mn,
         mx,
         expectation,
-
         window_size,
-        class_specific_params
+        class_specific_params,
     ):
         if expectation == "check":
             if (
@@ -2068,10 +2474,10 @@ class TestAdditiveBasis(CombinedBasis):
             else:
                 expectation = does_not_raise()
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj + basis_b_obj
         with expectation:
@@ -2081,12 +2487,14 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_fit_kernel(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
+    def test_fit_kernel(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
+    ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=10
+            n_basis_a, basis_a, class_specific_params, window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=10
+            n_basis_b, basis_b, class_specific_params, window_size=10
         )
         bas = basis_a_obj + basis_b_obj
         bas._set_kernel()
@@ -2108,18 +2516,23 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_transform_fails(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
+    def test_transform_fails(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
+    ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=10
+            n_basis_a, basis_a, class_specific_params, window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=10
+            n_basis_b, basis_b, class_specific_params, window_size=10
         )
         bas = basis_a_obj + basis_b_obj
         if "Eval" in basis_a.__name__ and "Eval" in basis_b.__name__:
             context = does_not_raise()
         else:
-            context = pytest.raises(ValueError, match="You must call `_set_kernel` before `_compute_features`")
+            context = pytest.raises(
+                ValueError,
+                match="You must call `_set_kernel` before `_compute_features`",
+            )
         with context:
             x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
             bas._compute_features(*x)
@@ -2127,8 +2540,8 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_output_features(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
-        bas2 = basis.ConvBSpline(11,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
+        bas2 = basis.ConvBSpline(11, window_size=10)
         bas_add = bas1 + bas2
         assert bas_add.n_output_features is None
         bas_add.compute_features(
@@ -2139,8 +2552,8 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
-        bas2 = basis.ConvBSpline(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
+        bas2 = basis.ConvBSpline(10, window_size=10)
         bas_add = bas1 + bas2
         assert bas_add.n_basis_input is None
         bas_add.compute_features(
@@ -2158,8 +2571,8 @@ class TestAdditiveBasis(CombinedBasis):
         ],
     )
     def test_expected_input_number(self, n_input, expectation):
-        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
-        bas2 = basis.ConvBSpline(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
+        bas2 = basis.ConvBSpline(10, window_size=10)
         bas = bas1 + bas2
         x = np.random.randn(20, 2), np.random.randn(20, 3)
         bas.compute_features(*x)
@@ -2174,7 +2587,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         "samples", [[[0], []], [[], [0]], [[0], [0]], [[0, 0], [0, 0]]]
     )
     @pytest.mark.parametrize(" ws", [3])
-    def test_non_empty_samples(self, samples,  ws):
+    def test_non_empty_samples(self, samples, ws):
         basis_obj = basis.EvalMSpline(5) * basis.EvalRaisedCosineLinear(5)
         if any(tuple(len(s) == 0 for s in samples)):
             with pytest.raises(
@@ -2208,7 +2621,14 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("window_size", [10])
     def test_compute_features_returns_expected_number_of_basis(
-        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        sample_size,
+        basis_a,
+        basis_b,
+        window_size,
+        class_specific_params,
     ):
         """
         Test whether the evaluation of the `MultiplicativeBasis` results in a number of basis
@@ -2216,10 +2636,10 @@ class TestMultiplicativeBasis(CombinedBasis):
         """
         # define the two basis
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
 
         basis_obj = basis_a_obj * basis_b_obj
@@ -2241,17 +2661,24 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("window_size", [10])
     def test_sample_size_of_compute_features_matches_that_of_input(
-        self, n_basis_a, n_basis_b, sample_size, basis_a, basis_b,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        sample_size,
+        basis_a,
+        basis_b,
+        window_size,
+        class_specific_params,
     ):
         """
         Test whether the output sample size from the `MultiplicativeBasis` fit_transform function
         matches the input sample size.
         """
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         eval_basis = basis_obj.compute_features(
@@ -2271,17 +2698,24 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_b", [5, 6])
     @pytest.mark.parametrize("window_size", [10])
     def test_number_of_required_inputs_compute_features(
-        self, n_input, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
+        self,
+        n_input,
+        n_basis_a,
+        n_basis_b,
+        basis_a,
+        basis_b,
+        window_size,
+        class_specific_params,
     ):
         """
         Test whether the number of required inputs for the `compute_features` function matches
         the sum of the number of input samples from the two bases.
         """
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         required_dim = (
@@ -2308,8 +2742,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         """
         Test whether the resulting meshgrid size matches the sample size input.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        basis_a_obj = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        )
+        basis_b_obj = self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         basis_obj = basis_a_obj * basis_b_obj
         res = basis_obj.evaluate_on_grid(
             *[sample_size] * basis_obj._n_input_dimensionality
@@ -2328,8 +2766,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         """
         Test whether the number sample size output by evaluate_on_grid matches the sample size of the input.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        basis_a_obj = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        )
+        basis_b_obj = self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         basis_obj = basis_a_obj * basis_b_obj
         eval_basis = basis_obj.evaluate_on_grid(
             *[sample_size] * basis_obj._n_input_dimensionality
@@ -2348,8 +2790,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         Test whether the number of inputs provided to `evaluate_on_grid` matches
         the sum of the number of input samples required from each of the basis objects.
         """
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        basis_a_obj = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        )
+        basis_b_obj = self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         basis_obj = basis_a_obj * basis_b_obj
         inputs = [20] * n_input
         required_dim = (
@@ -2371,12 +2817,23 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("sample_size_a", [11, 12])
     @pytest.mark.parametrize("sample_size_b", [11, 12])
     def test_inconsistent_sample_sizes(
-        self, basis_a, basis_b, n_basis_a, n_basis_b, sample_size_a, sample_size_b, class_specific_params
+        self,
+        basis_a,
+        basis_b,
+        n_basis_a,
+        n_basis_b,
+        sample_size_a,
+        sample_size_b,
+        class_specific_params,
     ):
         """Test that the inputs of inconsistent sample sizes result in an exception when compute_features is called"""
         raise_exception = sample_size_a != sample_size_b
-        basis_a_obj = self.instantiate_basis(n_basis_a, basis_a, class_specific_params, window_size=10)
-        basis_b_obj = self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        basis_a_obj = self.instantiate_basis(
+            n_basis_a, basis_a, class_specific_params, window_size=10
+        )
+        basis_b_obj = self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         basis_obj = basis_a_obj * basis_b_obj
         if raise_exception:
             with pytest.raises(
@@ -2407,7 +2864,9 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         basis_prod = self.instantiate_basis(
             n_basis_a, basis_a, class_specific_params, window_size=10
-        ) * self.instantiate_basis(n_basis_b, basis_b, class_specific_params, window_size=10)
+        ) * self.instantiate_basis(
+            n_basis_b, basis_b, class_specific_params, window_size=10
+        )
         out = basis_prod.compute_features(*([inp] * basis_prod._n_input_dimensionality))
         assert isinstance(out, nap.TsdFrame)
         assert np.all(out.time_support.values == inp.time_support.values)
@@ -2420,13 +2879,20 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("num_input", [0, 1, 2, 3, 4, 5])
     @pytest.mark.parametrize(" window_size", [3])
     def test_call_input_num(
-        self, n_basis_a, n_basis_b, basis_a, basis_b, num_input,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        basis_a,
+        basis_b,
+        num_input,
+        window_size,
+        class_specific_params,
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         if num_input == basis_obj._n_input_dimensionality:
@@ -2457,16 +2923,15 @@ class TestMultiplicativeBasis(CombinedBasis):
         basis_a,
         basis_b,
         inp,
-
         window_size,
         expectation,
-        class_specific_params
+        class_specific_params,
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         with expectation:
@@ -2479,13 +2944,20 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_sample_axis(
-        self, n_basis_a, n_basis_b, basis_a, basis_b, time_axis_shape,  window_size, class_specific_params
+        self,
+        n_basis_a,
+        n_basis_b,
+        basis_a,
+        basis_b,
+        time_axis_shape,
+        window_size,
+        class_specific_params,
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         inp = [np.linspace(0, 1, time_axis_shape)] * basis_obj._n_input_dimensionality
@@ -2496,17 +2968,19 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_call_nan(self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params):
+    def test_call_nan(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
+    ):
         if (
             basis_a == basis.OrthExponentialBasis
             or basis_b == basis.OrthExponentialBasis
         ):
             return
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         basis_obj = basis_a_obj * basis_b_obj
         inp = [np.linspace(0, 1, 10)] * basis_obj._n_input_dimensionality
@@ -2518,20 +2992,22 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_call_equivalent_in_conv(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
+    def test_call_equivalent_in_conv(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
+    ):
         basis_a_obj = self.instantiate_basis(
             n_basis_a, basis_a, class_specific_params, window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=10
+            n_basis_b, basis_b, class_specific_params, window_size=10
         )
         bas_eva = basis_a_obj * basis_b_obj
 
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=8
+            n_basis_a, basis_a, class_specific_params, window_size=8
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=8
+            n_basis_b, basis_b, class_specific_params, window_size=8
         )
         bas_con = basis_a_obj * basis_b_obj
 
@@ -2544,13 +3020,13 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_pynapple_support(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         x = np.linspace(0, 1, 10)
@@ -2568,13 +3044,13 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [6, 7])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_basis_number(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
@@ -2586,13 +3062,13 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
     def test_call_non_empty(
-        self, n_basis_a, n_basis_b, basis_a, basis_b,  window_size, class_specific_params
+        self, n_basis_a, n_basis_b, basis_a, basis_b, window_size, class_specific_params
     ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         with pytest.raises(ValueError, match="All sample provided must"):
@@ -2606,7 +3082,7 @@ class TestMultiplicativeBasis(CombinedBasis):
             (0.1, 2, does_not_raise()),
         ],
     )
-    @pytest.mark.parametrize(" window_size", [ 3])
+    @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
@@ -2620,9 +3096,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         mn,
         mx,
         expectation,
-
         window_size,
-        class_specific_params
+        class_specific_params,
     ):
         if expectation == "check":
             if (
@@ -2635,10 +3110,10 @@ class TestMultiplicativeBasis(CombinedBasis):
             else:
                 expectation = does_not_raise()
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=window_size
+            n_basis_a, basis_a, class_specific_params, window_size=window_size
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=window_size
+            n_basis_b, basis_b, class_specific_params, window_size=window_size
         )
         bas = basis_a_obj * basis_b_obj
         with expectation:
@@ -2648,12 +3123,14 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_fit_kernel(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
+    def test_fit_kernel(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
+    ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=10
+            n_basis_a, basis_a, class_specific_params, window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=10
+            n_basis_b, basis_b, class_specific_params, window_size=10
         )
         bas = basis_a_obj * basis_b_obj
         bas._set_kernel()
@@ -2675,18 +3152,23 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
     @pytest.mark.parametrize("n_basis_a", [5])
     @pytest.mark.parametrize("n_basis_b", [5])
-    def test_transform_fails(self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params):
+    def test_transform_fails(
+        self, n_basis_a, n_basis_b, basis_a, basis_b, class_specific_params
+    ):
         basis_a_obj = self.instantiate_basis(
-            n_basis_a, basis_a, class_specific_params,  window_size=10
+            n_basis_a, basis_a, class_specific_params, window_size=10
         )
         basis_b_obj = self.instantiate_basis(
-            n_basis_b, basis_b, class_specific_params,  window_size=10
+            n_basis_b, basis_b, class_specific_params, window_size=10
         )
         bas = basis_a_obj * basis_b_obj
-        if "Eval" in  basis_a.__name__ and "Eval" in  basis_b.__name__:
+        if "Eval" in basis_a.__name__ and "Eval" in basis_b.__name__:
             context = does_not_raise()
         else:
-            context = pytest.raises(ValueError, match="You must call `_set_kernel` before `_compute_features`")
+            context = pytest.raises(
+                ValueError,
+                match="You must call `_set_kernel` before `_compute_features`",
+            )
         with context:
             x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
             bas._compute_features(*x)
@@ -2694,8 +3176,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_output_features(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
-        bas2 = basis.ConvBSpline(11,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
+        bas2 = basis.ConvBSpline(11, window_size=10)
         bas_add = bas1 * bas2
         assert bas_add.n_output_features is None
         bas_add.compute_features(
@@ -2706,8 +3188,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
-        bas2 = basis.ConvBSpline(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
+        bas2 = basis.ConvBSpline(10, window_size=10)
         bas_add = bas1 * bas2
         assert bas_add.n_basis_input is None
         bas_add.compute_features(
@@ -2725,8 +3207,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         ],
     )
     def test_expected_input_number(self, n_input, expectation):
-        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
-        bas2 = basis.ConvBSpline(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
+        bas2 = basis.ConvBSpline(10, window_size=10)
         bas = bas1 * bas2
         x = np.random.randn(20, 2), np.random.randn(20, 3)
         bas.compute_features(*x)
@@ -2736,8 +3218,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_n_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10,  window_size=10)
-        bas2 = basis.ConvBSpline(10,  window_size=10)
+        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
+        bas2 = basis.ConvBSpline(10, window_size=10)
         bas_prod = bas1 * bas2
         bas_prod.compute_features(
             np.ones((20, n_basis_input1)), np.ones((20, n_basis_input2))
@@ -2758,7 +3240,9 @@ def test_power_of_basis(exponent, basis_class, class_specific_params):
     else:
         raise_exception_value = False
 
-    basis_obj = CombinedBasis.instantiate_basis(5, basis_class, class_specific_params, window_size=10)
+    basis_obj = CombinedBasis.instantiate_basis(
+        5, basis_class, class_specific_params, window_size=10
+    )
 
     if raise_exception_type:
         with pytest.raises(TypeError, match=r"Exponent should be an integer\!"):
@@ -2792,7 +3276,9 @@ def test_power_of_basis(exponent, basis_class, class_specific_params):
 )
 def test_basis_to_transformer(basis_cls, class_specific_params):
     n_basis_funcs = 5
-    bas = CombinedBasis().instantiate_basis(n_basis_funcs, basis_cls, class_specific_params, window_size=10)
+    bas = CombinedBasis().instantiate_basis(
+        n_basis_funcs, basis_cls, class_specific_params, window_size=10
+    )
 
     trans_bas = bas.to_transformer()
 
@@ -2807,9 +3293,13 @@ def test_basis_to_transformer(basis_cls, class_specific_params):
     "basis_cls",
     list_all_basis_classes(),
 )
-def test_transformer_has_the_same_public_attributes_as_basis(basis_cls, class_specific_params):
+def test_transformer_has_the_same_public_attributes_as_basis(
+    basis_cls, class_specific_params
+):
     n_basis_funcs = 5
-    bas = CombinedBasis().instantiate_basis(n_basis_funcs, basis_cls, class_specific_params, window_size=10)
+    bas = CombinedBasis().instantiate_basis(
+        n_basis_funcs, basis_cls, class_specific_params, window_size=10
+    )
 
     public_attrs_basis = {attr for attr in dir(bas) if not attr.startswith("_")}
     public_attrs_transformerbasis = {
@@ -2829,9 +3319,13 @@ def test_transformer_has_the_same_public_attributes_as_basis(basis_cls, class_sp
     "basis_cls",
     list_all_basis_classes(),
 )
-def test_to_transformer_and_constructor_are_equivalent(basis_cls, class_specific_params):
+def test_to_transformer_and_constructor_are_equivalent(
+    basis_cls, class_specific_params
+):
     n_basis_funcs = 5
-    bas = CombinedBasis().instantiate_basis(n_basis_funcs, basis_cls, class_specific_params, window_size=10)
+    bas = CombinedBasis().instantiate_basis(
+        n_basis_funcs, basis_cls, class_specific_params, window_size=10
+    )
 
     trans_bas_a = bas.to_transformer()
     trans_bas_b = TransformerBasis(bas)
@@ -2843,7 +3337,10 @@ def test_to_transformer_and_constructor_are_equivalent(basis_cls, class_specific
         == ["_basis"]
     )
     # and those bases are the same
-    assert np.all(trans_bas_a._basis.__dict__.pop("_decay_rates", 1) == trans_bas_b._basis.__dict__.pop("_decay_rates", 1))
+    assert np.all(
+        trans_bas_a._basis.__dict__.pop("_decay_rates", 1)
+        == trans_bas_b._basis.__dict__.pop("_decay_rates", 1)
+    )
     assert trans_bas_a._basis.__dict__ == trans_bas_b._basis.__dict__
 
 
@@ -2852,7 +3349,9 @@ def test_to_transformer_and_constructor_are_equivalent(basis_cls, class_specific
     list_all_basis_classes(),
 )
 def test_basis_to_transformer_makes_a_copy(basis_cls, class_specific_params):
-    bas_a = CombinedBasis().instantiate_basis(5, basis_cls, class_specific_params, window_size=10)
+    bas_a = CombinedBasis().instantiate_basis(
+        5, basis_cls, class_specific_params, window_size=10
+    )
     trans_bas_a = bas_a.to_transformer()
 
     # changing an attribute in bas should not change trans_bas
@@ -2860,7 +3359,9 @@ def test_basis_to_transformer_makes_a_copy(basis_cls, class_specific_params):
     assert trans_bas_a.n_basis_funcs == 5
 
     # changing an attribute in the transformer basis should not change the original
-    bas_b = CombinedBasis().instantiate_basis(5, basis_cls, class_specific_params, window_size=10)
+    bas_b = CombinedBasis().instantiate_basis(
+        5, basis_cls, class_specific_params, window_size=10
+    )
     trans_bas_b = bas_b.to_transformer()
     trans_bas_b.n_basis_funcs = 100
     assert bas_b.n_basis_funcs == 5
@@ -2873,7 +3374,9 @@ def test_basis_to_transformer_makes_a_copy(basis_cls, class_specific_params):
 @pytest.mark.parametrize("n_basis_funcs", [5, 10, 20])
 def test_transformerbasis_getattr(basis_cls, n_basis_funcs, class_specific_params):
     trans_basis = TransformerBasis(
-        CombinedBasis().instantiate_basis(n_basis_funcs, basis_cls, class_specific_params, window_size=10)
+        CombinedBasis().instantiate_basis(
+            n_basis_funcs, basis_cls, class_specific_params, window_size=10
+        )
     )
     assert trans_basis.n_basis_funcs == n_basis_funcs
 
@@ -2884,9 +3387,13 @@ def test_transformerbasis_getattr(basis_cls, n_basis_funcs, class_specific_param
 )
 @pytest.mark.parametrize("n_basis_funcs_init", [5])
 @pytest.mark.parametrize("n_basis_funcs_new", [6, 10, 20])
-def test_transformerbasis_set_params(basis_cls, n_basis_funcs_init, n_basis_funcs_new, class_specific_params):
+def test_transformerbasis_set_params(
+    basis_cls, n_basis_funcs_init, n_basis_funcs_new, class_specific_params
+):
     trans_basis = TransformerBasis(
-        CombinedBasis().instantiate_basis(n_basis_funcs_init, basis_cls, class_specific_params, window_size=10)
+        CombinedBasis().instantiate_basis(
+            n_basis_funcs_init, basis_cls, class_specific_params, window_size=10
+        )
     )
     trans_basis.set_params(n_basis_funcs=n_basis_funcs_new)
 
@@ -2901,9 +3408,13 @@ def test_transformerbasis_set_params(basis_cls, n_basis_funcs_init, n_basis_func
 def test_transformerbasis_setattr_basis(basis_cls, class_specific_params):
     # setting the _basis attribute should change it
     trans_bas = TransformerBasis(
-        CombinedBasis().instantiate_basis(10, basis_cls, class_specific_params, window_size=10)
+        CombinedBasis().instantiate_basis(
+            10, basis_cls, class_specific_params, window_size=10
+        )
     )
-    trans_bas._basis = CombinedBasis().instantiate_basis(20, basis_cls, class_specific_params, window_size=10)
+    trans_bas._basis = CombinedBasis().instantiate_basis(
+        20, basis_cls, class_specific_params, window_size=10
+    )
 
     assert trans_bas.n_basis_funcs == 20
     assert trans_bas._basis.n_basis_funcs == 20
@@ -2917,7 +3428,11 @@ def test_transformerbasis_setattr_basis(basis_cls, class_specific_params):
 def test_transformerbasis_setattr_basis_attribute(basis_cls, class_specific_params):
     # setting an attribute that is an attribute of the underlying _basis
     # should propagate setting it on _basis itself
-    trans_bas = TransformerBasis(CombinedBasis().instantiate_basis(10, basis_cls, class_specific_params, window_size=10))
+    trans_bas = TransformerBasis(
+        CombinedBasis().instantiate_basis(
+            10, basis_cls, class_specific_params, window_size=10
+        )
+    )
     trans_bas.n_basis_funcs = 20
 
     assert trans_bas.n_basis_funcs == 20
@@ -2932,7 +3447,9 @@ def test_transformerbasis_setattr_basis_attribute(basis_cls, class_specific_para
 def test_transformerbasis_copy_basis_on_contsruct(basis_cls, class_specific_params):
     # modifying the transformerbasis's attributes shouldn't
     # touch the original basis that was used to create it
-    orig_bas = CombinedBasis().instantiate_basis(10, basis_cls, class_specific_params, window_size=10)
+    orig_bas = CombinedBasis().instantiate_basis(
+        10, basis_cls, class_specific_params, window_size=10
+    )
     trans_bas = TransformerBasis(orig_bas)
     trans_bas.n_basis_funcs = 20
 
@@ -2949,7 +3466,11 @@ def test_transformerbasis_copy_basis_on_contsruct(basis_cls, class_specific_para
 def test_transformerbasis_setattr_illegal_attribute(basis_cls, class_specific_params):
     # changing an attribute that is not _basis or an attribute of _basis
     # is not allowed
-    trans_bas = TransformerBasis(CombinedBasis().instantiate_basis(10, basis_cls, class_specific_params, window_size=10))
+    trans_bas = TransformerBasis(
+        CombinedBasis().instantiate_basis(
+            10, basis_cls, class_specific_params, window_size=10
+        )
+    )
 
     with pytest.raises(
         ValueError,
@@ -2965,8 +3486,12 @@ def test_transformerbasis_setattr_illegal_attribute(basis_cls, class_specific_pa
 def test_transformerbasis_addition(basis_cls, class_specific_params):
     n_basis_funcs_a = 5
     n_basis_funcs_b = n_basis_funcs_a * 2
-    bas_a = CombinedBasis().instantiate_basis(n_basis_funcs_a, basis_cls, class_specific_params, window_size=10)
-    bas_b = CombinedBasis().instantiate_basis(n_basis_funcs_b, basis_cls, class_specific_params, window_size=10)
+    bas_a = CombinedBasis().instantiate_basis(
+        n_basis_funcs_a, basis_cls, class_specific_params, window_size=10
+    )
+    bas_b = CombinedBasis().instantiate_basis(
+        n_basis_funcs_b, basis_cls, class_specific_params, window_size=10
+    )
     trans_bas_a = TransformerBasis(bas_a)
     trans_bas_b = TransformerBasis(bas_b)
     trans_bas_sum = trans_bas_a + trans_bas_b
@@ -2991,8 +3516,16 @@ def test_transformerbasis_addition(basis_cls, class_specific_params):
 def test_transformerbasis_multiplication(basis_cls, class_specific_params):
     n_basis_funcs_a = 5
     n_basis_funcs_b = n_basis_funcs_a * 2
-    trans_bas_a = TransformerBasis(CombinedBasis().instantiate_basis(n_basis_funcs_a, basis_cls, class_specific_params, window_size=10))
-    trans_bas_b = TransformerBasis(CombinedBasis().instantiate_basis(n_basis_funcs_b, basis_cls, class_specific_params, window_size=10))
+    trans_bas_a = TransformerBasis(
+        CombinedBasis().instantiate_basis(
+            n_basis_funcs_a, basis_cls, class_specific_params, window_size=10
+        )
+    )
+    trans_bas_b = TransformerBasis(
+        CombinedBasis().instantiate_basis(
+            n_basis_funcs_b, basis_cls, class_specific_params, window_size=10
+        )
+    )
     trans_bas_prod = trans_bas_a * trans_bas_b
     assert isinstance(trans_bas_prod, TransformerBasis)
     assert isinstance(trans_bas_prod._basis, MultiplicativeBasis)
@@ -3024,7 +3557,11 @@ def test_transformerbasis_multiplication(basis_cls, class_specific_params):
 def test_transformerbasis_exponentiation(
     basis_cls, exponent: int, error_type, error_message, class_specific_params
 ):
-    trans_bas = TransformerBasis(CombinedBasis().instantiate_basis(5, basis_cls, class_specific_params, window_size=10))
+    trans_bas = TransformerBasis(
+        CombinedBasis().instantiate_basis(
+            5, basis_cls, class_specific_params, window_size=10
+        )
+    )
 
     if not isinstance(exponent, int):
         with pytest.raises(error_type, match=error_message):
@@ -3038,7 +3575,11 @@ def test_transformerbasis_exponentiation(
     list_all_basis_classes(),
 )
 def test_transformerbasis_dir(basis_cls, class_specific_params):
-    trans_bas = TransformerBasis(CombinedBasis().instantiate_basis(5, basis_cls, class_specific_params, window_size=10))
+    trans_bas = TransformerBasis(
+        CombinedBasis().instantiate_basis(
+            5, basis_cls, class_specific_params, window_size=10
+        )
+    )
     for attr_name in (
         "fit",
         "transform",
@@ -3057,7 +3598,9 @@ def test_transformerbasis_dir(basis_cls, class_specific_params):
     list_all_basis_classes("Conv"),
 )
 def test_transformerbasis_sk_clone_kernel_noned(basis_cls, class_specific_params):
-    orig_bas = CombinedBasis().instantiate_basis(10, basis_cls, class_specific_params, window_size=20)
+    orig_bas = CombinedBasis().instantiate_basis(
+        10, basis_cls, class_specific_params, window_size=20
+    )
     trans_bas = TransformerBasis(orig_bas)
 
     # kernel should be saved in the object after fit
@@ -3078,9 +3621,15 @@ def test_transformerbasis_sk_clone_kernel_noned(basis_cls, class_specific_params
     list_all_basis_classes(),
 )
 @pytest.mark.parametrize("n_basis_funcs", [5])
-def test_transformerbasis_pickle(tmpdir, basis_cls, n_basis_funcs, class_specific_params):
+def test_transformerbasis_pickle(
+    tmpdir, basis_cls, n_basis_funcs, class_specific_params
+):
     # the test that tries cross-validation with n_jobs = 2 already should test this
-    trans_bas = TransformerBasis(CombinedBasis().instantiate_basis(n_basis_funcs, basis_cls, class_specific_params, window_size=10))
+    trans_bas = TransformerBasis(
+        CombinedBasis().instantiate_basis(
+            n_basis_funcs, basis_cls, class_specific_params, window_size=10
+        )
+    )
     filepath = tmpdir / "transformerbasis.pickle"
     with open(filepath, "wb") as f:
         pickle.dump(trans_bas, f)
@@ -3123,10 +3672,18 @@ def test_transformerbasis_pickle(tmpdir, basis_cls, n_basis_funcs, class_specifi
     list_all_basis_classes("Conv"),
 )
 def test_multi_epoch_pynapple_basis(
-    basis_cls, tsd, window_size, shift, predictor_causality, nan_index, class_specific_params
+    basis_cls,
+    tsd,
+    window_size,
+    shift,
+    predictor_causality,
+    nan_index,
+    class_specific_params,
 ):
     """Test nan location in multi-epoch pynapple tsd."""
-    kwargs = dict(conv_kwargs=dict(shift=shift, predictor_causality=predictor_causality))
+    kwargs = dict(
+        conv_kwargs=dict(shift=shift, predictor_causality=predictor_causality)
+    )
 
     # require a ws of at least nbasis funcs.
     if "OrthExp" in basis_cls.__name__:
@@ -3134,7 +3691,9 @@ def test_multi_epoch_pynapple_basis(
     # splines requires at least 1 basis more than the order of the spline.
     else:
         nbasis = 5
-    bas = CombinedBasis().instantiate_basis(nbasis, basis_cls, class_specific_params, window_size=window_size, **kwargs)
+    bas = CombinedBasis().instantiate_basis(
+        nbasis, basis_cls, class_specific_params, window_size=window_size, **kwargs
+    )
 
     n_input = bas._n_input_dimensionality
 
@@ -3180,10 +3739,18 @@ def test_multi_epoch_pynapple_basis(
     list_all_basis_classes("Conv"),
 )
 def test_multi_epoch_pynapple_basis_transformer(
-    basis_cls, tsd, window_size, shift, predictor_causality, nan_index, class_specific_params
+    basis_cls,
+    tsd,
+    window_size,
+    shift,
+    predictor_causality,
+    nan_index,
+    class_specific_params,
 ):
     """Test nan location in multi-epoch pynapple tsd."""
-    kwargs = dict(conv_kwargs=dict(shift=shift, predictor_causality=predictor_causality))
+    kwargs = dict(
+        conv_kwargs=dict(shift=shift, predictor_causality=predictor_causality)
+    )
     # require a ws of at least nbasis funcs.
     if "OrthExp" in basis_cls.__name__:
         nbasis = 2
@@ -3191,7 +3758,9 @@ def test_multi_epoch_pynapple_basis_transformer(
     else:
         nbasis = 5
 
-    bas = CombinedBasis().instantiate_basis(nbasis, basis_cls, class_specific_params, window_size=window_size, **kwargs)
+    bas = CombinedBasis().instantiate_basis(
+        nbasis, basis_cls, class_specific_params, window_size=window_size, **kwargs
+    )
 
     n_input = bas._n_input_dimensionality
 
@@ -3215,11 +3784,7 @@ def test_multi_epoch_pynapple_basis_transformer(
 
 @pytest.mark.parametrize(
     "bas1, bas2, bas3",
-    list(
-        itertools.product(
-            *[list_all_basis_classes()] * 3
-        )
-    ),
+    list(itertools.product(*[list_all_basis_classes()] * 3)),
 )
 @pytest.mark.parametrize(
     "operator1, operator2, compute_slice",
@@ -3292,7 +3857,7 @@ def test_multi_epoch_pynapple_basis_transformer(
     ],
 )
 def test__get_splitter(
-   bas1, bas2, bas3, operator1, operator2, compute_slice, class_specific_params
+    bas1, bas2, bas3, operator1, operator2, compute_slice, class_specific_params
 ):
     # skip nested
     if any(
@@ -3305,9 +3870,15 @@ def test__get_splitter(
     n_input_basis = [1, 2, 3]
 
     combine_basis = CombinedBasis()
-    bas1_instance = combine_basis.instantiate_basis(n_basis[0], bas1, class_specific_params, window_size=10, label="1")
-    bas2_instance = combine_basis.instantiate_basis(n_basis[1], bas2, class_specific_params, window_size=10, label="2")
-    bas3_instance = combine_basis.instantiate_basis(n_basis[2], bas3, class_specific_params, window_size=10, label="3")
+    bas1_instance = combine_basis.instantiate_basis(
+        n_basis[0], bas1, class_specific_params, window_size=10, label="1"
+    )
+    bas2_instance = combine_basis.instantiate_basis(
+        n_basis[1], bas2, class_specific_params, window_size=10, label="2"
+    )
+    bas3_instance = combine_basis.instantiate_basis(
+        n_basis[2], bas3, class_specific_params, window_size=10, label="3"
+    )
 
     func1 = getattr(bas1_instance, operator1)
     func2 = getattr(bas2_instance, operator2)
@@ -3322,11 +3893,7 @@ def test__get_splitter(
 
 @pytest.mark.parametrize(
     "bas1, bas2",
-    list(
-        itertools.product(
-            *[list_all_basis_classes()] * 2
-        )
-    ),
+    list(itertools.product(*[list_all_basis_classes()] * 2)),
 )
 @pytest.mark.parametrize(
     "operator, n_input_basis_1, n_input_basis_2, compute_slice",
@@ -3441,7 +4008,13 @@ def test__get_splitter(
     ],
 )
 def test__get_splitter_split_by_input(
-    bas1, bas2, operator, n_input_basis_1, n_input_basis_2, compute_slice, class_specific_params
+    bas1,
+    bas2,
+    operator,
+    n_input_basis_1,
+    n_input_basis_2,
+    compute_slice,
+    class_specific_params,
 ):
     # skip nested
     if any(
@@ -3452,8 +4025,12 @@ def test__get_splitter_split_by_input(
     # define the basis
     n_basis = [5, 6]
     combine_basis = CombinedBasis()
-    bas1_instance = combine_basis.instantiate_basis(n_basis[0], bas1, class_specific_params, window_size=10, label="1")
-    bas2_instance = combine_basis.instantiate_basis(n_basis[1], bas2, class_specific_params, window_size=10, label="2")
+    bas1_instance = combine_basis.instantiate_basis(
+        n_basis[0], bas1, class_specific_params, window_size=10, label="1"
+    )
+    bas2_instance = combine_basis.instantiate_basis(
+        n_basis[1], bas2, class_specific_params, window_size=10, label="2"
+    )
 
     func1 = getattr(bas1_instance, operator)
     bas12 = func1(bas2_instance)
@@ -3470,11 +4047,7 @@ def test__get_splitter_split_by_input(
 
 @pytest.mark.parametrize(
     "bas1, bas2, bas3",
-    list(
-        itertools.product(
-            *[list_all_basis_classes()] * 3
-        )
-    ),
+    list(itertools.product(*[list_all_basis_classes()] * 3)),
 )
 def test_duplicate_keys(bas1, bas2, bas3, class_specific_params):
     # skip nested
@@ -3485,9 +4058,15 @@ def test_duplicate_keys(bas1, bas2, bas3, class_specific_params):
         return
 
     combine_basis = CombinedBasis()
-    bas1_instance = combine_basis.instantiate_basis(5, bas1, class_specific_params, window_size=10, label="label")
-    bas2_instance = combine_basis.instantiate_basis(5, bas2, class_specific_params, window_size=10, label="label")
-    bas3_instance = combine_basis.instantiate_basis(5, bas3, class_specific_params, window_size=10, label="label")
+    bas1_instance = combine_basis.instantiate_basis(
+        5, bas1, class_specific_params, window_size=10, label="label"
+    )
+    bas2_instance = combine_basis.instantiate_basis(
+        5, bas2, class_specific_params, window_size=10, label="label"
+    )
+    bas3_instance = combine_basis.instantiate_basis(
+        5, bas3, class_specific_params, window_size=10, label="label"
+    )
     bas_obj = bas1_instance + bas2_instance + bas3_instance
 
     inps = [np.zeros((1,)) for n in range(3)]
@@ -3498,11 +4077,7 @@ def test_duplicate_keys(bas1, bas2, bas3, class_specific_params):
 
 @pytest.mark.parametrize(
     "bas1, bas2",
-    list(
-        itertools.product(
-            *[list_all_basis_classes()] * 2
-        )
-    ),
+    list(itertools.product(*[list_all_basis_classes()] * 2)),
 )
 @pytest.mark.parametrize(
     "x, axis, expectation, exp_shapes",  # num output is 5*2 + 6*3 = 28
@@ -3520,7 +4095,9 @@ def test_duplicate_keys(bas1, bas2, bas3, class_specific_params):
         ),
     ],
 )
-def test_split_feature_axis(bas1, bas2, x, axis, expectation, exp_shapes, class_specific_params):
+def test_split_feature_axis(
+    bas1, bas2, x, axis, expectation, exp_shapes, class_specific_params
+):
     # skip nested
     if any(
         bas in (AdditiveBasis, MultiplicativeBasis, TransformerBasis)
@@ -3530,8 +4107,12 @@ def test_split_feature_axis(bas1, bas2, x, axis, expectation, exp_shapes, class_
     # define the basis
     n_basis = [5, 6]
     combine_basis = CombinedBasis()
-    bas1_instance = combine_basis.instantiate_basis(n_basis[0], bas1, class_specific_params, window_size=10, label="1")
-    bas2_instance = combine_basis.instantiate_basis(n_basis[1], bas2, class_specific_params, window_size=10, label="2")
+    bas1_instance = combine_basis.instantiate_basis(
+        n_basis[0], bas1, class_specific_params, window_size=10, label="1"
+    )
+    bas2_instance = combine_basis.instantiate_basis(
+        n_basis[1], bas2, class_specific_params, window_size=10, label="2"
+    )
 
     bas = bas1_instance + bas2_instance
     bas._set_num_output_features(np.zeros((1, 2)), np.zeros((1, 3)))

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -979,14 +979,14 @@ class TestSharedMethods:
             (
                 "conv",
                 -1,
-                pytest.raises(ValueError, match="`window_size` must be a positive "),
+                pytest.raises(ValueError, match="You must provide a window_siz"),
             ),
             (
                 "conv",
                 None,
                 pytest.raises(
                     ValueError,
-                    match="If the basis is in `conv` mode, you must provide a ",
+                    match="You must provide a window_siz",
                 ),
             ),
             (
@@ -1229,7 +1229,7 @@ class TestSharedMethods:
             bas = cls["conv"](
                 n_basis_funcs=10, window_size=10, **extra_decay_rates(cls["conv"], 10)
             )
-            with pytest.raises(ValueError, match="If the basis is in `conv` mode"):
+            with pytest.raises(ValueError, match="You must provide a window_siz"):
                 bas.set_params(window_size=None)
 
         if mode == "eval":

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -132,7 +132,7 @@ def test_all_basis_are_tested() -> None:
         ("evaluate_on_grid", "The number of points in the uniformly spaced grid"),
         (
             "compute_features",
-            "Compute the basis functions and transform input data into model features",
+            "Apply the basis transformation to the input data",
         ),
         (
             "split_by_feature",
@@ -167,7 +167,7 @@ def test_example_docstrings_add(
             continue
         if basis_name == basis_instance.__class__.__name__:
             continue
-        assert basis_name not in doc_components[1]
+        assert f" {basis_name}" not in doc_components[1]
 
 
 def test_add_docstring():
@@ -191,19 +191,19 @@ def test_add_docstring():
 @pytest.mark.parametrize(
     "basis_instance, super_class",
     [
-        (basis.EvalBSpline(10), BSplineBasis),
-        (basis.ConvBSpline(10, window_size=11), BSplineBasis),
-        (basis.EvalCyclicBSpline(10), CyclicBSplineBasis),
-        (basis.ConvCyclicBSpline(10, window_size=11), CyclicBSplineBasis),
-        (basis.EvalMSpline(10), MSplineBasis),
-        (basis.ConvMSpline(10, window_size=11), MSplineBasis),
-        (basis.EvalRaisedCosineLinear(10), RaisedCosineBasisLinear),
-        (basis.ConvRaisedCosineLinear(10, window_size=11), RaisedCosineBasisLinear),
-        (basis.EvalRaisedCosineLog(10), RaisedCosineBasisLog),
-        (basis.ConvRaisedCosineLog(10, window_size=11), RaisedCosineBasisLog),
-        (basis.EvalOrthExponential(10, np.arange(1, 11)), OrthExponentialBasis),
+        (basis.BSplineEval(10), BSplineBasis),
+        (basis.BSplineConv(10, window_size=11), BSplineBasis),
+        (basis.CyclicBSplineEval(10), CyclicBSplineBasis),
+        (basis.CyclicBSplineConv(10, window_size=11), CyclicBSplineBasis),
+        (basis.MSplineEval(10), MSplineBasis),
+        (basis.MSplineConv(10, window_size=11), MSplineBasis),
+        (basis.RaisedCosineLinearEval(10), RaisedCosineBasisLinear),
+        (basis.RaisedCosineLinearConv(10, window_size=11), RaisedCosineBasisLinear),
+        (basis.RaisedCosineLogEval(10), RaisedCosineBasisLog),
+        (basis.RaisedCosineLogConv(10, window_size=11), RaisedCosineBasisLog),
+        (basis.OrthExponentialEval(10, np.arange(1, 11)), OrthExponentialBasis),
         (
-            basis.ConvOrthExponential(10, decay_rates=np.arange(1, 11), window_size=12),
+            basis.OrthExponentialConv(10, decay_rates=np.arange(1, 11), window_size=12),
             OrthExponentialBasis,
         ),
     ],
@@ -218,19 +218,19 @@ def test_expected_output_eval_on_grid(basis_instance, super_class):
 @pytest.mark.parametrize(
     "basis_instance, super_class",
     [
-        (basis.EvalBSpline(10), BSplineBasis),
-        (basis.ConvBSpline(10, window_size=11), BSplineBasis),
-        (basis.EvalCyclicBSpline(10), CyclicBSplineBasis),
-        (basis.ConvCyclicBSpline(10, window_size=11), CyclicBSplineBasis),
-        (basis.EvalMSpline(10), MSplineBasis),
-        (basis.ConvMSpline(10, window_size=11), MSplineBasis),
-        (basis.EvalRaisedCosineLinear(10), RaisedCosineBasisLinear),
-        (basis.ConvRaisedCosineLinear(10, window_size=11), RaisedCosineBasisLinear),
-        (basis.EvalRaisedCosineLog(10), RaisedCosineBasisLog),
-        (basis.ConvRaisedCosineLog(10, window_size=11), RaisedCosineBasisLog),
-        (basis.EvalOrthExponential(10, np.arange(1, 11)), OrthExponentialBasis),
+        (basis.BSplineEval(10), BSplineBasis),
+        (basis.BSplineConv(10, window_size=11), BSplineBasis),
+        (basis.CyclicBSplineEval(10), CyclicBSplineBasis),
+        (basis.CyclicBSplineConv(10, window_size=11), CyclicBSplineBasis),
+        (basis.MSplineEval(10), MSplineBasis),
+        (basis.MSplineConv(10, window_size=11), MSplineBasis),
+        (basis.RaisedCosineLinearEval(10), RaisedCosineBasisLinear),
+        (basis.RaisedCosineLinearConv(10, window_size=11), RaisedCosineBasisLinear),
+        (basis.RaisedCosineLogEval(10), RaisedCosineBasisLog),
+        (basis.RaisedCosineLogConv(10, window_size=11), RaisedCosineBasisLog),
+        (basis.OrthExponentialEval(10, np.arange(1, 11)), OrthExponentialBasis),
         (
-            basis.ConvOrthExponential(10, decay_rates=np.arange(1, 11), window_size=12),
+            basis.OrthExponentialConv(10, decay_rates=np.arange(1, 11), window_size=12),
             OrthExponentialBasis,
         ),
     ],
@@ -246,31 +246,31 @@ def test_expected_output_compute_features(basis_instance, super_class):
 @pytest.mark.parametrize(
     "basis_instance, super_class",
     [
-        (basis.EvalBSpline(10, label="label"), BSplineBasis),
-        (basis.ConvBSpline(10, window_size=11, label="label"), BSplineBasis),
-        (basis.EvalCyclicBSpline(10, label="label"), CyclicBSplineBasis),
+        (basis.BSplineEval(10, label="label"), BSplineBasis),
+        (basis.BSplineConv(10, window_size=11, label="label"), BSplineBasis),
+        (basis.CyclicBSplineEval(10, label="label"), CyclicBSplineBasis),
         (
-            basis.ConvCyclicBSpline(10, window_size=11, label="label"),
+            basis.CyclicBSplineConv(10, window_size=11, label="label"),
             CyclicBSplineBasis,
         ),
-        (basis.EvalMSpline(10, label="label"), MSplineBasis),
-        (basis.ConvMSpline(10, window_size=11, label="label"), MSplineBasis),
-        (basis.EvalRaisedCosineLinear(10, label="label"), RaisedCosineBasisLinear),
+        (basis.MSplineEval(10, label="label"), MSplineBasis),
+        (basis.MSplineConv(10, window_size=11, label="label"), MSplineBasis),
+        (basis.RaisedCosineLinearEval(10, label="label"), RaisedCosineBasisLinear),
         (
-            basis.ConvRaisedCosineLinear(10, window_size=11, label="label"),
+            basis.RaisedCosineLinearConv(10, window_size=11, label="label"),
             RaisedCosineBasisLinear,
         ),
-        (basis.EvalRaisedCosineLog(10, label="label"), RaisedCosineBasisLog),
+        (basis.RaisedCosineLogEval(10, label="label"), RaisedCosineBasisLog),
         (
-            basis.ConvRaisedCosineLog(10, window_size=11, label="label"),
+            basis.RaisedCosineLogConv(10, window_size=11, label="label"),
             RaisedCosineBasisLog,
         ),
         (
-            basis.EvalOrthExponential(10, np.arange(1, 11), label="label"),
+            basis.OrthExponentialEval(10, np.arange(1, 11), label="label"),
             OrthExponentialBasis,
         ),
         (
-            basis.ConvOrthExponential(
+            basis.OrthExponentialConv(
                 10, decay_rates=np.arange(1, 11), window_size=12, label="label"
             ),
             OrthExponentialBasis,
@@ -305,12 +305,12 @@ class BasisFuncsTesting(abc.ABC):
 @pytest.mark.parametrize(
     "cls",
     [
-        {"eval": basis.EvalRaisedCosineLog, "conv": basis.ConvRaisedCosineLog},
-        {"eval": basis.EvalRaisedCosineLinear, "conv": basis.ConvRaisedCosineLinear},
-        {"eval": basis.EvalBSpline, "conv": basis.ConvBSpline},
-        {"eval": basis.EvalCyclicBSpline, "conv": basis.ConvCyclicBSpline},
-        {"eval": basis.EvalMSpline, "conv": basis.ConvMSpline},
-        {"eval": basis.EvalOrthExponential, "conv": basis.ConvOrthExponential},
+        {"eval": basis.RaisedCosineLogEval, "conv": basis.RaisedCosineLogConv},
+        {"eval": basis.RaisedCosineLinearEval, "conv": basis.RaisedCosineLinearConv},
+        {"eval": basis.BSplineEval, "conv": basis.BSplineConv},
+        {"eval": basis.CyclicBSplineEval, "conv": basis.CyclicBSplineConv},
+        {"eval": basis.MSplineEval, "conv": basis.MSplineConv},
+        {"eval": basis.OrthExponentialEval, "conv": basis.OrthExponentialConv},
     ],
 )
 class TestSharedMethods:
@@ -345,7 +345,7 @@ class TestSharedMethods:
             return
         bas = cls["eval"](5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5))
         with expectation:
-            bas(samples)
+            bas._evaluate(samples)
 
     @pytest.mark.parametrize(
         "attribute, value",
@@ -532,7 +532,7 @@ class TestSharedMethods:
             n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
         )
         x = np.linspace(0, 1, 10)
-        assert bas(x).shape[1] == n_basis
+        assert bas._evaluate(x).shape[1] == n_basis
 
     @pytest.mark.parametrize("n_basis", [6])
     def test_call_equivalent_in_conv(self, n_basis, cls):
@@ -545,7 +545,7 @@ class TestSharedMethods:
             n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis)
         )
         x = np.linspace(0, 1, 10)
-        assert np.all(bas_con(x) == bas_eval(x))
+        assert np.all(bas_con._evaluate(x) == bas_eval._evaluate(x))
 
     @pytest.mark.parametrize(
         "num_input, expectation",
@@ -564,7 +564,7 @@ class TestSharedMethods:
             n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
         )
         with expectation:
-            bas(*([np.linspace(0, 1, 10)] * num_input))
+            bas._evaluate(*([np.linspace(0, 1, 10)] * num_input))
 
     @pytest.mark.parametrize(
         "inp, expectation",
@@ -582,7 +582,7 @@ class TestSharedMethods:
             n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
         )
         with expectation:
-            bas(inp)
+            bas._evaluate(inp)
 
     @pytest.mark.parametrize(
         "samples, expectation",
@@ -600,7 +600,7 @@ class TestSharedMethods:
             n_basis_funcs=n_basis, **extra_decay_rates(cls["eval"], n_basis)
         )  # Only eval mode is relevant here
         with expectation:
-            bas(samples)
+            bas._evaluate(samples)
 
     @pytest.mark.parametrize(
         "mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})]
@@ -609,7 +609,7 @@ class TestSharedMethods:
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
         x = np.linspace(0, 1, 10)
         x[3] = np.nan
-        assert all(np.isnan(bas(x)[3]))
+        assert all(np.isnan(bas._evaluate(x)[3]))
 
     @pytest.mark.parametrize("n_basis", [6, 7])
     @pytest.mark.parametrize(
@@ -620,7 +620,7 @@ class TestSharedMethods:
             n_basis_funcs=n_basis, **kwargs, **extra_decay_rates(cls[mode], n_basis)
         )
         with pytest.raises(ValueError, match="All sample provided must"):
-            bas(np.array([]))
+            bas._evaluate(np.array([]))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
     @pytest.mark.parametrize(
@@ -628,7 +628,10 @@ class TestSharedMethods:
     )
     def test_call_sample_axis(self, time_axis_shape, mode, kwargs, cls):
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
-        assert bas(np.linspace(0, 1, time_axis_shape)).shape[0] == time_axis_shape
+        assert (
+            bas._evaluate(np.linspace(0, 1, time_axis_shape)).shape[0]
+            == time_axis_shape
+        )
 
     @pytest.mark.parametrize(
         "mn, mx, expectation",
@@ -643,7 +646,7 @@ class TestSharedMethods:
     def test_call_sample_range(self, mn, mx, expectation, mode, kwargs, cls):
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
         with expectation:
-            bas(np.linspace(mn, mx, 10))
+            bas._evaluate(np.linspace(mn, mx, 10))
 
     @pytest.mark.parametrize(
         "kwargs, input1_shape, expectation",
@@ -1020,9 +1023,9 @@ class TestSharedMethods:
     # @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
     # def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, mode, kwargs, order, cls):
     #     min_per_basis = {
-    #         "EvalMSpline": (order < 1) | (n_basis_funcs < 1) | (order > n_basis_funcs),
-    #         "EvalRaisedCosineLog": lambda x: x < 2,
-    #         "EvalBSpline": lambda x: order > x,
+    #         "MSplineEval": (order < 1) | (n_basis_funcs < 1) | (order > n_basis_funcs),
+    #         "RaisedCosineLogEval": lambda x: x < 2,
+    #         "BSplineEval": lambda x: order > x,
     #     }
     #     if n_basis_funcs < 2:
     #         with pytest.raises(
@@ -1085,8 +1088,8 @@ class TestSharedMethods:
         bas = cls[mode](n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5))
         x = np.linspace(0, 1, 10)
         x_nap = nap.Tsd(t=np.arange(10), d=x)
-        y = bas(x)
-        y_nap = bas(x_nap)
+        y = bas._evaluate(x)
+        y_nap = bas._evaluate(x_nap)
         assert isinstance(y_nap, nap.TsdFrame)
         assert np.all(y == y_nap.d)
         assert np.all(y_nap.t == x_nap.t)
@@ -1258,7 +1261,7 @@ class TestSharedMethods:
 
 
 class TestRaisedCosineLogBasis(BasisFuncsTesting):
-    cls = {"eval": basis.EvalRaisedCosineLog, "conv": basis.ConvRaisedCosineLog}
+    cls = {"eval": basis.RaisedCosineLogEval, "conv": basis.RaisedCosineLogConv}
 
     @pytest.mark.parametrize("width", [1.5, 2, 2.5])
     def test_decay_to_zero_basis_number_match(self, width):
@@ -1332,7 +1335,7 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
     def test_time_scaling_property(self):
         time_scaling = [0.1, 10, 100]
         n_basis_funcs = 5
-        _, lin_ev = basis.EvalRaisedCosineLinear(n_basis_funcs).evaluate_on_grid(100)
+        _, lin_ev = basis.RaisedCosineLinearEval(n_basis_funcs).evaluate_on_grid(100)
         corr = np.zeros(len(time_scaling))
         for idx, ts in enumerate(time_scaling):
             basis_log = self.cls["eval"](
@@ -1395,7 +1398,7 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
 
 
 class TestRaisedCosineLinearBasis(BasisFuncsTesting):
-    cls = {"eval": basis.EvalRaisedCosineLinear, "conv": basis.ConvRaisedCosineLinear}
+    cls = {"eval": basis.RaisedCosineLinearEval, "conv": basis.RaisedCosineLinearConv}
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     @pytest.mark.parametrize(
@@ -1469,7 +1472,7 @@ class TestRaisedCosineLinearBasis(BasisFuncsTesting):
 
 
 class TestMSplineBasis(BasisFuncsTesting):
-    cls = {"eval": basis.EvalMSpline, "conv": basis.ConvMSpline}
+    cls = {"eval": basis.MSplineEval, "conv": basis.MSplineConv}
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     @pytest.mark.parametrize("order", [-1, 0, 1, 2, 3, 4, 5])
@@ -1573,7 +1576,7 @@ class TestMSplineBasis(BasisFuncsTesting):
 
 
 class TestOrthExponentialBasis(BasisFuncsTesting):
-    cls = {"eval": basis.EvalOrthExponential, "conv": basis.ConvOrthExponential}
+    cls = {"eval": basis.OrthExponentialEval, "conv": basis.OrthExponentialConv}
 
     @pytest.mark.parametrize(
         "decay_rates", [[1, 2, 3], [0.01, 0.02, 0.001], [2, 1, 1, 2.4]]
@@ -1645,7 +1648,7 @@ class TestOrthExponentialBasis(BasisFuncsTesting):
 
 
 class TestBSplineBasis(BasisFuncsTesting):
-    cls = {"eval": basis.EvalBSpline, "conv": basis.ConvBSpline}
+    cls = {"eval": basis.BSplineEval, "conv": basis.BSplineConv}
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     @pytest.mark.parametrize("order", [1, 2, 3, 4, 5])
@@ -1733,7 +1736,7 @@ class TestBSplineBasis(BasisFuncsTesting):
 
 
 class TestCyclicBSplineBasis(BasisFuncsTesting):
-    cls = {"eval": basis.EvalCyclicBSpline, "conv": basis.ConvCyclicBSpline}
+    cls = {"eval": basis.CyclicBSplineEval, "conv": basis.CyclicBSplineConv}
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
     @pytest.mark.parametrize("order", [2, 3, 4, 5])
@@ -1872,23 +1875,23 @@ class CombinedBasis(BasisFuncsTesting):
 
         if basis_class == AdditiveBasis:
             kwargs_mspline = trim_kwargs(
-                basis.EvalMSpline, kwargs, class_specific_params
+                basis.MSplineEval, kwargs, class_specific_params
             )
             kwargs_raised_cosine = trim_kwargs(
-                basis.ConvRaisedCosineLinear, kwargs, class_specific_params
+                basis.RaisedCosineLinearConv, kwargs, class_specific_params
             )
-            b1 = basis.EvalMSpline(**kwargs_mspline)
-            b2 = basis.ConvRaisedCosineLinear(**kwargs_raised_cosine)
+            b1 = basis.MSplineEval(**kwargs_mspline)
+            b2 = basis.RaisedCosineLinearConv(**kwargs_raised_cosine)
             basis_obj = b1 + b2
         elif basis_class == MultiplicativeBasis:
             kwargs_mspline = trim_kwargs(
-                basis.EvalMSpline, kwargs, class_specific_params
+                basis.MSplineEval, kwargs, class_specific_params
             )
             kwargs_raised_cosine = trim_kwargs(
-                basis.ConvRaisedCosineLinear, kwargs, class_specific_params
+                basis.RaisedCosineLinearConv, kwargs, class_specific_params
             )
-            b1 = basis.EvalMSpline(**kwargs_mspline)
-            b2 = basis.ConvRaisedCosineLinear(**kwargs_raised_cosine)
+            b1 = basis.MSplineEval(**kwargs_mspline)
+            b2 = basis.RaisedCosineLinearConv(**kwargs_raised_cosine)
             basis_obj = b1 * b2
         else:
             basis_obj = basis_class(
@@ -1901,7 +1904,7 @@ class TestAdditiveBasis(CombinedBasis):
     cls = {"eval": AdditiveBasis, "conv": AdditiveBasis}
 
     @pytest.mark.parametrize("samples", [[[0], []], [[], [0]], [[0, 0], [0, 0]]])
-    @pytest.mark.parametrize("base_cls", [basis.EvalBSpline, basis.ConvBSpline])
+    @pytest.mark.parametrize("base_cls", [basis.BSplineEval, basis.BSplineConv])
     def test_non_empty_samples(self, base_cls, samples, class_specific_params):
         kwargs = {"window_size": 2, "n_basis_funcs": 5}
         kwargs = trim_kwargs(base_cls, kwargs, class_specific_params)
@@ -1928,7 +1931,7 @@ class TestAdditiveBasis(CombinedBasis):
         """
         Checks that the sample size of the output from the compute_features() method matches the input sample size.
         """
-        basis_obj = basis.EvalMSpline(5) + basis.EvalMSpline(5)
+        basis_obj = basis.MSplineEval(5) + basis.MSplineEval(5)
         basis_obj.compute_features(*eval_input)
 
     @pytest.mark.parametrize("n_basis_a", [5, 6])
@@ -2183,7 +2186,7 @@ class TestAdditiveBasis(CombinedBasis):
                 TypeError, match="Input dimensionality mismatch"
             )
         with expectation:
-            basis_obj(*([np.linspace(0, 1, 10)] * num_input))
+            basis_obj._evaluate(*([np.linspace(0, 1, 10)] * num_input))
 
     @pytest.mark.parametrize(
         "inp, expectation",
@@ -2216,7 +2219,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj + basis_b_obj
         with expectation:
-            basis_obj(*([inp] * basis_obj._n_input_dimensionality))
+            basis_obj._evaluate(*([inp] * basis_obj._n_input_dimensionality))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
     @pytest.mark.parametrize(" window_size", [3])
@@ -2242,7 +2245,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj + basis_b_obj
         inp = [np.linspace(0, 1, time_axis_shape)] * basis_obj._n_input_dimensionality
-        assert basis_obj(*inp).shape[0] == time_axis_shape
+        assert basis_obj._evaluate(*inp).shape[0] == time_axis_shape
 
     @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -2267,7 +2270,7 @@ class TestAdditiveBasis(CombinedBasis):
         inp = [np.linspace(0, 1, 10)] * basis_obj._n_input_dimensionality
         for x in inp:
             x[3] = np.nan
-        assert all(np.isnan(basis_obj(*inp)[3]))
+        assert all(np.isnan(basis_obj._evaluate(*inp)[3]))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
@@ -2293,7 +2296,7 @@ class TestAdditiveBasis(CombinedBasis):
         bas_con = basis_a_obj + basis_b_obj
 
         x = [np.linspace(0, 1, 10)] * bas_con._n_input_dimensionality
-        assert np.all(bas_con(*x) == bas_eva(*x))
+        assert np.all(bas_con._evaluate(*x) == bas_eva._evaluate(*x))
 
     @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -2313,8 +2316,8 @@ class TestAdditiveBasis(CombinedBasis):
         x = np.linspace(0, 1, 10)
         x_nap = [nap.Tsd(t=np.arange(10), d=x)] * bas._n_input_dimensionality
         x = [x] * bas._n_input_dimensionality
-        y = bas(*x)
-        y_nap = bas(*x_nap)
+        y = bas._evaluate(*x)
+        y_nap = bas._evaluate(*x_nap)
         assert isinstance(y_nap, nap.TsdFrame)
         assert np.all(y == y_nap.d)
         assert np.all(y_nap.t == x_nap[0].t)
@@ -2335,7 +2338,10 @@ class TestAdditiveBasis(CombinedBasis):
         )
         bas = basis_a_obj + basis_b_obj
         x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
-        assert bas(*x).shape[1] == basis_a_obj.n_basis_funcs + basis_b_obj.n_basis_funcs
+        assert (
+            bas._evaluate(*x).shape[1]
+            == basis_a_obj.n_basis_funcs + basis_b_obj.n_basis_funcs
+        )
 
     @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -2353,7 +2359,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         bas = basis_a_obj + basis_b_obj
         with pytest.raises(ValueError, match="All sample provided must"):
-            bas(*([np.array([])] * bas._n_input_dimensionality))
+            bas._evaluate(*([np.array([])] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize(
         "mn, mx, expectation",
@@ -2398,7 +2404,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         bas = basis_a_obj + basis_b_obj
         with expectation:
-            bas(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
+            bas._evaluate(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
@@ -2457,8 +2463,8 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_output_features(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
-        bas2 = basis.ConvBSpline(11, window_size=10)
+        bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
+        bas2 = basis.BSplineConv(11, window_size=10)
         bas_add = bas1 + bas2
         assert bas_add.n_output_features is None
         bas_add.compute_features(
@@ -2469,8 +2475,8 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
-        bas2 = basis.ConvBSpline(10, window_size=10)
+        bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
+        bas2 = basis.BSplineConv(10, window_size=10)
         bas_add = bas1 + bas2
         assert bas_add.n_basis_input is None
         bas_add.compute_features(
@@ -2488,8 +2494,8 @@ class TestAdditiveBasis(CombinedBasis):
         ],
     )
     def test_expected_input_number(self, n_input, expectation):
-        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
-        bas2 = basis.ConvBSpline(10, window_size=10)
+        bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
+        bas2 = basis.BSplineConv(10, window_size=10)
         bas = bas1 + bas2
         x = np.random.randn(20, 2), np.random.randn(20, 3)
         bas.compute_features(*x)
@@ -2505,7 +2511,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     )
     @pytest.mark.parametrize(" ws", [3])
     def test_non_empty_samples(self, samples, ws):
-        basis_obj = basis.EvalMSpline(5) * basis.EvalRaisedCosineLinear(5)
+        basis_obj = basis.MSplineEval(5) * basis.RaisedCosineLinearEval(5)
         if any(tuple(len(s) == 0 for s in samples)):
             with pytest.raises(
                 ValueError, match="All sample provided must be non empty"
@@ -2528,7 +2534,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         """
         Checks that the sample size of the output from the compute_features() method matches the input sample size.
         """
-        basis_obj = basis.EvalMSpline(5) * basis.EvalMSpline(5)
+        basis_obj = basis.MSplineEval(5) * basis.MSplineEval(5)
         basis_obj.compute_features(*eval_input)
 
     @pytest.mark.parametrize("n_basis_a", [5, 6])
@@ -2821,7 +2827,7 @@ class TestMultiplicativeBasis(CombinedBasis):
                 TypeError, match="Input dimensionality mismatch"
             )
         with expectation:
-            basis_obj(*([np.linspace(0, 1, 10)] * num_input))
+            basis_obj._evaluate(*([np.linspace(0, 1, 10)] * num_input))
 
     @pytest.mark.parametrize(
         "inp, expectation",
@@ -2854,7 +2860,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj * basis_b_obj
         with expectation:
-            basis_obj(*([inp] * basis_obj._n_input_dimensionality))
+            basis_obj._evaluate(*([inp] * basis_obj._n_input_dimensionality))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
     @pytest.mark.parametrize(" window_size", [3])
@@ -2880,7 +2886,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj * basis_b_obj
         inp = [np.linspace(0, 1, time_axis_shape)] * basis_obj._n_input_dimensionality
-        assert basis_obj(*inp).shape[0] == time_axis_shape
+        assert basis_obj._evaluate(*inp).shape[0] == time_axis_shape
 
     @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -2905,7 +2911,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         inp = [np.linspace(0, 1, 10)] * basis_obj._n_input_dimensionality
         for x in inp:
             x[3] = np.nan
-        assert all(np.isnan(basis_obj(*inp)[3]))
+        assert all(np.isnan(basis_obj._evaluate(*inp)[3]))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
@@ -2931,7 +2937,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         bas_con = basis_a_obj * basis_b_obj
 
         x = [np.linspace(0, 1, 10)] * bas_con._n_input_dimensionality
-        assert np.all(bas_con(*x) == bas_eva(*x))
+        assert np.all(bas_con._evaluate(*x) == bas_eva._evaluate(*x))
 
     @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -2951,8 +2957,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         x = np.linspace(0, 1, 10)
         x_nap = [nap.Tsd(t=np.arange(10), d=x)] * bas._n_input_dimensionality
         x = [x] * bas._n_input_dimensionality
-        y = bas(*x)
-        y_nap = bas(*x_nap)
+        y = bas._evaluate(*x)
+        y_nap = bas._evaluate(*x_nap)
         assert isinstance(y_nap, nap.TsdFrame)
         assert np.all(y == y_nap.d)
         assert np.all(y_nap.t == x_nap[0].t)
@@ -2973,7 +2979,10 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         bas = basis_a_obj * basis_b_obj
         x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
-        assert bas(*x).shape[1] == basis_a_obj.n_basis_funcs * basis_b_obj.n_basis_funcs
+        assert (
+            bas._evaluate(*x).shape[1]
+            == basis_a_obj.n_basis_funcs * basis_b_obj.n_basis_funcs
+        )
 
     @pytest.mark.parametrize(" window_size", [3])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -2991,7 +3000,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         bas = basis_a_obj * basis_b_obj
         with pytest.raises(ValueError, match="All sample provided must"):
-            bas(*([np.array([])] * bas._n_input_dimensionality))
+            bas._evaluate(*([np.array([])] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize(
         "mn, mx, expectation",
@@ -3036,7 +3045,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         bas = basis_a_obj * basis_b_obj
         with expectation:
-            bas(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
+            bas._evaluate(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
@@ -3095,8 +3104,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_output_features(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
-        bas2 = basis.ConvBSpline(11, window_size=10)
+        bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
+        bas2 = basis.BSplineConv(11, window_size=10)
         bas_add = bas1 * bas2
         assert bas_add.n_output_features is None
         bas_add.compute_features(
@@ -3107,8 +3116,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_set_num_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
-        bas2 = basis.ConvBSpline(10, window_size=10)
+        bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
+        bas2 = basis.BSplineConv(10, window_size=10)
         bas_add = bas1 * bas2
         assert bas_add.n_basis_input is None
         bas_add.compute_features(
@@ -3126,8 +3135,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         ],
     )
     def test_expected_input_number(self, n_input, expectation):
-        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
-        bas2 = basis.ConvBSpline(10, window_size=10)
+        bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
+        bas2 = basis.BSplineConv(10, window_size=10)
         bas = bas1 * bas2
         x = np.random.randn(20, 2), np.random.randn(20, 3)
         bas.compute_features(*x)
@@ -3137,8 +3146,8 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
     def test_n_basis_input(self, n_basis_input1, n_basis_input2):
-        bas1 = basis.ConvRaisedCosineLinear(10, window_size=10)
-        bas2 = basis.ConvBSpline(10, window_size=10)
+        bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
+        bas2 = basis.BSplineConv(10, window_size=10)
         bas_prod = bas1 * bas2
         bas_prod.compute_features(
             np.ones((20, n_basis_input1)), np.ones((20, n_basis_input2))
@@ -3147,7 +3156,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
 
 @pytest.mark.parametrize(
-    "exponent", [-1, 0, 0.5, basis.EvalRaisedCosineLog(4), 1, 2, 3]
+    "exponent", [-1, 0, 0.5, basis.RaisedCosineLogEval(4), 1, 2, 3]
 )
 @pytest.mark.parametrize("basis_class", list_all_basis_classes())
 def test_power_of_basis(exponent, basis_class, class_specific_params):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -27,31 +27,6 @@ from nemos.basis._spline_basis import BSplineBasis, CyclicBSplineBasis, MSplineB
 from nemos.utils import pynapple_concatenate_numpy
 
 
-@pytest.fixture()
-def class_specific_params():
-    shared_params = ["n_basis_funcs", "label"]
-    eval_params = ["bounds"]
-    conv_params = ["window_size", "conv_kwargs"]
-    return dict(
-        EvalBSpline=shared_params + eval_params + ["order"],
-        ConvBSpline=shared_params + conv_params + ["order"],
-        EvalMSpline=shared_params + eval_params + ["order"],
-        ConvMSpline=shared_params + conv_params + ["order"],
-        EvalCyclicBSpline=shared_params + eval_params + ["order"],
-        ConvCyclicBSpline=shared_params + conv_params + ["order"],
-        EvalRaisedCosineLinear=shared_params + eval_params + ["width"],
-        ConvRaisedCosineLinear=shared_params + conv_params + ["width"],
-        EvalRaisedCosineLog=shared_params
-        + eval_params
-        + ["width", "time_scaling", "enforce_decay_to_zero"],
-        ConvRaisedCosineLog=shared_params
-        + conv_params
-        + ["width", "time_scaling", "enforce_decay_to_zero"],
-        EvalOrthExponential=shared_params + eval_params + ["decay_rates"],
-        ConvOrthExponential=shared_params + conv_params + ["decay_rates"],
-    )
-
-
 def trim_kwargs(cls, kwargs, class_specific_params):
     return {
         key: value
@@ -85,6 +60,13 @@ def list_all_basis_classes(filter_basis="all") -> list[type]:
     if filter_basis != "all":
         all_basis = [a for a in all_basis if filter_basis in a.__name__]
     return all_basis
+
+
+@pytest.fixture()
+def class_specific_params():
+    """Returns all the params for each class."""
+    all_cls = list_all_basis_classes("Conv") + list_all_basis_classes("Eval")
+    return {cls.__name__: cls._get_param_names() for cls in all_cls}
 
 
 def test_all_basis_are_tested() -> None:

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -262,12 +262,8 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         if mode == "conv" and len(samples) == 1:
             return
         if len(samples) == 0:
-            with pytest.raises(
-                ValueError, match="All sample provided must be non empty"
-            ):
-                self.cls[mode](5, **kwargs).compute_features(
-                    samples
-                )
+            with pytest.raises(ValueError, match="All sample provided must be non empty"):
+                self.cls[mode](5, **kwargs).compute_features(samples)
         else:
             self.cls[mode](5, **kwargs).compute_features(samples)
 
@@ -281,36 +277,15 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         [
             (10, does_not_raise()),
             (10.5, does_not_raise()),
-            (
-                    0.5,
-                    pytest.raises(
-                        ValueError,
-                        match=r"Invalid raised cosine width\. 2\*width must be a positive",
-                    ),
-            ),
-            (
-                    10.3,
-                    pytest.raises(
-                        ValueError,
-                        match=r"Invalid raised cosine width\. 2\*width must be a positive",
-                    ),
-            ),
-            (
-                    -10,
-                    pytest.raises(
-                        ValueError,
-                        match=r"Invalid raised cosine width\. 2\*width must be a positive",
-                    ),
-            ),
+            (0.5, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
+            (10.3, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
+            (-10, pytest.raises(ValueError, match=r"Invalid raised cosine width\. 2\*width must be a positive")),
             (None, pytest.raises(TypeError, match="'<=' not supported between")),
         ],
     )
-    @pytest.mark.parametrize("cls, kwargs", [
-        (basis.EvalRaisedCosineLog, {}),
-        (basis.ConvRaisedCosineLog, {"window_size": 5}),
-    ])
-    def test_set_width(self, width, expectation, cls, kwargs):
-        basis_obj = cls(n_basis_funcs=5, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})])
+    def test_set_width(self, width, expectation, mode, kwargs):
+        basis_obj = self.cls[mode](n_basis_funcs=5, **kwargs)
         with expectation:
             basis_obj.width = width
         with expectation:
@@ -320,20 +295,8 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         "kwargs, input1_shape, expectation",
         [
             (dict(), (10,), does_not_raise()),
-            (
-                    dict(axis=0),
-                    (10,),
-                    pytest.raises(
-                        ValueError, match="Setting the `axis` parameter is not allowed"
-                    ),
-            ),
-            (
-                    dict(axis=1),
-                    (2, 10),
-                    pytest.raises(
-                        ValueError, match="Setting the `axis` parameter is not allowed"
-                    ),
-            ),
+            (dict(axis=0), (10,), pytest.raises(ValueError, match="Setting the `axis` parameter is not allowed")),
+            (dict(axis=1), (2, 10), pytest.raises(ValueError, match="Setting the `axis` parameter is not allowed")),
         ],
     )
     def test_compute_features_axis(self, kwargs, input1_shape, expectation):
@@ -357,13 +320,13 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         ],
     )
     def test_compute_features_conv_input(
-            self,
-            n_basis_funcs,
-            time_scaling,
-            enforce_decay,
-            window_size,
-            input_shape,
-            expected_n_input,
+        self,
+        n_basis_funcs,
+        time_scaling,
+        enforce_decay,
+        window_size,
+        input_shape,
+        expected_n_input,
     ):
         x = np.ones(input_shape)
         basis_obj = self.cls["conv"](
@@ -379,21 +342,9 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         "args, sample_size",
         [[{"n_basis_funcs": n_basis}, 100] for n_basis in [2, 10, 100]],
     )
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_compute_features_returns_expected_number_of_basis(
-            self, args, sample_size, cls, kwargs
-    ):
-        """
-        Verifies the number of basis functions returned by the compute_features() method matches
-        the expected number of basis functions.
-        """
-        basis_obj = cls(**args, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_compute_features_returns_expected_number_of_basis(self, args, sample_size, mode, kwargs):
+        basis_obj = self.cls[mode](**args, **kwargs)
         eval_basis = basis_obj.compute_features(np.linspace(0, 1, sample_size))
         assert eval_basis.shape[1] == args["n_basis_funcs"], (
             "Dimensions do not agree: The number of basis should match the first dimension "
@@ -403,20 +354,9 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
 
     @pytest.mark.parametrize("sample_size", [100, 1000])
     @pytest.mark.parametrize("n_basis_funcs", [2, 10, 100])
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_sample_size_of_compute_features_matches_that_of_input(
-            self, n_basis_funcs, sample_size, cls, kwargs
-    ):
-        """
-        Checks that the sample size of the output from the compute_features() method matches the input sample size.
-        """
-        basis_obj = cls(n_basis_funcs=n_basis_funcs, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_sample_size_of_compute_features_matches_that_of_input(self, n_basis_funcs, sample_size, mode, kwargs):
+        basis_obj = self.cls[mode](n_basis_funcs=n_basis_funcs, **kwargs)
         eval_basis = basis_obj.compute_features(np.linspace(0, 1, sample_size))
         assert eval_basis.shape[0] == sample_size, (
             f"Dimensions do not agree: The sample size of the output should match the input sample size. "
@@ -429,62 +369,30 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             (0.5, 0, 1, does_not_raise()),
             (-0.5, 0, 1, pytest.raises(ValueError, match="All the samples lie outside")),
             (np.linspace(-1, 1, 10), 0, 1, does_not_raise()),
-            (
-                    np.linspace(-1, 0, 10),
-                    0,
-                    1,
-                    pytest.warns(UserWarning, match="More than 90% of the samples"),
-            ),
-            (
-                    np.linspace(1, 2, 10),
-                    0,
-                    1,
-                    pytest.warns(UserWarning, match="More than 90% of the samples"),
-            ),
+            (np.linspace(-1, 0, 10), 0, 1, pytest.warns(UserWarning, match="More than 90% of the samples")),
+            (np.linspace(1, 2, 10), 0, 1, pytest.warns(UserWarning, match="More than 90% of the samples")),
         ],
     )
     def test_compute_features_vmin_vmax(self, samples, vmin, vmax, expectation):
-        """
-        Tests that compute_features handles samples correctly within specified bounds.
-        """
         basis_obj = self.cls["eval"](5, bounds=(vmin, vmax))
         with expectation:
             basis_obj.compute_features(samples)
 
     @pytest.mark.parametrize("n_basis_funcs", [-1, 0, 1, 3, 10, 20])
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, cls, kwargs):
-        """
-        Verifies that the minimum number of basis functions required (i.e., 2) is enforced.
-        """
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_minimum_number_of_basis_required_is_matched(self, n_basis_funcs, mode, kwargs):
         if n_basis_funcs < 2:
             with pytest.raises(
-                    ValueError,
-                    match=f"Object class {cls.__name__} requires >= 2 basis elements.",
+                ValueError, match=f"Object class {self.cls[mode].__name__} requires >= 2 basis elements.",
             ):
-                cls(n_basis_funcs=n_basis_funcs, **kwargs)
+                self.cls[mode](n_basis_funcs=n_basis_funcs, **kwargs)
         else:
-            cls(n_basis_funcs=n_basis_funcs, **kwargs)
+            self.cls[mode](n_basis_funcs=n_basis_funcs, **kwargs)
 
     @pytest.mark.parametrize("n_input", [0, 1, 2, 3])
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_number_of_required_inputs_compute_features(self, n_input, cls, kwargs):
-        """
-        Confirms that the compute_features() method correctly handles the number of input samples provided.
-        """
-        basis_obj = cls(n_basis_funcs=5, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_number_of_required_inputs_compute_features(self, n_input, mode, kwargs):
+        basis_obj = self.cls[mode](n_basis_funcs=5, **kwargs)
         inputs = [np.linspace(0, 1, 20)] * n_input
         if n_input == 0:
             expectation = pytest.raises(TypeError, match="missing 1 required positional argument")
@@ -497,72 +405,39 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             basis_obj.compute_features(*inputs)
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_evaluate_on_grid_meshgrid_size(self, sample_size, cls, kwargs):
-        """
-        Checks that the evaluate_on_grid() method returns a grid of the expected size.
-        """
-        basis_obj = cls(n_basis_funcs=5, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_evaluate_on_grid_meshgrid_size(self, sample_size, mode, kwargs):
+        basis_obj = self.cls[mode](n_basis_funcs=5, **kwargs)
         if sample_size <= 0:
-            with pytest.raises(
-                    ValueError, match=r"All sample counts provided must be greater"
-            ):
+            with pytest.raises(ValueError, match=r"All sample counts provided must be greater"):
                 basis_obj.evaluate_on_grid(sample_size)
         else:
             grid, _ = basis_obj.evaluate_on_grid(sample_size)
             assert grid.shape[0] == sample_size
 
     @pytest.mark.parametrize("sample_size", [-1, 0, 1, 10, 11, 100])
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_evaluate_on_grid_basis_size(self, sample_size, cls, kwargs):
-        """
-        Ensures that the evaluate_on_grid() method returns basis functions of the expected size.
-        """
-        basis_obj = cls(n_basis_funcs=5, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_evaluate_on_grid_basis_size(self, sample_size, mode, kwargs):
+        basis_obj = self.cls[mode](n_basis_funcs=5, **kwargs)
         if sample_size <= 0:
-            with pytest.raises(
-                    ValueError, match=r"All sample counts provided must be greater"
-            ):
+            with pytest.raises(ValueError, match=r"All sample counts provided must be greater"):
                 basis_obj.evaluate_on_grid(sample_size)
         else:
             _, eval_basis = basis_obj.evaluate_on_grid(sample_size)
             assert eval_basis.shape[0] == sample_size
 
     @pytest.mark.parametrize("n_input", [0, 1, 2])
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_evaluate_on_grid_input_number(self, n_input, cls, kwargs):
-        """
-        Validates that the evaluate_on_grid() method correctly handles the number of input samples provided.
-        """
-        basis_obj = cls(n_basis_funcs=5, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_evaluate_on_grid_input_number(self, n_input, mode, kwargs):
+        basis_obj = self.cls[mode](n_basis_funcs=5, **kwargs)
         inputs = [10] * n_input
         if n_input == 0:
             expectation = pytest.raises(
-                TypeError,
-                match=r"evaluate_on_grid\(\) missing 1 required positional argument",
+                TypeError, match=r"evaluate_on_grid\(\) missing 1 required positional argument",
             )
         elif n_input != basis_obj._n_input_dimensionality:
             expectation = pytest.raises(
-                TypeError,
-                match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
+                TypeError, match=r"evaluate_on_grid\(\) takes [0-9] positional arguments but [0-9] were given",
             )
         else:
             expectation = does_not_raise()
@@ -582,21 +457,13 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             (2.1, pytest.raises(ValueError, match="Invalid raised cosine width. ")),
         ],
     )
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 2}),
-        ],
-    )
-    def test_width_values(self, width, expectation, cls, kwargs):
-        """Test allowable widths: integer multiple of 1/2, greater than 1."""
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 2})])
+    def test_width_values(self, width, expectation, mode, kwargs):
         with expectation:
-            cls(n_basis_funcs=5, width=width, **kwargs)
+            self.cls[mode](n_basis_funcs=5, width=width, **kwargs)
 
     @pytest.mark.parametrize("width", [1.5, 2, 2.5])
     def test_decay_to_zero_basis_number_match(self, width):
-        """Test that the number of basis is preserved."""
         n_basis_funcs = 10
         _, ev = self.cls["conv"](
             n_basis_funcs=n_basis_funcs, width=width, enforce_decay_to_zero=True, window_size=5
@@ -615,37 +482,26 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             (10, does_not_raise()),
         ],
     )
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 5}),
-        ],
-    )
-    def test_time_scaling_values(self, time_scaling, expectation, cls, kwargs):
-        """Test that only positive time_scaling are allowed."""
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 5})])
+    def test_time_scaling_values(self, time_scaling, expectation, mode, kwargs):
         with expectation:
-            cls(n_basis_funcs=5, time_scaling=time_scaling, **kwargs)
+            self.cls[mode](n_basis_funcs=5, time_scaling=time_scaling, **kwargs)
 
     def test_time_scaling_property(self):
-        """Test that larger time_scaling results in larger departures from linearity."""
         time_scaling = [0.1, 10, 100]
         n_basis_funcs = 5
         _, lin_ev = basis.EvalRaisedCosineLinear(n_basis_funcs).evaluate_on_grid(100)
         corr = np.zeros(len(time_scaling))
         for idx, ts in enumerate(time_scaling):
-            # set default decay to zero to get comparable basis
             basis_log = self.cls["eval"](
                 n_basis_funcs=n_basis_funcs,
                 time_scaling=ts,
                 enforce_decay_to_zero=False,
             )
             _, log_ev = basis_log.evaluate_on_grid(100)
-            # compute the correlation
             corr[idx] = (lin_ev.flatten() @ log_ev.flatten()) / (
-                    np.linalg.norm(lin_ev.flatten()) * np.linalg.norm(log_ev.flatten())
+                np.linalg.norm(lin_ev.flatten()) * np.linalg.norm(log_ev.flatten())
             )
-        # check that the correlation decreases as time_scale increases
         assert np.all(
             np.diff(corr) < 0
         ), "As time scales increases, deviation from linearity should increase!"
@@ -653,9 +509,6 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
     @pytest.mark.parametrize("sample_size", [30])
     @pytest.mark.parametrize("n_basis", [5])
     def test_pynapple_support_compute_features(self, n_basis, sample_size):
-        """
-        Test compute_features compatibility with pynapple Tsd input.
-        """
         iset = nap.IntervalSet(start=[0, 0.5], end=[0.49999, 1])
         inp = nap.Tsd(
             t=np.linspace(0, 1, sample_size),
@@ -666,7 +519,6 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         assert isinstance(out, nap.TsdFrame)
         assert np.all(out.time_support.values == inp.time_support.values)
 
-    # TEST CALL
     @pytest.mark.parametrize(
         "num_input, expectation",
         [
@@ -675,18 +527,9 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             (2, pytest.raises(TypeError, match="Input dimensionality mismatch")),
         ],
     )
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 3}),
-        ],
-    )
-    def test_call_input_num(self, num_input, cls, kwargs, expectation):
-        """
-        Test handling of input dimensionality mismatch when calling the basis.
-        """
-        bas = cls(n_basis_funcs=5, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
+    def test_call_input_num(self, num_input, mode, kwargs, expectation):
+        bas = self.cls[mode](n_basis_funcs=5, **kwargs)
         with expectation:
             bas(*([np.linspace(0, 1, 10)] * num_input))
 
@@ -697,18 +540,9 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             (np.linspace(0, 1, 10)[:, None], pytest.raises(ValueError)),
         ],
     )
-    @pytest.mark.parametrize(
-        "cls, kwargs",
-        [
-            (basis.EvalRaisedCosineLog, {}),
-            (basis.ConvRaisedCosineLog, {"window_size": 3}),
-        ],
-    )
-    def test_call_input_shape(self, inp, cls, kwargs, expectation):
-        """
-        Test handling of input shape mismatch when calling the basis.
-        """
-        bas = cls(n_basis_funcs=5, **kwargs)
+    @pytest.mark.parametrize("mode, kwargs", [("eval", {}), ("conv", {"window_size": 3})])
+    def test_call_input_shape(self, inp, mode, kwargs, expectation):
+        bas = self.cls[mode](n_basis_funcs=5, **kwargs)
         with expectation:
             bas(inp)
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -571,7 +571,7 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             basis_obj.evaluate_on_grid(*inputs)
 
     @pytest.mark.parametrize(
-        "width ,expectation",
+        "width, expectation",
         [
             (-1, pytest.raises(ValueError, match="Invalid raised cosine width. ")),
             (0, pytest.raises(ValueError, match="Invalid raised cosine width. ")),
@@ -582,17 +582,24 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
             (2.1, pytest.raises(ValueError, match="Invalid raised cosine width. ")),
         ],
     )
-    def test_width_values(self, width, expectation):
+    @pytest.mark.parametrize(
+        "cls, kwargs",
+        [
+            (basis.EvalRaisedCosineLog, {}),
+            (basis.ConvRaisedCosineLog, {"window_size": 2}),
+        ],
+    )
+    def test_width_values(self, width, expectation, cls, kwargs):
         """Test allowable widths: integer multiple of 1/2, greater than 1."""
         with expectation:
-            self.cls(n_basis_funcs=5, width=width)
+            cls(n_basis_funcs=5, width=width, **kwargs)
 
     @pytest.mark.parametrize("width", [1.5, 2, 2.5])
     def test_decay_to_zero_basis_number_match(self, width):
         """Test that the number of basis is preserved."""
         n_basis_funcs = 10
-        _, ev = self.cls(
-            n_basis_funcs=n_basis_funcs, width=width, enforce_decay_to_zero=True
+        _, ev = self.cls["conv"](
+            n_basis_funcs=n_basis_funcs, width=width, enforce_decay_to_zero=True, window_size=5
         ).evaluate_on_grid(2)
         assert ev.shape[1] == n_basis_funcs, (
             "Basis function number mismatch. "
@@ -600,28 +607,25 @@ class TestRaisedCosineLogBasis(BasisFuncsTesting):
         )
 
     @pytest.mark.parametrize(
-        "time_scaling ,expectation",
+        "time_scaling, expectation",
         [
-            (
-                -1,
-                pytest.raises(
-                    ValueError, match="Only strictly positive time_scaling are allowed"
-                ),
-            ),
-            (
-                0,
-                pytest.raises(
-                    ValueError, match="Only strictly positive time_scaling are allowed"
-                ),
-            ),
+            (-1, pytest.raises(ValueError, match="Only strictly positive time_scaling are allowed")),
+            (0, pytest.raises(ValueError, match="Only strictly positive time_scaling are allowed")),
             (0.1, does_not_raise()),
             (10, does_not_raise()),
         ],
     )
-    def test_time_scaling_values(self, time_scaling, expectation):
+    @pytest.mark.parametrize(
+        "cls, kwargs",
+        [
+            (basis.EvalRaisedCosineLog, {}),
+            (basis.ConvRaisedCosineLog, {"window_size": 5}),
+        ],
+    )
+    def test_time_scaling_values(self, time_scaling, expectation, cls, kwargs):
         """Test that only positive time_scaling are allowed."""
         with expectation:
-            self.cls(n_basis_funcs=5, time_scaling=time_scaling)
+            cls(n_basis_funcs=5, time_scaling=time_scaling, **kwargs)
 
     def test_time_scaling_property(self):
         """Test that larger time_scaling results in larger departures from linearity."""

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -476,38 +476,6 @@ class TestSharedMethods:
         assert bas._n_basis_input == (n_input,)
 
     @pytest.mark.parametrize(
-        "samples, vmin, vmax, expectation",
-        [
-            (0.5, 0, 1, does_not_raise()),
-            (
-                -0.5,
-                0,
-                1,
-                pytest.raises(ValueError, match="All the samples lie outside"),
-            ),
-            (np.linspace(-1, 1, 10), 0, 1, does_not_raise()),
-            (
-                np.linspace(-1, 0, 10),
-                0,
-                1,
-                pytest.warns(UserWarning, match="More than 90% of the samples"),
-            ),
-            (
-                np.linspace(1, 2, 10),
-                0,
-                1,
-                pytest.warns(UserWarning, match="More than 90% of the samples"),
-            ),
-        ],
-    )
-    def test_compute_features_vmin_vmax(self, samples, vmin, vmax, expectation, cls):
-        basis_obj = cls["eval"](
-            5, bounds=(vmin, vmax), **extra_decay_rates(cls["eval"], 5)
-        )
-        with expectation:
-            basis_obj.compute_features(samples)
-
-    @pytest.mark.parametrize(
         "bounds, samples, nan_idx, mn, mx",
         [
             (None, np.arange(5), [4], 0, 1),
@@ -576,57 +544,6 @@ class TestSharedMethods:
             bas = cls["eval"](
                 n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5)
             )
-            assert bounds == bas.bounds if bounds else bas.bounds is None
-
-    @pytest.mark.parametrize(
-        "bounds, expectation",
-        [
-            (None, does_not_raise()),
-            ((None, 3), pytest.raises(TypeError, match=r"Could not convert")),
-            ((1, None), pytest.raises(TypeError, match=r"Could not convert")),
-            ((1, 3), does_not_raise()),
-            (("a", 3), pytest.raises(TypeError, match="Could not convert")),
-            ((1, "a"), pytest.raises(TypeError, match="Could not convert")),
-            (("a", "a"), pytest.raises(TypeError, match="Could not convert")),
-            (
-                (1, 2, 3),
-                pytest.raises(
-                    ValueError, match="The provided `bounds` must be of length two"
-                ),
-            ),
-        ],
-    )
-    def test_vmin_vmax_init(self, bounds, expectation, cls):
-        with expectation:
-            bas = cls["eval"](
-                n_basis_funcs=5, bounds=bounds, **extra_decay_rates(cls["eval"], 5)
-            )
-            assert bounds == bas.bounds if bounds else bas.bounds is None
-
-    @pytest.mark.parametrize(
-        "bounds, expectation",
-        [
-            (None, does_not_raise()),
-            ((None, 3), pytest.raises(TypeError, match=r"Could not convert")),
-            ((1, None), pytest.raises(TypeError, match=r"Could not convert")),
-            ((1, 3), does_not_raise()),
-            (("a", 3), pytest.raises(TypeError, match="Could not convert")),
-            ((1, "a"), pytest.raises(TypeError, match="Could not convert")),
-            (("a", "a"), pytest.raises(TypeError, match="Could not convert")),
-            (
-                (2, 1),
-                pytest.raises(
-                    ValueError, match=r"Invalid bound \(2, 1\). Lower bound is greater"
-                ),
-            ),
-        ],
-    )
-    def test_vmin_vmax_setter(self, bounds, expectation, cls):
-        bas = cls["eval"](
-            n_basis_funcs=5, bounds=(1, 3), **extra_decay_rates(cls["eval"], 5)
-        )
-        with expectation:
-            bas.set_params(bounds=bounds)
             assert bounds == bas.bounds if bounds else bas.bounds is None
 
     @pytest.mark.parametrize("n_basis", [6, 7])

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -17,13 +17,7 @@ from sklearn.base import clone as sk_clone
 import nemos as nmo
 import nemos.basis.basis as basis
 import nemos.convolve as convolve
-from nemos.basis._basis import (
-    AdditiveBasis,
-    Basis,
-    MultiplicativeBasis,
-    TransformerBasis,
-    add_docstring,
-)
+from nemos.basis._basis import AdditiveBasis, Basis, MultiplicativeBasis, add_docstring
 from nemos.basis._decaying_exponential import OrthExponentialBasis
 from nemos.basis._raised_cosine_basis import (
     RaisedCosineBasisLinear,
@@ -86,7 +80,7 @@ def list_all_basis_classes(filter_basis="all") -> list[type]:
     ] + [
         bas
         for _, bas in utils_testing.get_non_abstract_classes(nmo.basis._basis)
-        if bas != TransformerBasis
+        if bas != basis.TransformerBasis
     ]
     if filter_basis != "all":
         all_basis = [a for a in all_basis if filter_basis in a.__name__]
@@ -3228,7 +3222,7 @@ def test_basis_to_transformer(basis_cls, class_specific_params):
 
     trans_bas = bas.to_transformer()
 
-    assert isinstance(trans_bas, TransformerBasis)
+    assert isinstance(trans_bas, basis.TransformerBasis)
 
     # check that things like n_basis_funcs are the same as the original basis
     for k in bas.__dict__.keys():
@@ -3277,7 +3271,7 @@ def test_to_transformer_and_constructor_are_equivalent(
     )
 
     trans_bas_a = bas.to_transformer()
-    trans_bas_b = TransformerBasis(bas)
+    trans_bas_b = basis.TransformerBasis(bas)
 
     # they both just have a _basis
     assert (
@@ -3334,7 +3328,7 @@ def test_basis_to_transformer_makes_a_copy(basis_cls, class_specific_params):
 )
 @pytest.mark.parametrize("n_basis_funcs", [5, 10, 20])
 def test_transformerbasis_getattr(basis_cls, n_basis_funcs, class_specific_params):
-    trans_basis = TransformerBasis(
+    trans_basis = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             n_basis_funcs, basis_cls, class_specific_params, window_size=10
         )
@@ -3357,7 +3351,7 @@ def test_transformerbasis_getattr(basis_cls, n_basis_funcs, class_specific_param
 def test_transformerbasis_set_params(
     basis_cls, n_basis_funcs_init, n_basis_funcs_new, class_specific_params
 ):
-    trans_basis = TransformerBasis(
+    trans_basis = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             n_basis_funcs_init, basis_cls, class_specific_params, window_size=10
         )
@@ -3374,7 +3368,7 @@ def test_transformerbasis_set_params(
 )
 def test_transformerbasis_setattr_basis(basis_cls, class_specific_params):
     # setting the _basis attribute should change it
-    trans_bas = TransformerBasis(
+    trans_bas = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             10, basis_cls, class_specific_params, window_size=10
         )
@@ -3395,7 +3389,7 @@ def test_transformerbasis_setattr_basis(basis_cls, class_specific_params):
 def test_transformerbasis_setattr_basis_attribute(basis_cls, class_specific_params):
     # setting an attribute that is an attribute of the underlying _basis
     # should propagate setting it on _basis itself
-    trans_bas = TransformerBasis(
+    trans_bas = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             10, basis_cls, class_specific_params, window_size=10
         )
@@ -3417,7 +3411,7 @@ def test_transformerbasis_copy_basis_on_contsruct(basis_cls, class_specific_para
     orig_bas = CombinedBasis().instantiate_basis(
         10, basis_cls, class_specific_params, window_size=10
     )
-    trans_bas = TransformerBasis(orig_bas)
+    trans_bas = basis.TransformerBasis(orig_bas)
     trans_bas.n_basis_funcs = 20
 
     assert orig_bas.n_basis_funcs == 10
@@ -3433,7 +3427,7 @@ def test_transformerbasis_copy_basis_on_contsruct(basis_cls, class_specific_para
 def test_transformerbasis_setattr_illegal_attribute(basis_cls, class_specific_params):
     # changing an attribute that is not _basis or an attribute of _basis
     # is not allowed
-    trans_bas = TransformerBasis(
+    trans_bas = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             10, basis_cls, class_specific_params, window_size=10
         )
@@ -3459,10 +3453,10 @@ def test_transformerbasis_addition(basis_cls, class_specific_params):
     bas_b = CombinedBasis().instantiate_basis(
         n_basis_funcs_b, basis_cls, class_specific_params, window_size=10
     )
-    trans_bas_a = TransformerBasis(bas_a)
-    trans_bas_b = TransformerBasis(bas_b)
+    trans_bas_a = basis.TransformerBasis(bas_a)
+    trans_bas_b = basis.TransformerBasis(bas_b)
     trans_bas_sum = trans_bas_a + trans_bas_b
-    assert isinstance(trans_bas_sum, TransformerBasis)
+    assert isinstance(trans_bas_sum, basis.TransformerBasis)
     assert isinstance(trans_bas_sum._basis, AdditiveBasis)
     assert (
         trans_bas_sum.n_basis_funcs
@@ -3484,18 +3478,18 @@ def test_transformerbasis_addition(basis_cls, class_specific_params):
 def test_transformerbasis_multiplication(basis_cls, class_specific_params):
     n_basis_funcs_a = 5
     n_basis_funcs_b = n_basis_funcs_a * 2
-    trans_bas_a = TransformerBasis(
+    trans_bas_a = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             n_basis_funcs_a, basis_cls, class_specific_params, window_size=10
         )
     )
-    trans_bas_b = TransformerBasis(
+    trans_bas_b = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             n_basis_funcs_b, basis_cls, class_specific_params, window_size=10
         )
     )
     trans_bas_prod = trans_bas_a * trans_bas_b
-    assert isinstance(trans_bas_prod, TransformerBasis)
+    assert isinstance(trans_bas_prod, basis.TransformerBasis)
     assert isinstance(trans_bas_prod._basis, MultiplicativeBasis)
     assert (
         trans_bas_prod.n_basis_funcs
@@ -3526,7 +3520,7 @@ def test_transformerbasis_multiplication(basis_cls, class_specific_params):
 def test_transformerbasis_exponentiation(
     basis_cls, exponent: int, error_type, error_message, class_specific_params
 ):
-    trans_bas = TransformerBasis(
+    trans_bas = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             5, basis_cls, class_specific_params, window_size=10
         )
@@ -3535,7 +3529,7 @@ def test_transformerbasis_exponentiation(
     if not isinstance(exponent, int):
         with pytest.raises(error_type, match=error_message):
             trans_bas_exp = trans_bas**exponent
-            assert isinstance(trans_bas_exp, TransformerBasis)
+            assert isinstance(trans_bas_exp, basis.TransformerBasis)
             assert isinstance(trans_bas_exp._basis, MultiplicativeBasis)
 
 
@@ -3544,7 +3538,7 @@ def test_transformerbasis_exponentiation(
     list_all_basis_classes(),
 )
 def test_transformerbasis_dir(basis_cls, class_specific_params):
-    trans_bas = TransformerBasis(
+    trans_bas = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             5, basis_cls, class_specific_params, window_size=10
         )
@@ -3573,7 +3567,7 @@ def test_transformerbasis_sk_clone_kernel_noned(basis_cls, class_specific_params
     orig_bas = CombinedBasis().instantiate_basis(
         10, basis_cls, class_specific_params, window_size=20
     )
-    trans_bas = TransformerBasis(orig_bas)
+    trans_bas = basis.TransformerBasis(orig_bas)
 
     # kernel should be saved in the object after fit
     trans_bas.fit(np.random.randn(100, 20))
@@ -3597,7 +3591,7 @@ def test_transformerbasis_pickle(
     tmpdir, basis_cls, n_basis_funcs, class_specific_params
 ):
     # the test that tries cross-validation with n_jobs = 2 already should test this
-    trans_bas = TransformerBasis(
+    trans_bas = basis.TransformerBasis(
         CombinedBasis().instantiate_basis(
             n_basis_funcs, basis_cls, class_specific_params, window_size=10
         )
@@ -3608,7 +3602,7 @@ def test_transformerbasis_pickle(
     with open(filepath, "rb") as f:
         trans_bas2 = pickle.load(f)
 
-    assert isinstance(trans_bas2, TransformerBasis)
+    assert isinstance(trans_bas2, basis.TransformerBasis)
     if basis_cls in [AdditiveBasis, MultiplicativeBasis]:
         for bas in [
             getattr(trans_bas2._basis, attr) for attr in ("_basis1", "_basis2")
@@ -3743,7 +3737,7 @@ def test_multi_epoch_pynapple_basis_transformer(
     n_input = bas._n_input_dimensionality
 
     # pass through transformer
-    bas = TransformerBasis(bas)
+    bas = basis.TransformerBasis(bas)
 
     # concat input
     X = pynapple_concatenate_numpy([tsd[:, None]] * n_input, axis=1)
@@ -3839,7 +3833,7 @@ def test__get_splitter(
 ):
     # skip nested
     if any(
-        bas in (AdditiveBasis, MultiplicativeBasis, TransformerBasis)
+        bas in (AdditiveBasis, MultiplicativeBasis, basis.TransformerBasis)
         for bas in [bas1, bas2, bas3]
     ):
         return
@@ -3996,7 +3990,7 @@ def test__get_splitter_split_by_input(
 ):
     # skip nested
     if any(
-        bas in (AdditiveBasis, MultiplicativeBasis, TransformerBasis)
+        bas in (AdditiveBasis, MultiplicativeBasis, basis.TransformerBasis)
         for bas in [bas1, bas2]
     ):
         return
@@ -4030,7 +4024,7 @@ def test__get_splitter_split_by_input(
 def test_duplicate_keys(bas1, bas2, bas3, class_specific_params):
     # skip nested
     if any(
-        bas in (AdditiveBasis, MultiplicativeBasis, TransformerBasis)
+        bas in (AdditiveBasis, MultiplicativeBasis, basis.TransformerBasis)
         for bas in [bas1, bas2, bas3]
     ):
         return
@@ -4078,7 +4072,7 @@ def test_split_feature_axis(
 ):
     # skip nested
     if any(
-        bas in (AdditiveBasis, MultiplicativeBasis, TransformerBasis)
+        bas in (AdditiveBasis, MultiplicativeBasis, basis.TransformerBasis)
         for bas in [bas1, bas2]
     ):
         return

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -132,7 +132,7 @@ def test_all_basis_are_tested() -> None:
         ("evaluate_on_grid", "The number of points in the uniformly spaced grid"),
         (
             "compute_features",
-            "Apply the basis transformation to the input data",
+            "Apply the basis transformation to the input data|Convolve basis functions with input time series",
         ),
         (
             "split_by_feature",

--- a/tests/test_identifiability_constraints.py
+++ b/tests/test_identifiability_constraints.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from nemos.basis.basis import BSplineBasis, RaisedCosineBasisLinear
+from nemos.basis.basis import EvalBSpline, ConvBSpline, EvalRaisedCosineLinear
 from nemos.identifiability_constraints import (
     _WARN_FLOAT32_MESSAGE,
     _find_drop_column,
@@ -92,20 +92,20 @@ def test_apply_identifiability_constraints_add_constant(add_intercept, expected_
 @pytest.mark.parametrize(
     "basis, input_shape, output_shape, expected_columns",
     [
-        (RaisedCosineBasisLinear(10, width=4), (50,), (50, 10), jnp.arange(10)),
+        (EvalRaisedCosineLinear(10, width=4), (50,), (50, 10), jnp.arange(10)),
         (
-            BSplineBasis(5) + BSplineBasis(6),
+            EvalBSpline(5) + EvalBSpline(6),
             (20,),
             (20, 9),
             jnp.array([1, 2, 3, 4, 6, 7, 8, 9, 10]),
         ),
         (
-            BSplineBasis(5, mode="conv", window_size=10) + BSplineBasis(6),
+            ConvBSpline(5, window_size=10) + EvalBSpline(6),
             (20,),
             (20, 10),
             jnp.array([0, 1, 2, 3, 4, 6, 7, 8, 9, 10]),
         ),
-        (BSplineBasis(5), (10,), (10, 4), jnp.arange(1, 5)),
+        (EvalBSpline(5), (10,), (10, 4), jnp.arange(1, 5)),
     ],
 )
 def test_apply_identifiability_constraints_by_basis_component(
@@ -207,7 +207,7 @@ def test_apply_constraint_with_invalid(invalid_entries):
 )
 def test_apply_constraint_by_basis_with_invalid(invalid_entries):
     """Test if the matrix retains its dtype after applying constraints."""
-    basis = BSplineBasis(5)
+    basis = EvalBSpline(5)
     x = basis.compute_features(
         np.random.randn(
             10,

--- a/tests/test_identifiability_constraints.py
+++ b/tests/test_identifiability_constraints.py
@@ -215,7 +215,7 @@ def test_apply_constraint_by_basis_with_invalid(invalid_entries):
     )
     # add invalid
     x[:2, 2] = invalid_entries
-    constrained_x, kept_cols = apply_identifiability_constraints(x)
+    constrained_x, kept_cols = apply_identifiability_constraints(x, warn_if_float32=False)
     assert jnp.array_equal(kept_cols, jnp.arange(1, 5))
     assert constrained_x.shape[0] == x.shape[0]
     assert jnp.all(jnp.isnan(constrained_x[:2]))

--- a/tests/test_identifiability_constraints.py
+++ b/tests/test_identifiability_constraints.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from nemos.basis.basis import ConvBSpline, EvalBSpline, EvalRaisedCosineLinear
+from nemos.basis.basis import BSplineConv, BSplineEval, RaisedCosineLinearEval
 from nemos.identifiability_constraints import (
     _WARN_FLOAT32_MESSAGE,
     _find_drop_column,
@@ -92,20 +92,20 @@ def test_apply_identifiability_constraints_add_constant(add_intercept, expected_
 @pytest.mark.parametrize(
     "basis, input_shape, output_shape, expected_columns",
     [
-        (EvalRaisedCosineLinear(10, width=4), (50,), (50, 10), jnp.arange(10)),
+        (RaisedCosineLinearEval(10, width=4), (50,), (50, 10), jnp.arange(10)),
         (
-            EvalBSpline(5) + EvalBSpline(6),
+            BSplineEval(5) + BSplineEval(6),
             (20,),
             (20, 9),
             jnp.array([1, 2, 3, 4, 6, 7, 8, 9, 10]),
         ),
         (
-            ConvBSpline(5, window_size=10) + EvalBSpline(6),
+            BSplineConv(5, window_size=10) + BSplineEval(6),
             (20,),
             (20, 10),
             jnp.array([0, 1, 2, 3, 4, 6, 7, 8, 9, 10]),
         ),
-        (EvalBSpline(5), (10,), (10, 4), jnp.arange(1, 5)),
+        (BSplineEval(5), (10,), (10, 4), jnp.arange(1, 5)),
     ],
 )
 def test_apply_identifiability_constraints_by_basis_component(
@@ -207,7 +207,7 @@ def test_apply_constraint_with_invalid(invalid_entries):
 )
 def test_apply_constraint_by_basis_with_invalid(invalid_entries):
     """Test if the matrix retains its dtype after applying constraints."""
-    basis = EvalBSpline(5)
+    basis = BSplineEval(5)
     x = basis.compute_features(
         np.random.randn(
             10,

--- a/tests/test_identifiability_constraints.py
+++ b/tests/test_identifiability_constraints.py
@@ -215,7 +215,9 @@ def test_apply_constraint_by_basis_with_invalid(invalid_entries):
     )
     # add invalid
     x[:2, 2] = invalid_entries
-    constrained_x, kept_cols = apply_identifiability_constraints(x, warn_if_float32=False)
+    constrained_x, kept_cols = apply_identifiability_constraints(
+        x, warn_if_float32=False
+    )
     assert jnp.array_equal(kept_cols, jnp.arange(1, 5))
     assert constrained_x.shape[0] == x.shape[0]
     assert jnp.all(jnp.isnan(constrained_x[:2]))

--- a/tests/test_identifiability_constraints.py
+++ b/tests/test_identifiability_constraints.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from nemos.basis.basis import EvalBSpline, ConvBSpline, EvalRaisedCosineLinear
+from nemos.basis.basis import ConvBSpline, EvalBSpline, EvalRaisedCosineLinear
 from nemos.identifiability_constraints import (
     _WARN_FLOAT32_MESSAGE,
     _find_drop_column,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,7 +6,7 @@ from sklearn import pipeline
 from sklearn.model_selection import GridSearchCV
 
 from nemos import basis
-from nemos.basis._basis import TransformerBasis
+from nemos.basis._transformer_basis import TransformerBasis
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,11 +12,11 @@ from nemos.basis._transformer_basis import TransformerBasis
 @pytest.mark.parametrize(
     "bas",
     [
-        basis.EvalMSpline(5),
-        basis.EvalBSpline(5),
-        basis.EvalCyclicBSpline(5),
-        basis.EvalOrthExponential(5, decay_rates=np.arange(1, 6)),
-        basis.EvalRaisedCosineLinear(5),
+        basis.MSplineEval(5),
+        basis.BSplineEval(5),
+        basis.CyclicBSplineEval(5),
+        basis.OrthExponentialEval(5, decay_rates=np.arange(1, 6)),
+        basis.RaisedCosineLinearEval(5),
     ],
 )
 def test_sklearn_transformer_pipeline(bas, poissonGLM_model_instantiation):
@@ -30,11 +30,11 @@ def test_sklearn_transformer_pipeline(bas, poissonGLM_model_instantiation):
 @pytest.mark.parametrize(
     "bas",
     [
-        basis.EvalMSpline(5),
-        basis.EvalBSpline(5),
-        basis.EvalCyclicBSpline(5),
-        basis.EvalRaisedCosineLinear(5),
-        basis.EvalRaisedCosineLog(5),
+        basis.MSplineEval(5),
+        basis.BSplineEval(5),
+        basis.CyclicBSplineEval(5),
+        basis.RaisedCosineLinearEval(5),
+        basis.RaisedCosineLogEval(5),
     ],
 )
 def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
@@ -49,11 +49,11 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
 @pytest.mark.parametrize(
     "bas",
     [
-        basis.EvalMSpline(5),
-        basis.EvalBSpline(5),
-        basis.EvalCyclicBSpline(5),
-        basis.EvalRaisedCosineLinear(5),
-        basis.EvalRaisedCosineLog(5),
+        basis.MSplineEval(5),
+        basis.BSplineEval(5),
+        basis.CyclicBSplineEval(5),
+        basis.RaisedCosineLinearEval(5),
+        basis.RaisedCosineLogEval(5),
     ],
 )
 def test_sklearn_transformer_pipeline_cv_multiprocess(
@@ -74,11 +74,11 @@ def test_sklearn_transformer_pipeline_cv_multiprocess(
 @pytest.mark.parametrize(
     "bas_cls",
     [
-        basis.EvalMSpline,
-        basis.EvalMSpline,
-        basis.EvalCyclicBSpline,
-        basis.EvalRaisedCosineLinear,
-        basis.EvalRaisedCosineLog,
+        basis.MSplineEval,
+        basis.MSplineEval,
+        basis.CyclicBSplineEval,
+        basis.RaisedCosineLinearEval,
+        basis.RaisedCosineLogEval,
     ],
 )
 def test_sklearn_transformer_pipeline_cv_directly_over_basis(
@@ -95,11 +95,11 @@ def test_sklearn_transformer_pipeline_cv_directly_over_basis(
 @pytest.mark.parametrize(
     "bas_cls",
     [
-        basis.EvalMSpline,
-        basis.EvalMSpline,
-        basis.EvalCyclicBSpline,
-        basis.EvalRaisedCosineLinear,
-        basis.EvalRaisedCosineLog,
+        basis.MSplineEval,
+        basis.MSplineEval,
+        basis.CyclicBSplineEval,
+        basis.RaisedCosineLinearEval,
+        basis.RaisedCosineLogEval,
     ],
 )
 def test_sklearn_transformer_pipeline_cv_illegal_combination(
@@ -123,35 +123,35 @@ def test_sklearn_transformer_pipeline_cv_illegal_combination(
 @pytest.mark.parametrize(
     "bas, expected_nans",
     [
-        (basis.EvalMSpline(5), 0),
-        (basis.EvalBSpline(5), 0),
-        (basis.EvalCyclicBSpline(5), 0),
-        (basis.EvalOrthExponential(5, decay_rates=np.arange(1, 6)), 0),
-        (basis.EvalRaisedCosineLinear(5), 0),
-        (basis.EvalRaisedCosineLog(5), 0),
-        (basis.EvalRaisedCosineLog(5) + basis.EvalMSpline(5), 0),
-        (basis.ConvMSpline(5, window_size=3), 6),
-        (basis.ConvBSpline(5, window_size=3), 6),
+        (basis.MSplineEval(5), 0),
+        (basis.BSplineEval(5), 0),
+        (basis.CyclicBSplineEval(5), 0),
+        (basis.OrthExponentialEval(5, decay_rates=np.arange(1, 6)), 0),
+        (basis.RaisedCosineLinearEval(5), 0),
+        (basis.RaisedCosineLogEval(5), 0),
+        (basis.RaisedCosineLogEval(5) + basis.MSplineEval(5), 0),
+        (basis.MSplineConv(5, window_size=3), 6),
+        (basis.BSplineConv(5, window_size=3), 6),
         (
-            basis.ConvCyclicBSpline(
+            basis.CyclicBSplineConv(
                 5, window_size=3, conv_kwargs=dict(predictor_causality="acausal")
             ),
             4,
         ),
         (
-            basis.ConvOrthExponential(
+            basis.OrthExponentialConv(
                 5, decay_rates=np.linspace(0.1, 1, 5), window_size=7
             ),
             14,
         ),
-        (basis.ConvRaisedCosineLinear(5, window_size=3), 6),
-        (basis.ConvRaisedCosineLog(5, window_size=3), 6),
+        (basis.RaisedCosineLinearConv(5, window_size=3), 6),
+        (basis.RaisedCosineLogConv(5, window_size=3), 6),
         (
-            basis.ConvRaisedCosineLog(5, window_size=3) + basis.EvalMSpline(5),
+            basis.RaisedCosineLogConv(5, window_size=3) + basis.MSplineEval(5),
             6,
         ),
         (
-            basis.ConvRaisedCosineLog(5, window_size=3) * basis.EvalMSpline(5),
+            basis.RaisedCosineLogConv(5, window_size=3) * basis.MSplineEval(5),
             6,
         ),
     ],

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,21 +6,21 @@ from sklearn import pipeline
 from sklearn.model_selection import GridSearchCV
 
 from nemos import basis
-
+from nemos.basis._basis import TransformerBasis
 
 @pytest.mark.parametrize(
     "bas",
     [
         basis.EvalMSpline(5),
-        basis.BSplineBasis(5),
-        basis.CyclicBSplineBasis(5),
-        basis.OrthExponentialBasis(5, decay_rates=np.arange(1, 6)),
-        basis.RaisedCosineBasisLinear(5),
+        basis.EvalBSpline(5),
+        basis.EvalCyclicBSpline(5),
+        basis.EvalOrthExponential(5, decay_rates=np.arange(1, 6)),
+        basis.EvalRaisedCosineLinear(5),
     ],
 )
 def test_sklearn_transformer_pipeline(bas, poissonGLM_model_instantiation):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    bas = basis.TransformerBasis(bas)
+    bas = TransformerBasis(bas)
     pipe = pipeline.Pipeline([("eval", bas), ("fit", model)])
 
     pipe.fit(X[:, : bas._basis._n_input_dimensionality] ** 2, y)
@@ -30,15 +30,15 @@ def test_sklearn_transformer_pipeline(bas, poissonGLM_model_instantiation):
     "bas",
     [
         basis.EvalMSpline(5),
-        basis.BSplineBasis(5),
-        basis.CyclicBSplineBasis(5),
-        basis.RaisedCosineBasisLinear(5),
-        basis.RaisedCosineBasisLog(5),
+        basis.EvalBSpline(5),
+        basis.EvalCyclicBSpline(5),
+        basis.EvalRaisedCosineLinear(5),
+        basis.EvalRaisedCosineLog(5),
     ],
 )
 def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    bas = basis.TransformerBasis(bas)
+    bas = TransformerBasis(bas)
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
     param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
     gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, error_score="raise")
@@ -49,17 +49,17 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
     "bas",
     [
         basis.EvalMSpline(5),
-        basis.BSplineBasis(5),
-        basis.CyclicBSplineBasis(5),
-        basis.RaisedCosineBasisLinear(5),
-        basis.RaisedCosineBasisLog(5),
+        basis.EvalBSpline(5),
+        basis.EvalCyclicBSpline(5),
+        basis.EvalRaisedCosineLinear(5),
+        basis.EvalRaisedCosineLog(5),
     ],
 )
 def test_sklearn_transformer_pipeline_cv_multiprocess(
     bas, poissonGLM_model_instantiation
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    bas = basis.TransformerBasis(bas)
+    bas = TransformerBasis(bas)
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
     param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
     gridsearch = GridSearchCV(
@@ -74,17 +74,17 @@ def test_sklearn_transformer_pipeline_cv_multiprocess(
     "bas_cls",
     [
         basis.EvalMSpline,
-        basis.BSplineBasis,
-        basis.CyclicBSplineBasis,
-        basis.RaisedCosineBasisLinear,
-        basis.RaisedCosineBasisLog,
+        basis.EvalMSpline,
+        basis.EvalCyclicBSpline,
+        basis.EvalRaisedCosineLinear,
+        basis.EvalRaisedCosineLog,
     ],
 )
 def test_sklearn_transformer_pipeline_cv_directly_over_basis(
     bas_cls, poissonGLM_model_instantiation
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    bas = basis.TransformerBasis(bas_cls(5))
+    bas = TransformerBasis(bas_cls(5))
     pipe = pipeline.Pipeline([("transformerbasis", bas), ("fit", model)])
     param_grid = dict(transformerbasis___basis=(bas_cls(5), bas_cls(10), bas_cls(20)))
     gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, error_score="raise")
@@ -95,17 +95,17 @@ def test_sklearn_transformer_pipeline_cv_directly_over_basis(
     "bas_cls",
     [
         basis.EvalMSpline,
-        basis.BSplineBasis,
-        basis.CyclicBSplineBasis,
-        basis.RaisedCosineBasisLinear,
-        basis.RaisedCosineBasisLog,
+        basis.EvalMSpline,
+        basis.EvalCyclicBSpline,
+        basis.EvalRaisedCosineLinear,
+        basis.EvalRaisedCosineLog,
     ],
 )
 def test_sklearn_transformer_pipeline_cv_illegal_combination(
     bas_cls, poissonGLM_model_instantiation
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    bas = basis.TransformerBasis(bas_cls(5))
+    bas = TransformerBasis(bas_cls(5))
     pipe = pipeline.Pipeline([("transformerbasis", bas), ("fit", model)])
     param_grid = dict(
         transformerbasis___basis=(bas_cls(5), bas_cls(10), bas_cls(20)),
@@ -123,35 +123,35 @@ def test_sklearn_transformer_pipeline_cv_illegal_combination(
     "bas, expected_nans",
     [
         (basis.EvalMSpline(5), 0),
-        (basis.BSplineBasis(5), 0),
-        (basis.CyclicBSplineBasis(5), 0),
-        (basis.OrthExponentialBasis(5, decay_rates=np.arange(1, 6)), 0),
-        (basis.RaisedCosineBasisLinear(5), 0),
-        (basis.RaisedCosineBasisLog(5), 0),
-        (basis.RaisedCosineBasisLog(5) + basis.EvalMSpline(5), 0),
-        (basis.EvalMSpline(5, mode="conv", window_size=3), 6),
-        (basis.BSplineBasis(5, mode="conv", window_size=3), 6),
+        (basis.EvalBSpline(5), 0),
+        (basis.EvalCyclicBSpline(5), 0),
+        (basis.EvalOrthExponential(5, decay_rates=np.arange(1, 6)), 0),
+        (basis.EvalRaisedCosineLinear(5), 0),
+        (basis.EvalRaisedCosineLog(5), 0),
+        (basis.EvalRaisedCosineLog(5) + basis.EvalMSpline(5), 0),
+        (basis.ConvMSpline(5, window_size=3), 6),
+        (basis.ConvBSpline(5, window_size=3), 6),
         (
-            basis.CyclicBSplineBasis(
-                5, mode="conv", window_size=3, predictor_causality="acausal"
+            basis.ConvCyclicBSpline(
+                5, window_size=3, conv_kwargs=dict(predictor_causality="acausal")
             ),
             4,
         ),
         (
-            basis.OrthExponentialBasis(
-                5, decay_rates=np.linspace(0.1, 1, 5), mode="conv", window_size=7
+            basis.ConvOrthExponential(
+                5, decay_rates=np.linspace(0.1, 1, 5), window_size=7
             ),
             14,
         ),
-        (basis.RaisedCosineBasisLinear(5, mode="conv", window_size=3), 6),
-        (basis.RaisedCosineBasisLog(5, mode="conv", window_size=3), 6),
+        (basis.ConvRaisedCosineLinear(5, window_size=3), 6),
+        (basis.ConvRaisedCosineLog(5, window_size=3), 6),
         (
-            basis.RaisedCosineBasisLog(5, mode="conv", window_size=3)
+            basis.ConvRaisedCosineLog(5, window_size=3)
             + basis.EvalMSpline(5),
             6,
         ),
         (
-            basis.RaisedCosineBasisLog(5, mode="conv", window_size=3)
+            basis.ConvRaisedCosineLog(5, window_size=3)
             * basis.EvalMSpline(5),
             6,
         ),
@@ -166,7 +166,7 @@ def test_sklearn_transformer_pipeline_pynapple(
     ep = nap.IntervalSet(start=[0, 20.5], end=[20, X.shape[0]])
     X_nap = nap.TsdFrame(t=np.arange(X.shape[0]), d=X, time_support=ep)
     y_nap = nap.Tsd(t=np.arange(X.shape[0]), d=y, time_support=ep)
-    bas = basis.TransformerBasis(bas)
+    bas = TransformerBasis(bas)
     # fit a pipeline & predict from pynapple
     pipe = pipeline.Pipeline([("eval", bas), ("fit", model)])
     pipe.fit(X_nap[:, : bas._basis._n_input_dimensionality] ** 2, y_nap)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,6 +8,7 @@ from sklearn.model_selection import GridSearchCV
 from nemos import basis
 from nemos.basis._basis import TransformerBasis
 
+
 @pytest.mark.parametrize(
     "bas",
     [
@@ -146,13 +147,11 @@ def test_sklearn_transformer_pipeline_cv_illegal_combination(
         (basis.ConvRaisedCosineLinear(5, window_size=3), 6),
         (basis.ConvRaisedCosineLog(5, window_size=3), 6),
         (
-            basis.ConvRaisedCosineLog(5, window_size=3)
-            + basis.EvalMSpline(5),
+            basis.ConvRaisedCosineLog(5, window_size=3) + basis.EvalMSpline(5),
             6,
         ),
         (
-            basis.ConvRaisedCosineLog(5, window_size=3)
-            * basis.EvalMSpline(5),
+            basis.ConvRaisedCosineLog(5, window_size=3) * basis.EvalMSpline(5),
             6,
         ),
     ],

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -213,7 +213,7 @@ def test_least_square_correctness():
     # set up problem dimensionality
     ws, n_neurons_receiver, n_neurons_sender, n_basis_funcs = 100, 1, 2, 10
     # evaluate a basis
-    _, eval_basis = basis.EvalRaisedCosineLinear(n_basis_funcs).evaluate_on_grid(ws)
+    _, eval_basis = basis.RaisedCosineLinearEval(n_basis_funcs).evaluate_on_grid(ws)
     # generate random weights to define filters
     weights = np.random.normal(
         size=(n_neurons_receiver, n_neurons_sender, n_basis_funcs)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -213,7 +213,7 @@ def test_least_square_correctness():
     # set up problem dimensionality
     ws, n_neurons_receiver, n_neurons_sender, n_basis_funcs = 100, 1, 2, 10
     # evaluate a basis
-    _, eval_basis = basis.RaisedCosineBasisLog(n_basis_funcs).evaluate_on_grid(ws)
+    _, eval_basis = basis.EvalRaisedCosineLinear(n_basis_funcs).evaluate_on_grid(ws)
     # generate random weights to define filters
     weights = np.random.normal(
         size=(n_neurons_receiver, n_neurons_sender, n_basis_funcs)


### PR DESCRIPTION
# Basis API Refactor

## Overview
This is a massive PR that revisiting the basis API. In particular it addresses #266 and notably breaks backwards compatibility.

The goal was to simplify the initialization and control logic of the basis class. Before this PR the classes for basis could operate in two modes: convolving the input with basis elements, or maps non-linearly the input through the basis, in what was originally `mode="conv"` and `mode="eval"` respectively. The issue with this approach is that the initialization presented a number of parameters that only applied to one modality (bounds applies to "eval", "window_size" to "conv"). 

To design our classes we had to operate under the following constraints:

1. **scikit-learn API:** this means that all the retrievable and settable attributes must be defined at initialization for `get_params` and `set_params` to work. The name of the attribute must match the name of the parameter defined at initialization.
2. **Basis composition:** all basis must have a single `compute_features` method, so that we can guarantee that complex basis (addition and multiplication of a number of bases) can call recursively the `compute_features` method of the components. Also, this makes it easier to map a basis to a scikit-learn transformer.

These requirements are incompatible with the original plan of having a single class with default mode of operation, and a method for switching mode. The reason is that if the default initialization requires only a subset of the parameters, the other mode of operation will not respect the scikit-learn API (having parameter set outside the initialization). 

We settled for 2 distinct classes for each operational mode, at the cost of doubling the size of the basis API. The pros of this approach is: simpler initialization, and improved modularity of the implementation.

## Module Refactor Details
The `basis` module has been moved from to a folder with the following scripts:
- `_basis.py`: contains the `Basis` abstract class, `AdditiveBasis` and `MultiplicativeBasis` (classes that cannot/should not be initialized directly).
- `_basis_mixin.py`: contains `ConvBasisMixin` and `EvalBasisMixin`, implementing all mode specific methods and the parameter control logic. `BasisTransformerMixin` equips basis with the `to_transformer` method. These classes cannot be initialized on their own but add the mode of operation and extra methods to concrete sublcasses of `Basis`.
- `_transformer_basis.py`: Implements the transformer API for basis.
- `basis.py`: contains all the concrete basis for both modality. Each basis name starts with either `Conv` and `Eval` depending on the mixin super-class.
_ `_raised_cosine_basis.py`, `_decaying_exponential.py`, `_spline_basis.py` implements the `__call__` method and check logic that is specific to each basis type.


