### PR TITLE
PopulationGLM sklearn clone

### DIFF
--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -1618,8 +1618,7 @@ class PopulationGLM(GLM):
         )
 
     def __sklearn_clone__(self) -> GLM:
-        """Clone the PopulationGLM, dropping feature_mask
-        """
+        """Clone the PopulationGLM, dropping feature_mask"""
         params = self.get_params(deep=False)
         params.pop("feature_mask")
         klass = self.__class__(**params)

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -1616,3 +1616,11 @@ class PopulationGLM(GLM):
             )
             + bs
         )
+
+    def __sklearn_clone__(self) -> GLM:
+        """Clone the PopulationGLM, dropping feature_mask
+        """
+        params = self.get_params(deep=False)
+        params.pop("feature_mask")
+        klass = self.__class__(**params)
+        return klass

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -7,9 +7,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import sklearn
 import statsmodels.api as sm
 from pynapple import Tsd, TsdFrame
-import sklearn
 from sklearn.linear_model import GammaRegressor, PoissonRegressor
 from sklearn.model_selection import GridSearchCV
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import statsmodels.api as sm
 from pynapple import Tsd, TsdFrame
+import sklearn
 from sklearn.linear_model import GammaRegressor, PoissonRegressor
 from sklearn.model_selection import GridSearchCV
 
@@ -3569,6 +3570,13 @@ class TestPopulationGLM:
         X, y, model, true_params, firing_rate = gamma_population_GLM_model
         param_grid = {"solver_name": ["BFGS", "GradientDescent"]}
         GridSearchCV(model, param_grid).fit(X, y)
+
+    def test_sklearn_clone(self, poisson_population_GLM_model):
+        X, y, model, true_params, firing_rate = poisson_population_GLM_model
+        model.fit(X, y)
+        cloned = sklearn.clone(model)
+        assert cloned.feature_mask is None, "cloned GLM shouldn't have feature mask!"
+        assert model.feature_mask is not None, "fit GLM should have feature mask!"
 
     @pytest.mark.parametrize(
         "mask, expectation",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -46,6 +46,20 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
     gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 
 
+def test_sklearn_cv_clone(poissonGLM_model_instantiation):
+    X, y, model, _, _ = poissonGLM_model_instantiation
+    bas = basis.CyclicBSplineEval(5)
+    bas = TransformerBasis(bas).set_input_shape(*([1] * bas._n_input_dimensionality))
+    pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
+    # if feature_mask isn't dropped by the cloning done by gridsearch cv, this will
+    # error, because the shape of feature_mask doesn't match the shape of the output of
+    # transformer basis with different number of basis funcs
+    pipe.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
+    param_grid = dict(basis__n_basis_funcs=(4, 8))
+    gridsearch = GridSearchCV(pipe, param_grid=param_grid, cv=3, error_score="raise")
+    gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
+
+
 @pytest.mark.parametrize(
     "bas",
     [

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -46,8 +46,8 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
     gridsearch.fit(X[:, : bas._n_input_dimensionality] ** 2, y)
 
 
-def test_sklearn_cv_clone(poissonGLM_model_instantiation):
-    X, y, model, _, _ = poissonGLM_model_instantiation
+def test_sklearn_cv_clone(poisson_population_GLM_model):
+    X, y, model, _, _ = poisson_population_GLM_model
     bas = basis.CyclicBSplineEval(5)
     bas = TransformerBasis(bas).set_input_shape(*([1] * bas._n_input_dimensionality))
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])


### PR DESCRIPTION
This PR adds a `__sklearn_clone__` method to  PopulationGLM, which removes the `feature_mask` attribute for reinitializing. This avoids a bug where if `PopulationGLM` was part of a pipeline with transformer basis, was fit (so that `feature_mask` was initialized) and then cross-validation was attempted over the number of basis funcs, errors would be raised:

```python
x = np.random.rand(100)
y = np.random.rand(2)
bas = CyclicBSplineEval(5)
bas.compute_features(x)
bas = TransformerBasis(bas)
pipe = Pipeline([("basis", bas), ("model", nmo.glm.PopulationGLM())])
pipe.fit(x, y)
cv = GridSearchCV(pipe, {"basis__n_basis_funcs": [2, 5]}, cv=3)
cv.fit(x, y)
```