### PR TITLE
set version dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,5 @@ docs/data/
 # rst generated files
 docs/stubs
 
-
+# created automatically by setuptools.scm, don't track
+src/nemos/version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ exclude = '''
     | buck-out
     | build
     | dist
+    | version.py
     | examples))'''
 
 # Configure isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemos"
-version = "0.2.0"
+dynamic = ["version"]
 authors = [{name = "nemos authors"}]
 description = "NEural MOdelS, a statistical modeling framework for neuroscience."
 readme = "README.md"
@@ -37,6 +37,10 @@ dependencies = [
 where = ["src"]     # The directory where package modules are located
 include = ["nemos"] # The specific package(s) to include in the distribution
 
+[tool.setuptools_scm]
+write_to = "src/nemos/version.py"
+version_scheme = 'python-simplified-semver'
+local_scheme = 'no-local-version'
 
 # Define optional dependencies for the project
 [project.optional-dependencies]

--- a/src/nemos/__init__.py
+++ b/src/nemos/__init__.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from .version import version as __version__
-
 from . import (
     basis,
     convolve,
@@ -17,3 +15,4 @@ from . import (
     type_casting,
     utils,
 )
+from .version import version as __version__

--- a/src/nemos/__init__.py
+++ b/src/nemos/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-__version__ = "0.2.0"
+from .version import version as __version__
 
 from . import (
     basis,


### PR DESCRIPTION
With this change, `setuptools_scm` will set the installed package version dynamically, based on the git tag. This is the same way I handle it for plenoptic.