### PR TITLE
fix split_by_feature bug

### DIFF
--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -694,7 +694,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         # Apply the slicing using the custom leaf function
         out = jax.tree_util.tree_map(lambda sl: x[sl], index_dict, is_leaf=is_leaf)
 
-        # reshape the arrays to spilt by n_basis_input_
+        # reshape the arrays to match input shapes
         reshaped_out = dict()
         for items, bas in zip(out.items(), self):
             key, val = items

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -1010,8 +1010,8 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
         >>> split_coef = basis.split_by_feature(model.coef_, axis=0)
         >>> for feature, coef in split_coef.items():
         ...     print(f"{feature}: shape {coef.shape}")
-        feature_1: shape (1, 5)
-        feature_2: shape (1, 6)
+        feature_1: shape (5,)
+        feature_2: shape (6,)
 
         """
         return super().split_by_feature(x, axis=axis)
@@ -1358,7 +1358,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
         >>> split_features = basis_mul.split_by_feature(X_multi, axis=1)
         >>> for feature, arr in split_features.items():
         ...     print(f"{feature}: shape {arr.shape}")
-        (one_input * two_inputs): shape (20, 2, 60)
+        (one_input * two_inputs): shape (20, 2, 30)
 
         """
         return super().split_by_feature(x, axis=axis)

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -175,14 +175,6 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         return self._label
 
     @property
-    def n_basis_input_(self) -> tuple | None:
-        """Number of expected inputs.
-
-        The number of inputs ``compute_feature`` expects.
-        """
-        return self._input_shape_product
-
-    @property
     def n_basis_funcs(self):
         """Number of basis functions."""
         return self._n_basis_funcs

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -960,10 +960,9 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
             - **Values**: Sub-arrays corresponding to each component. Each sub-array has the shape:
 
             .. math::
-                (..., n_i, b_i, ...)
+                (..., n_i1, n_i2,..,n_im, b_i, ...)
 
-            - ``n_i``: The number of inputs processed by the i-th basis component.
-            - ``n_i``: The number of inputs processed by the i-th basis component.
+            - ``(n_samples, n_i1, n_i2,..,n_im)``: is the shape of the input to the i-th basis.
             - ``b_i``: The number of basis functions for the i-th basis component.
 
             These sub-arrays are reshaped along the specified axis, with all other dimensions

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import abc
 import copy
-from functools import wraps
 from collections import OrderedDict
+from functools import wraps
 from typing import Callable, Generator, Literal, Optional, Tuple, Union
 
 import jax

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -994,8 +994,8 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
         >>> split_features = basis.split_by_feature(X, axis=1)
         >>> for feature, arr in split_features.items():
         ...     print(f"{feature}: shape {arr.shape}")
-        feature_1: shape (20, 1, 5)
-        feature_2: shape (20, 1, 6)
+        feature_1: shape (20, 5)
+        feature_2: shape (20, 6)
         >>> # If one of the basis components accepts multiple inputs, the resulting dictionary will be nested:
         >>> multi_input_basis = BSplineConv(n_basis_funcs=6, window_size=10,
         ... label="multi_input")
@@ -1358,7 +1358,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
         >>> split_features = basis_mul.split_by_feature(X_multi, axis=1)
         >>> for feature, arr in split_features.items():
         ...     print(f"{feature}: shape {arr.shape}")
-        (one_input * two_inputs): shape (20, 1, 60)
+        (one_input * two_inputs): shape (20, 2, 60)
 
         """
         return super().split_by_feature(x, axis=axis)

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import abc
 import copy
 from functools import wraps
+from collections import OrderedDict
 from typing import Callable, Generator, Literal, Optional, Tuple, Union
 
 import jax
@@ -534,7 +535,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         n_inputs: Optional[tuple] = None,
         start_slice: Optional[int] = None,
         split_by_input: bool = True,
-    ) -> Tuple[dict, int]:
+    ) -> Tuple[OrderedDict, int]:
         """
         Calculate and return the slicing for features based on the input structure.
 
@@ -586,7 +587,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
 
     def _get_default_slicing(
         self, split_by_input: bool, start_slice: int
-    ) -> Tuple[dict, int]:
+    ) -> Tuple[OrderedDict, int]:
         """Handle default slicing logic."""
         if split_by_input:
             # should we remove this option?
@@ -609,7 +610,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
                 self.label: slice(start_slice, start_slice + self.n_output_features)
             }
         start_slice += self.n_output_features
-        return split_dict, start_slice
+        return OrderedDict(split_dict), start_slice
 
     def split_by_feature(
         self,

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -10,7 +10,6 @@ from itertools import chain
 from typing import TYPE_CHECKING, Generator, Optional, Tuple, Union
 
 import numpy as np
-from decorator import decorator
 from numpy.typing import ArrayLike, NDArray
 from pynapple import Tsd, TsdFrame, TsdTensor
 
@@ -21,9 +20,7 @@ if TYPE_CHECKING:
     from ._basis import Basis
 
 
-def set_input_shape_state(
-    states: Tuple[str] = ("_input_shape_product", )
-):
+def set_input_shape_state(states: Tuple[str] = ("_input_shape_product",)):
     """
     Decorator to preserve input shape-related attributes during method execution.
 
@@ -157,7 +154,7 @@ class AtomicBasisMixin:
         n_inputs = (int(np.prod(shape)),)
 
         self._input_shape_ = [shape]
-        
+
         # total number of input time series. Used  for slicing and reshaping
         self._input_shape_product = n_inputs
         return self
@@ -608,7 +605,7 @@ class CompositeBasisMixin:
             self.basis2._iterate_over_components(),
         )
 
-    @set_input_shape_state(states=("_input_shape_product", ))
+    @set_input_shape_state(states=("_input_shape_product",))
     def __sklearn_clone__(self) -> Basis:
         """Clone the basis while preserving attributes related to input shapes.
 

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -87,7 +87,7 @@ class TransformerBasis:
 
     @staticmethod
     def _check_initialized(basis):
-        if basis._n_basis_input_ is None:
+        if basis._input_shape_product is None:
             raise RuntimeError(
                 "Cannot apply TransformerBasis: the provided basis has no defined input shape. "
                 "Please call `set_input_shape` before calling `fit`, `transform`, or "
@@ -113,11 +113,11 @@ class TransformerBasis:
         """
         n_samples = X.shape[0]
         out = (
-            np.reshape(X[:, cc : cc + n_input], (n_samples, *bas._input_shape_))
+            np.reshape(X[:, cc : cc + n_input], (n_samples, *bas.input_shape))
             for i, (bas, n_input) in enumerate(
-                zip(self._iterate_over_components(), self._n_basis_input_)
+                zip(self._iterate_over_components(), self._input_shape_product)
             )
-            for cc in [sum(self._n_basis_input_[:i])]
+            for cc in [sum(self._input_shape_product[:i])]
         )
         return out
 

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -493,7 +493,7 @@ class TransformerBasis:
                 f"X must be 2-dimensional, shape (n_samples, n_features). The provided X has shape {X.shape} instead."
             )
 
-        if X.shape[1] != sum(self.n_basis_input_):
+        if X.shape[1] != sum(self._input_shape_product):
             raise ValueError(
                 f"Input mismatch: expected {sum(self._input_shape_product)} inputs, but got {X.shape[1]} columns in X.\n"
                 "To modify the required number of inputs, call `set_input_shape` before using `fit` or `fit_transform`."

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -495,7 +495,7 @@ class TransformerBasis:
 
         if X.shape[1] != sum(self.n_basis_input_):
             raise ValueError(
-                f"Input mismatch: expected {sum(self.n_basis_input_)} inputs, but got {X.shape[1]} columns in X.\n"
+                f"Input mismatch: expected {sum(self._input_shape_product)} inputs, but got {X.shape[1]} columns in X.\n"
                 "To modify the required number of inputs, call `set_input_shape` before using `fit` or `fit_transform`."
             )
 

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -495,8 +495,9 @@ class TransformerBasis:
 
         if X.shape[1] != sum(self._input_shape_product):
             raise ValueError(
-                f"Input mismatch: expected {sum(self._input_shape_product)} inputs, but got {X.shape[1]} columns in X.\n"
-                "To modify the required number of inputs, call `set_input_shape` before using `fit` or `fit_transform`."
+                f"Input mismatch: expected {sum(self._input_shape_product)} inputs, but got {X.shape[1]} "
+                f"columns in X.\nTo modify the required number of inputs, call `set_input_shape` before using "
+                f"`fit` or `fit_transform`."
             )
 
         if y is not None and y.shape[0] != X.shape[0]:

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -113,7 +113,7 @@ class BSplineEval(EvalBasisMixin, BSplineBasis):
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        one_input, shape (20, 1, 6)
+        one_input, shape (20, 6)
 
         """
         return super().split_by_feature(x, axis=axis)
@@ -402,7 +402,7 @@ class CyclicBSplineEval(EvalBasisMixin, CyclicBSplineBasis):
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        one_input, shape (20, 1, 6)
+        one_input, shape (20, 6)
 
         """
         return super().split_by_feature(x, axis=axis)
@@ -707,7 +707,7 @@ class MSplineEval(EvalBasisMixin, MSplineBasis):
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        one_input, shape (20, 1, 6)
+        one_input, shape (20, 6)
 
         """
         return MSplineBasis.split_by_feature(self, x, axis=axis)
@@ -1056,7 +1056,7 @@ class RaisedCosineLinearEval(EvalBasisMixin, RaisedCosineBasisLinear):
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        one_input, shape (20, 1, 6)
+        one_input, shape (20, 6)
 
         """
         return super().split_by_feature(x, axis=axis)
@@ -1347,7 +1347,7 @@ class RaisedCosineLogEval(EvalBasisMixin, RaisedCosineBasisLog):
         >>> split_features_multi = basis.split_by_feature(X, axis=1)
         >>> for feature, sub_dict in split_features_multi.items():
         ...        print(f"{feature}, shape {sub_dict.shape}")
-        one_input, shape (20, 1, 6)
+        one_input, shape (20, 6)
 
         """
         return super().split_by_feature(x, axis=axis)
@@ -1640,7 +1640,7 @@ class OrthExponentialEval(EvalBasisMixin, OrthExponentialBasis):
         >>> split_features = basis.split_by_feature(X, axis=1)
         >>> for feature, arr in split_features.items():
         ...     print(f"{feature}: shape {arr.shape}")
-        feature: shape (20, 1, 5)
+        feature: shape (20, 5)
 
         """
         return super().split_by_feature(x, axis=axis)
@@ -1912,7 +1912,7 @@ class IdentityEval(EvalBasisMixin, IdentityBasis):
         >>> split_features = basis.split_by_feature(X, axis=1)
         >>> for feature, arr in split_features.items():
         ...     print(f"{feature}: shape {arr.shape}")
-        feature: shape (20, 1, 1)
+        feature: shape (20, 1)
 
         """
         return super().split_by_feature(x, axis=axis)
@@ -2031,7 +2031,7 @@ class HistoryConv(ConvBasisMixin, HistoryBasis):
         >>> split_features = basis.split_by_feature(X, axis=1)
         >>> for feature, arr in split_features.items():
         ...     print(f"{feature}: shape {arr.shape}")
-        feature: shape (20, 1, 5)
+        feature: shape (20, 5)
 
         """
         return super().split_by_feature(x, axis=axis)

--- a/src/nemos/identifiability_constraints.py
+++ b/src/nemos/identifiability_constraints.py
@@ -312,10 +312,16 @@ def apply_identifiability_constraints_by_basis_component(
     # convolutions on multiple signals (as for counts TsdFrames)
     splits_x = basis.split_by_feature(feature_matrix)
 
+    # list the arrays
+    split_x = jax.tree_util.tree_leaves(splits_x)
+    # add dim if needed (the dim is at least 2, (n_samples, n_basis)
+    split_x = [x if x.ndim > 2 else x[:, None] for x in split_x]
+    # flatten over inputs
+    split_x = [x.reshape(x.shape[0], -1, x.shape[-1]) for x in split_x]
     # list leaves and unwrap over input dimension. Additive components have shapes:
     # (n_samples, n_inputs, n_basis_funcs)
     split_by_input_x = [
-        x[:, k] for x in jax.tree_util.tree_leaves(splits_x) for k in range(x.shape[1])
+        x[:, k] for x in split_x for k in range(x.shape[1])
     ]
 
     apply_identifiability = partial(

--- a/src/nemos/identifiability_constraints.py
+++ b/src/nemos/identifiability_constraints.py
@@ -320,9 +320,7 @@ def apply_identifiability_constraints_by_basis_component(
     split_x = [x.reshape(x.shape[0], -1, x.shape[-1]) for x in split_x]
     # list leaves and unwrap over input dimension. Additive components have shapes:
     # (n_samples, n_inputs, n_basis_funcs)
-    split_by_input_x = [
-        x[:, k] for x in split_x for k in range(x.shape[1])
-    ]
+    split_by_input_x = [x[:, k] for x in split_x for k in range(x.shape[1])]
 
     apply_identifiability = partial(
         apply_identifiability_constraints,

--- a/src/nemos/type_casting.py
+++ b/src/nemos/type_casting.py
@@ -126,8 +126,8 @@ def _has_same_time_axis(*args, **kwargs) -> bool:
         return True
 
     # get first pynapple
-    is_nap = list(is_pynapple_tsd(x) for x in flat_tree)
-    time = [x.t for i, x in enumerate(flat_tree) if is_nap[i]]
+    is_nap = (is_pynapple_tsd(x) for x in flat_tree)
+    time = [x.t for x, bl in zip(flat_tree, is_nap) if bl]
 
     # check time samples are close (using pynapple precision)
     return _check_all_close(time)
@@ -158,8 +158,8 @@ def _has_same_support(*args, **kwargs):
         return True
 
     # get first pynapple
-    is_nap = list(is_pynapple_tsd(x) for x in flat_tree)
-    time_support = [x.time_support.values for i, x in enumerate(flat_tree) if is_nap[i]]
+    is_nap = (is_pynapple_tsd(x) for x in flat_tree)
+    time_support = [x.time_support.values for x, bl in zip(flat_tree, is_nap) if bl]
 
     # check starts and ends are close (using pynapple precision)
     return _check_all_close(time_support)

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -542,7 +542,7 @@ class TestSharedMethods:
         assert bas.n_basis_input_ is None
         bas.compute_features(np.random.randn(20, n_input))
         assert bas.n_basis_input_ == (n_input,)
-        assert bas._n_basis_input_ == (n_input,)
+        assert bas._input_shape_product == (n_input,)
 
     @pytest.mark.parametrize(
         "bounds, samples, nan_idx, mn, mx",
@@ -4003,7 +4003,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
-    def test_n_basis_input_(self, n_basis_input1, n_basis_input2):
+    def test_input_shape_product(self, n_basis_input1, n_basis_input2):
         bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
         bas2 = basis.BSplineConv(10, window_size=10)
         bas_prod = bas1 * bas2
@@ -4516,18 +4516,18 @@ def test_multi_epoch_pynapple_basis_transformer(
             "__add__",
             "__add__",
             lambda bas1, bas2, bas3: {
-                "1": slice(0, bas1._n_basis_input_[0] * bas1.n_basis_funcs),
+                "1": slice(0, bas1._input_shape_product[0] * bas1.n_basis_funcs),
                 "2": slice(
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs,
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs
-                    + bas2._n_basis_input_[0] * bas2.n_basis_funcs,
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs,
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs
+                    + bas2._input_shape_product[0] * bas2.n_basis_funcs,
                 ),
                 "3": slice(
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs
-                    + bas2._n_basis_input_[0] * bas2.n_basis_funcs,
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs
-                    + bas2._n_basis_input_[0] * bas2.n_basis_funcs
-                    + bas3._n_basis_input_[0] * bas3.n_basis_funcs,
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs
+                    + bas2._input_shape_product[0] * bas2.n_basis_funcs,
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs
+                    + bas2._input_shape_product[0] * bas2.n_basis_funcs
+                    + bas3._input_shape_product[0] * bas3.n_basis_funcs,
                 ),
             },
         ),
@@ -4535,13 +4535,13 @@ def test_multi_epoch_pynapple_basis_transformer(
             "__add__",
             "__mul__",
             lambda bas1, bas2, bas3: {
-                "1": slice(0, bas1._n_basis_input_[0] * bas1.n_basis_funcs),
+                "1": slice(0, bas1._input_shape_product[0] * bas1.n_basis_funcs),
                 "(2 * 3)": slice(
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs,
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs
-                    + bas2._n_basis_input_[0]
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs,
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs
+                    + bas2._input_shape_product[0]
                     * bas2.n_basis_funcs
-                    * bas3._n_basis_input_[0]
+                    * bas3._input_shape_product[0]
                     * bas3.n_basis_funcs,
                 ),
             },
@@ -4553,11 +4553,11 @@ def test_multi_epoch_pynapple_basis_transformer(
                 # note that it doesn't respect algebra order but execute right to left (first add then multiplies)
                 "(1 * (2 + 3))": slice(
                     0,
-                    bas1._n_basis_input_[0]
+                    bas1._input_shape_product[0]
                     * bas1.n_basis_funcs
                     * (
-                        bas2._n_basis_input_[0] * bas2.n_basis_funcs
-                        + bas3._n_basis_input_[0] * bas3.n_basis_funcs
+                        bas2._input_shape_product[0] * bas2.n_basis_funcs
+                        + bas3._input_shape_product[0] * bas3.n_basis_funcs
                     ),
                 ),
             },
@@ -4568,11 +4568,11 @@ def test_multi_epoch_pynapple_basis_transformer(
             lambda bas1, bas2, bas3: {
                 "(1 * (2 * 3))": slice(
                     0,
-                    bas1._n_basis_input_[0]
+                    bas1._input_shape_product[0]
                     * bas1.n_basis_funcs
-                    * bas2._n_basis_input_[0]
+                    * bas2._input_shape_product[0]
                     * bas2.n_basis_funcs
-                    * bas3._n_basis_input_[0]
+                    * bas3._input_shape_product[0]
                     * bas3.n_basis_funcs,
                 ),
             },
@@ -4635,11 +4635,11 @@ def test__get_splitter(
             1,
             1,
             lambda bas1, bas2: {
-                "1": slice(0, bas1._n_basis_input_[0] * bas1.n_basis_funcs),
+                "1": slice(0, bas1._input_shape_product[0] * bas1.n_basis_funcs),
                 "2": slice(
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs,
-                    bas1._n_basis_input_[0] * bas1.n_basis_funcs
-                    + bas2._n_basis_input_[0] * bas2.n_basis_funcs,
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs,
+                    bas1._input_shape_product[0] * bas1.n_basis_funcs
+                    + bas2._input_shape_product[0] * bas2.n_basis_funcs,
                 ),
             },
         ),
@@ -4650,9 +4650,9 @@ def test__get_splitter(
             lambda bas1, bas2: {
                 "(1 * 2)": slice(
                     0,
-                    bas1._n_basis_input_[0]
+                    bas1._input_shape_product[0]
                     * bas1.n_basis_funcs
-                    * bas2._n_basis_input_[0]
+                    * bas2._input_shape_product[0]
                     * bas2.n_basis_funcs,
                 )
             },
@@ -4677,7 +4677,7 @@ def test__get_splitter(
             1,
             lambda bas1, bas2: {
                 "(1 * 2)": slice(
-                    0, bas1._n_basis_input_[0] * bas1.n_basis_funcs * bas2.n_basis_funcs
+                    0, bas1._input_shape_product[0] * bas1.n_basis_funcs * bas2.n_basis_funcs
                 )
             },
         ),
@@ -4704,7 +4704,7 @@ def test__get_splitter(
             2,
             lambda bas1, bas2: {
                 "(1 * 2)": slice(
-                    0, bas2._n_basis_input_[0] * bas1.n_basis_funcs * bas2.n_basis_funcs
+                    0, bas2._input_shape_product[0] * bas1.n_basis_funcs * bas2.n_basis_funcs
                 )
             },
         ),

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -304,6 +304,20 @@ def test_expected_output_split_by_feature(basis_instance, super_class):
         np.testing.assert_array_equal(xx[~nans], x[~nans])
 
 
+@pytest.mark.parametrize("composite_op", ["add", "multiply"])
+def test_composite_split_by_feature(composite_op):
+    # by default, jax was sorting the dict we use in split_by_feature for the labels to
+    # be alphabetical. thus, if the additive basis was made up of basis objects whose
+    # n_basis_input values were different AND whose alphabetical sorting was the
+    # different from their order in initialization, it would fail
+    if composite_op == "add":
+        comp_basis = basis.RaisedCosineLogEval(10) + basis.CyclicBSplineEval(5)
+    elif composite_op == "multiply":
+        comp_basis = basis.RaisedCosineLogEval(10) * basis.CyclicBSplineEval(5)
+    X = comp_basis.compute_features(np.random.rand(100, 10), np.random.rand(100, 1))
+    comp_basis.split_by_feature(X)
+
+
 @pytest.mark.parametrize(
     "cls",
     [

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -465,7 +465,6 @@ class TestSharedMethods:
         [
             ("label", None),
             ("label", "label"),
-            ("n_basis_input_", 1),
             ("n_output_features", 5),
         ],
     )
@@ -574,9 +573,9 @@ class TestSharedMethods:
             window_size=10,
             **extra_decay_rates(cls["conv"], 5),
         )
-        assert bas.n_basis_input_ is None
+        assert bas._input_shape_product is None
         bas.compute_features(np.random.randn(20, n_input))
-        assert bas.n_basis_input_ == (n_input,)
+        assert bas._input_shape_product == (n_input,)
         assert bas._input_shape_product == (n_input,)
 
     @pytest.mark.parametrize(
@@ -3088,11 +3087,11 @@ class TestAdditiveBasis(CombinedBasis):
         bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
         bas2 = basis.BSplineConv(10, window_size=10)
         bas_add = bas1 + bas2
-        assert bas_add.n_basis_input_ is None
+        assert bas_add._input_shape_product is None
         bas_add.compute_features(
             np.ones((20, n_basis_input1)), np.ones((20, n_basis_input2))
         )
-        assert bas_add.n_basis_input_ == (n_basis_input1, n_basis_input2)
+        assert bas_add._input_shape_product == (n_basis_input1, n_basis_input2)
 
     @pytest.mark.parametrize(
         "n_input, expectation",
@@ -4079,11 +4078,11 @@ class TestMultiplicativeBasis(CombinedBasis):
         bas1 = basis.RaisedCosineLinearConv(10, window_size=10)
         bas2 = basis.BSplineConv(10, window_size=10)
         bas_add = bas1 * bas2
-        assert bas_add.n_basis_input_ is None
+        assert bas_add._input_shape_product is None
         bas_add.compute_features(
             np.ones((20, n_basis_input1)), np.ones((20, n_basis_input2))
         )
-        assert bas_add.n_basis_input_ == (n_basis_input1, n_basis_input2)
+        assert bas_add._input_shape_product == (n_basis_input1, n_basis_input2)
 
     @pytest.mark.parametrize(
         "n_input, expectation",
@@ -4112,7 +4111,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         bas_prod.compute_features(
             np.ones((20, n_basis_input1)), np.ones((20, n_basis_input2))
         )
-        assert bas_prod.n_basis_input_ == (n_basis_input1, n_basis_input2)
+        assert bas_prod._input_shape_product == (n_basis_input1, n_basis_input2)
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -569,7 +569,7 @@ def test_transformer_fit_input_shape_mismatch(
     transformer = bas.set_input_shape(
         *([inp] * bas._n_input_dimensionality)
     ).to_transformer()
-    X = np.random.randn(10, int(sum(bas._n_basis_input_) + delta_input))
+    X = np.random.randn(10, int(sum(bas._input_shape_product) + delta_input))
     with expectation:
         transformer.fit(X)
 
@@ -667,7 +667,7 @@ def test_transformer_fit_transform_input_shape_mismatch(
     transformer = bas.set_input_shape(
         *([inp] * bas._n_input_dimensionality)
     ).to_transformer()
-    X = np.random.randn(10, int(sum(bas._n_basis_input_) + delta_input))
+    X = np.random.randn(10, int(sum(bas._input_shape_product) + delta_input))
     with expectation:
         transformer.fit_transform(X)
 

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -11,12 +11,7 @@ from sklearn.pipeline import Pipeline
 import nemos as nmo
 from nemos import basis
 from nemos._inspect_utils import get_subclass_methods, list_abstract_methods
-from nemos.basis import (
-    AdditiveBasis,
-    HistoryConv,
-    IdentityEval,
-    MultiplicativeBasis,
-)
+from nemos.basis import AdditiveBasis, HistoryConv, IdentityEval, MultiplicativeBasis
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Small bugfix: in `split_by_feature` for the additive basis, jax tree map was sorting the dictionary that was being used to be alphabetical with respect to the labels of `basis1` and `basis2`. Thus, if those two basis objects had different `n_basis_input` values and were passed in using a different order than their alphabetical sorting, `split_by_feature` would fail. This fixes that by using an OrderedDict

It doesn't look like this was an issue for the `MultiplicativeBasis`, but I added that test anyway, let me know if you want me to remove it.