### PR TITLE
Speed up recursions

### DIFF
--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -549,9 +549,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
 
         if exponent <= 0:
             raise ValueError("Basis exponent should be a non-negative integer!")
-        elif not all(
-                b._has_default_label for _, b in generate_basis_label_pair(self)
-        ):
+        elif not all(b._has_default_label for _, b in generate_basis_label_pair(self)):
             raise ValueError(
                 "Cannot calculate the power of a basis including a user-defined labels "
                 "(because then they won't be unique). Set labels after exponentiation."

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import abc
 import copy
 from collections import OrderedDict
+from contextlib import nullcontext
 from copy import deepcopy
 from functools import wraps
-from contextlib import nullcontext
-from typing import Any, Callable, Generator, List, Literal, Optional, Tuple, Union
+from typing import Callable, Generator, List, Literal, Optional, Tuple, Union
 
 import jax
 import numpy as np
@@ -529,7 +529,9 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
                     "Basis multiplication error. Integer multiplicative factor must be positive, "
                     f"{other} provided instead."
                 )
-            elif not all(b._has_default_label for _, b in generate_basis_label_pair(self)):
+            elif not all(
+                b._has_default_label for _, b in generate_basis_label_pair(self)
+            ):
                 raise ValueError(
                     "Cannot multiply by an integer a basis including a user-defined labels."
                 )
@@ -829,6 +831,7 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
         basis2=RaisedCosineLogEval(n_basis_funcs=100, width=2.0, time_scaling=50.0, enforce_decay_to_zero=True),
     )
     """
+
     def __init__(
         self, basis1: Basis, basis2: Basis, label: Optional[str] = None
     ) -> None:
@@ -1268,6 +1271,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
         basis2=RaisedCosineLogEval(n_basis_funcs=100, width=2.0, time_scaling=50.0, enforce_decay_to_zero=True),
     )
     """
+
     def __init__(
         self, basis1: Basis, basis2: Basis, label: Optional[str] = None
     ) -> None:

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -508,7 +508,8 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         if isinstance(other, int):
             if other <= 0:
                 raise ValueError(
-                    f"Basis multiplication error. Integer multiplicative factor must be positive, {other} provided instead."
+                    "Basis multiplication error. Integer multiplicative factor must be positive, "
+                    f"{other} provided instead."
                 )
             return _bisect_mul(self, other)
         if not isinstance(other, Basis):
@@ -788,8 +789,12 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
     )
     """
 
+    _shallow_copy: bool = False
+
     def __init__(self, basis1: Basis, basis2: Basis) -> None:
-        CompositeBasisMixin.__init__(self, basis1, basis2)
+        CompositeBasisMixin.__init__(
+            self, basis1, basis2, shallow_copy=self._shallow_copy
+        )
         Basis.__init__(self, mode="composite")
         self._label = "(" + basis1.label + " + " + basis2.label + ")"
 
@@ -1222,8 +1227,12 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
     )
     """
 
+    _shallow_copy: bool = False
+
     def __init__(self, basis1: Basis, basis2: Basis) -> None:
-        CompositeBasisMixin.__init__(self, basis1, basis2)
+        CompositeBasisMixin.__init__(
+            self, basis1, basis2, shallow_copy=self._shallow_copy
+        )
         Basis.__init__(self, mode="composite")
         self._label = "(" + basis1.label + " * " + basis2.label + ")"
         self._n_input_dimensionality = (

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -471,10 +471,10 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         """
         return AdditiveBasis(self, other)
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: Basis | int):
         return self.__mul__(other)
 
-    def __mul__(self, other: Basis) -> MultiplicativeBasis:
+    def __mul__(self, other: Basis | int) -> MultiplicativeBasis:
         """
         Multiply two Basis objects together.
 

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -503,7 +503,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
             add = AdditiveBasis(self, self)
             with add._set_shallow_copy_temporarily(True):
                 for _ in range(2, other):
-                    add = AdditiveBasis(add, deepcopy(self))
+                    add += deepcopy(self)
             return add
 
         if not isinstance(other, Basis):

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -471,6 +471,9 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         """
         return AdditiveBasis(self, other)
 
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
     def __mul__(self, other: Basis) -> MultiplicativeBasis:
         """
         Multiply two Basis objects together.

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -485,6 +485,15 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         :
             The resulting Basis object.
         """
+        if isinstance(other, int):
+            def add(base, mul):
+                if mul == 1:
+                    return base  # Base case
+                half = add(base, mul // 2)
+                sum = half + half  # Less deep copying
+                return sum + base if mul % 2 else sum
+            return add(self, other)
+
         return MultiplicativeBasis(self, other)
 
     def __pow__(self, exponent: int) -> MultiplicativeBasis:

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -68,31 +68,34 @@ def remap_parameters(method):
 
 
 def _bisect_mul(base: Basis, mul: int):
-    """Speed up adding n basis of the same type"""
+    """Speed up adding n basis of the same type
+
+    Achieve substantial speed-up minimizing the additions and
+    deep-copy operations.
+    """
     if mul == 1:
         return deepcopy(base)  # Base case
     half = _bisect_mul(base, mul // 2)
     context = getattr(half, "_set_shallow_copy_temporarily", nullcontext)
     with context(True):
-        if context is nullcontext:
-            addition = half + deepcopy(half)
-        else:
-            addition = half + deepcopy(half)
+        addition = half + deepcopy(half)
     with addition._set_shallow_copy_temporarily(True):
         addition = addition + deepcopy(base) if mul % 2 else addition
     return addition
 
 
 def _bisect_power(base: Basis, expon: int):
+    """Speed up multiplying n basis of the same type.
+
+    Achieve substantial speed-up minimizing the multiplication and
+    deep-copy operations.
+    """
     if expon == 1:
         return deepcopy(base)  # Base case
     squared = _bisect_power(base, expon // 2)
     context = getattr(squared, "_set_shallow_copy_temporarily", nullcontext)
     with context(True):
-        if context is nullcontext:
-            squared = squared * deepcopy(squared)
-        else:
-            squared = squared * deepcopy(squared)
+        squared = squared * deepcopy(squared)
     with squared._set_shallow_copy_temporarily(True):
         squared = squared * deepcopy(base) if expon % 2 else squared
     return squared

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -79,8 +79,9 @@ def _bisect_mul(base: Basis, mul: int):
     context = getattr(half, "_set_shallow_copy_temporarily", nullcontext)
     with context(True):
         addition = half + deepcopy(half)
-    with addition._set_shallow_copy_temporarily(True):
-        addition = addition + deepcopy(base) if mul % 2 else addition
+    if mul % 2:
+        with addition._set_shallow_copy_temporarily(True):
+            addition = addition + deepcopy(base)
     return addition
 
 
@@ -93,11 +94,14 @@ def _bisect_power(base: Basis, expon: int):
     if expon == 1:
         return deepcopy(base)  # Base case
     squared = _bisect_power(base, expon // 2)
+
     context = getattr(squared, "_set_shallow_copy_temporarily", nullcontext)
+
     with context(True):
         squared = squared * deepcopy(squared)
-    with squared._set_shallow_copy_temporarily(True):
-        squared = squared * deepcopy(base) if expon % 2 else squared
+    if expon % 2:
+        with squared._set_shallow_copy_temporarily(True):
+            squared = squared * deepcopy(base)
     return squared
 
 

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import abc
 import copy
 from collections import OrderedDict
-from contextlib import nullcontext
 from copy import deepcopy
 from functools import wraps
 from typing import Callable, Generator, List, Literal, Optional, Tuple, Union
@@ -501,10 +500,10 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
             if other == 1:
                 return deepcopy(self)
 
-            add = deepcopy(self) + deepcopy(self)
-            for _ in range(2, other):
-                with add._set_shallow_copy_temporarily(True):
-                    add = add + deepcopy(self)
+            add = AdditiveBasis(self, self)
+            with add._set_shallow_copy_temporarily(True):
+                for _ in range(2, other):
+                    add = AdditiveBasis(add, deepcopy(self))
             return add
 
         if not isinstance(other, Basis):
@@ -546,12 +545,11 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         if exponent == 1:
             return deepcopy(self)
 
-        mul = deepcopy(self) * deepcopy(self)
-        for _ in range(2, exponent):
-            with mul._set_shallow_copy_temporarily(True):
-                mul = mul * deepcopy(self)
+        mul = MultiplicativeBasis(self, self)
+        with mul._set_shallow_copy_temporarily(True):
+            for _ in range(2, exponent):
+                mul = MultiplicativeBasis(mul, deepcopy(self))
         return mul
-
 
     def __repr__(self):
         return format_repr(self)

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -502,7 +502,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
             if other == 1:
                 # __sklearn_clone__ reset the parent to None in case bas.basis1 * 1
                 # (deepcopy would not)
-                copy_ = getattr(self, "__sklearn_clone__", deepcopy)
+                copy_ = getattr(self.__class__, "__sklearn_clone__", deepcopy)
                 bas = copy_(self)
 
                 # if deepcopy was called (custom basis used in composition)
@@ -564,7 +564,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         if exponent == 1:
             # __sklearn_clone__ reset the parent to None in case bas.basis1 ** 1
             # (deepcopy would not)
-            copy_ = getattr(self, "__sklearn_clone__", deepcopy)
+            copy_ = getattr(self.__class__, "__sklearn_clone__", deepcopy)
             bas = copy_(self)
 
             # if deepcopy was called (custom basis used in composition)

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -548,7 +548,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         mul = MultiplicativeBasis(self, self)
         with mul._set_shallow_copy_temporarily(True):
             for _ in range(2, exponent):
-                mul = MultiplicativeBasis(mul, deepcopy(self))
+                mul *= deepcopy(self)
         return mul
 
     def __repr__(self):

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -703,6 +703,10 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
                     "Basis multiplication error. Integer multiplicative factor must be positive, "
                     f"{other} provided instead."
                 )
+            elif not all(b._has_default_label for _, b in generate_basis_label_pair(self)):
+                raise ValueError(
+                    "Cannot multiply by an integer a basis including a user-defined labels."
+                )
             return _bisect_mul(self, other)
         if not isinstance(other, Basis):
             raise TypeError(

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -516,10 +516,14 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         if exponent <= 0:
             raise ValueError("Exponent should be a non-negative integer!")
 
-        result = self
-        for _ in range(exponent - 1):
-            result = result * self
-        return result
+        def power(base, exp):
+            if exp == 1:
+                return base  # Base case
+            half = power(base, exp // 2)
+            squared = half * half  # Less deep copying
+            return squared * base if exp % 2 else squared
+
+        return power(self, exponent)
 
     def __repr__(self):
         return format_repr(self)

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -494,7 +494,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
                 b._has_default_label for _, b in generate_basis_label_pair(self)
             ):
                 raise ValueError(
-                    "Cannot multiply by an integer a basis including a user-defined labels."
+                    "Cannot multiply by an integer a basis including a user-defined labels (because then they won't be unique). Set labels after multiplication."
                 )
             # default case
             if other == 1:

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -549,6 +549,13 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
 
         if exponent <= 0:
             raise ValueError("Basis exponent should be a non-negative integer!")
+        elif not all(
+                b._has_default_label for _, b in generate_basis_label_pair(self)
+        ):
+            raise ValueError(
+                "Cannot calculate the power of a basis including a user-defined labels "
+                "(because then they won't be unique). Set labels after exponentiation."
+            )
 
         # default case
         if exponent == 1:

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -789,11 +789,9 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
     )
     """
 
-    _shallow_copy: bool = False
-
     def __init__(self, basis1: Basis, basis2: Basis) -> None:
         CompositeBasisMixin.__init__(
-            self, basis1, basis2, shallow_copy=self._shallow_copy
+            self, basis1, basis2,
         )
         Basis.__init__(self, mode="composite")
         self._label = "(" + basis1.label + " + " + basis2.label + ")"
@@ -1227,11 +1225,9 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
     )
     """
 
-    _shallow_copy: bool = False
-
     def __init__(self, basis1: Basis, basis2: Basis) -> None:
         CompositeBasisMixin.__init__(
-            self, basis1, basis2, shallow_copy=self._shallow_copy
+            self, basis1, basis2,
         )
         Basis.__init__(self, mode="composite")
         self._label = "(" + basis1.label + " * " + basis2.label + ")"

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -500,10 +500,15 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
                 )
             # default case
             if other == 1:
-                bas = deepcopy(self)
-                # reset parent
-                # takes care of case: bas.basis1 * 1
-                bas._parent = None
+                # __sklearn_clone__ reset the parent to None in case bas.basis1 * 1
+                # (deepcopy would not)
+                copy_ = getattr(self, "__sklearn_clone__", deepcopy)
+                bas = copy_(self)
+
+                # if deepcopy was called (custom basis used in composition)
+                # reset _parent if it exists and is not None
+                if hasattr(bas, "_parent") and bas._parent is not None:
+                    bas._parent = None
                 _recompute_all_default_labels(bas)
                 return bas
 
@@ -557,10 +562,16 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
 
         # default case
         if exponent == 1:
-            bas = deepcopy(self)
-            # reset parent
-            # takes care of case: bas.basis1 * 1
-            bas._parent = None
+            # __sklearn_clone__ reset the parent to None in case bas.basis1 ** 1
+            # (deepcopy would not)
+            copy_ = getattr(self, "__sklearn_clone__", deepcopy)
+            bas = copy_(self)
+
+            # if deepcopy was called (custom basis used in composition)
+            # reset _parent if it exists and it is not None
+            if hasattr(bas, "_parent") and bas._parent is not None:
+                bas._parent = None
+
             _recompute_all_default_labels(bas)
             return bas
 

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -671,8 +671,9 @@ class CompositeBasisMixin:
             self.basis1 = copy.deepcopy(basis1)
             self.basis2 = copy.deepcopy(basis2)
         else:
-            self.basis1 = basis1
-            self.basis2 = basis2
+            # skip checks and shallow copy
+            self._basis1 = basis1
+            self._basis2 = basis2
 
         # set parents
         self.basis1._parent = self
@@ -760,7 +761,7 @@ class CompositeBasisMixin:
 
     def _input_shape_update(self):
         # if all bases where set, then set input for composition.
-        set_bases = [s is not None for s in self.input_shape]
+        set_bases = (s is not None for s in self.input_shape)
 
         if all(set_bases):
             # pass down the input shapes

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -595,7 +595,7 @@ class CompositeBasisMixin:
         # deep copy to avoid changes directly to the 1d basis to be reflected
         # in the composite basis.
 
-        if not self._shallow_copy:
+        if not self.__class__._shallow_copy:
             self.basis1 = copy.deepcopy(basis1)
             self.basis2 = copy.deepcopy(basis2)
         else:
@@ -861,7 +861,7 @@ class CompositeBasisMixin:
         )
 
     @contextmanager
-    def _set_shallow_copy_temporarily(self, value):
+    def _set_shallow_copy(self, value):
         """Context manger for setting the shallow copy flag in a thread safe way."""
         old_value = self.__class__._shallow_copy
         self.__class__._shallow_copy = value
@@ -886,7 +886,7 @@ class CompositeBasisMixin:
         before the klass definition, and reset to False after cloning.
         """
 
-        with self._set_shallow_copy_temporarily(True):
+        with self._set_shallow_copy(True):
             # clone recursively
             basis1 = self.basis1.__sklearn_clone__()
             basis2 = self.basis2.__sklearn_clone__()

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -642,7 +642,7 @@ class CompositeBasisMixin:
         # shallow copy init
         klass = self.__class__(basis1, basis2)
 
-        # restore the deep copy default behavior.
+        # restore the deep copy default behavior only at the top level call
         self.__class__._shallow_copy = shallow_copy
         klass.__class__._shallow_copy = shallow_copy
         return klass

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -862,7 +862,7 @@ class CompositeBasisMixin:
 
     @contextmanager
     def _set_shallow_copy(self, value):
-        """Context manger for setting the shallow copy flag in a thread safe way."""
+        """Context manager for setting the shallow copy flag in a thread safe way."""
         old_value = self.__class__._shallow_copy
         self.__class__._shallow_copy = value
         try:

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import abc
-from contextlib import contextmanager
 import copy
 import inspect
 import re
+from contextlib import contextmanager
 from functools import wraps
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Generator, Literal, Optional, Tuple, Union
@@ -585,6 +585,7 @@ class CompositeBasisMixin:
     Add overwrites concrete methods or defines abstract methods for composite basis
     (AdditiveBasis and MultiplicativeBasis).
     """
+
     _shallow_copy: bool = False
 
     def __init__(self, basis1: Basis, basis2: Basis, label: Optional[str] = None):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -49,9 +49,7 @@ def extra_decay_rates(cls, n_basis):
 
 
 def filter_attributes(obj, exclude_keys):
-    return {
-        key: val for key, val in obj.__dict__.items() if key not in exclude_keys
-    }
+    return {key: val for key, val in obj.__dict__.items() if key not in exclude_keys}
 
 
 def compare_basis(b1, b2):
@@ -69,12 +67,8 @@ def compare_basis(b1, b2):
         compare_basis(b1.basis1, b2.basis1)
         compare_basis(b1.basis2, b2.basis2)
         # add all params that are not parent or basis1,basis2
-        d1 = filter_attributes(
-            b1, exclude_keys=["_basis1", "_basis2", "_parent"]
-        )
-        d2 = filter_attributes(
-            b2, exclude_keys=["_basis1", "_basis2", "_parent"]
-        )
+        d1 = filter_attributes(b1, exclude_keys=["_basis1", "_basis2", "_parent"])
+        d2 = filter_attributes(b2, exclude_keys=["_basis1", "_basis2", "_parent"])
         assert d1 == d2
     else:
         decay_rates_b1 = b1.__dict__.get("_decay_rates", -1)
@@ -3742,10 +3736,10 @@ class TestMultiplicativeBasis(CombinedBasis):
         basis_obj = self.instantiate_basis(
             5, bas_cls, basis_class_specific_params, window_size=10
         )
-        _ = basis_obj ** 2
+        _ = basis_obj**2
         basis_obj.label = "x"
         with pytest.raises(ValueError, match="Cannot calculate the power of a basis"):
-            _ = basis_obj ** 2
+            _ = basis_obj**2
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
@@ -4993,7 +4987,10 @@ def test_mul_of_basis_by_int(mul, basis_class, basis_class_specific_params):
             )
             assert np.all(np.isnan(out[~non_nan]))
 
-@pytest.mark.parametrize("basis_class", list_all_basis_classes("Eval") + list_all_basis_classes("Conv"))
+
+@pytest.mark.parametrize(
+    "basis_class", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
+)
 def test_mul_of_basis_from_nested(basis_class, basis_class_specific_params):
     basis_obj = CombinedBasis.instantiate_basis(
         5, basis_class, basis_class_specific_params, window_size=5

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -2457,6 +2457,18 @@ class TestAdditiveBasis(CombinedBasis):
     cls = {"eval": AdditiveBasis, "conv": AdditiveBasis}
 
     @pytest.mark.parametrize(
+        "bas_cls", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
+    )
+    def test_mul_by_int_basis_with_label(self, bas_cls, basis_class_specific_params):
+        basis_obj = self.instantiate_basis(
+            5, bas_cls, basis_class_specific_params, window_size=10
+        )
+        _ = basis_obj * 2
+        basis_obj.label = "x"
+        with pytest.raises(ValueError, match="Cannot multiply by an integer"):
+            _ = basis_obj * 2
+
+    @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
     )
     def test_add_label_using_class_name(self, basis_a, basis_class_specific_params):
@@ -3722,6 +3734,18 @@ class TestAdditiveBasis(CombinedBasis):
 
 class TestMultiplicativeBasis(CombinedBasis):
     cls = {"eval": MultiplicativeBasis, "conv": MultiplicativeBasis}
+
+    @pytest.mark.parametrize(
+        "bas_cls", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
+    )
+    def test_pow_by_int_basis_with_label(self, bas_cls, basis_class_specific_params):
+        basis_obj = self.instantiate_basis(
+            5, bas_cls, basis_class_specific_params, window_size=10
+        )
+        _ = basis_obj ** 2
+        basis_obj.label = "x"
+        with pytest.raises(ValueError, match="Cannot calculate the power of a basis"):
+            _ = basis_obj ** 2
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -16,7 +16,6 @@ import nemos.basis.basis as basis
 import nemos.convolve as convolve
 from nemos.basis import HistoryConv, IdentityEval, TransformerBasis
 from nemos.basis._basis import AdditiveBasis, Basis, MultiplicativeBasis, add_docstring
-
 from nemos.basis._decaying_exponential import OrthExponentialBasis
 from nemos.basis._identity import HistoryBasis, IdentityBasis
 from nemos.basis._raised_cosine_basis import (
@@ -6004,7 +6003,6 @@ def test_composite_basis_repr_wrapping():
     )
     assert out.endswith(
         "        basis2='98': MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='99': MSplineEval(n_basis_funcs=10, order=4),\n)"
-
     )
     assert "    ...\n" in out
 
@@ -6018,6 +6016,7 @@ def test_composite_basis_repr_wrapping():
     )
     assert "    ...\n" in out
 
+
 def test_all_public_importable_bases_equal():
     import nemos.basis
 
@@ -6026,7 +6025,8 @@ def test_all_public_importable_bases_equal():
     # these are all the bases that are imported in the init file
     # Get all classes that are explicitly defined or imported into nemos.basis
     imported_bases = {
-        name for name, obj in inspect.getmembers(nemos.basis, inspect.isclass)
+        name
+        for name, obj in inspect.getmembers(nemos.basis, inspect.isclass)
         if issubclass(obj, nemos.basis._basis.Basis)
     }
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -5988,7 +5988,7 @@ def test_composite_basis_repr_wrapping():
         "MultiplicativeBasis(\n    basis1=MultiplicativeBasis(\n        basis1=MultiplicativeBasis(\n "
     )
     assert out.endswith(
-        "MultiplicativeBasis(\n                        ...\n                    ),\n                ),\n            ),\n            basis2=BSplineEval(n_basis_funcs=10, order=4),\n        ),\n    ),\n)"
+        "BSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2=BSplineEval(n_basis_funcs=10, order=4),\n)"
     )
     assert "    ...\n" in out
 
@@ -6012,7 +6012,7 @@ def test_composite_basis_repr_wrapping():
         "AdditiveBasis(\n    basis1=AdditiveBasis(\n        basis1=AdditiveBasis(\n "
     )
     assert out.endswith(
-        "AdditiveBasis(\n                        ...\n                    ),\n                ),\n            ),\n            basis2=MSplineEval(n_basis_funcs=10, order=4),\n        ),\n    ),\n)"
+        "MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2=MSplineEval(n_basis_funcs=10, order=4),\n)"
     )
     assert "    ...\n" in out
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -4996,9 +4996,47 @@ def test_mul_of_basis_from_nested(basis_class, basis_class_specific_params):
         5, basis_class, basis_class_specific_params, window_size=5
     )
     add = basis_obj * 2
-    b1 = add.basis1 * 2
+    b1 = add.basis1 * 1
     # use deep copy
-    b2 = AdditiveBasis(add.basis1, add.basis1)
+    b2 = add.basis1
+    with pytest.raises(AssertionError):
+        compare_basis(b1, b2)
+    b2._parent = None
+    compare_basis(b1, b2)
+    # nest one more
+    add = basis_obj * 3
+    b1 = add.basis1 * 1
+    # use deep copy
+    b2 = add.basis1
+    with pytest.raises(AssertionError):
+        compare_basis(b1, b2)
+    b2._parent = None
+    compare_basis(b1, b2)
+
+
+@pytest.mark.parametrize(
+    "basis_class", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
+)
+def test_pow_of_basis_from_nested(basis_class, basis_class_specific_params):
+    basis_obj = CombinedBasis.instantiate_basis(
+        5, basis_class, basis_class_specific_params, window_size=5
+    )
+    add = basis_obj * 2
+    b1 = add.basis1**1
+    # use deep copy
+    b2 = add.basis1
+    with pytest.raises(AssertionError):
+        compare_basis(b1, b2)
+    b2._parent = None
+    compare_basis(b1, b2)
+    # nest one more
+    add = basis_obj * 3
+    b1 = add.basis1**1
+    # use deep copy
+    b2 = add.basis1
+    with pytest.raises(AssertionError):
+        compare_basis(b1, b2)
+    b2._parent = None
     compare_basis(b1, b2)
 
 
@@ -6078,7 +6116,7 @@ def test_composite_basis_repr_wrapping():
         "MultiplicativeBasis(\n    basis1=MultiplicativeBasis(\n        basis1=MultiplicativeBasis(\n "
     )
     assert out.endswith(
-        "BSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2=BSplineEval(n_basis_funcs=10, order=4),\n)"
+        "'BSplineEval_98': BSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='BSplineEval_99': BSplineEval(n_basis_funcs=10, order=4),\n)"
     )
     assert "    ...\n" in out
 
@@ -6102,7 +6140,7 @@ def test_composite_basis_repr_wrapping():
         "AdditiveBasis(\n    basis1=AdditiveBasis(\n        basis1=AdditiveBasis(\n "
     )
     assert out.endswith(
-        "MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2=MSplineEval(n_basis_funcs=10, order=4),\n)"
+        "'MSplineEval_98': MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='MSplineEval_99': MSplineEval(n_basis_funcs=10, order=4),\n)"
     )
     assert "    ...\n" in out
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -5913,7 +5913,7 @@ def test_composite_basis_repr_wrapping():
         "MultiplicativeBasis(\n    basis1=MultiplicativeBasis(\n        basis1=MultiplicativeBasis(\n "
     )
     assert out.endswith(
-        "MultiplicativeBasis(\n                        ...\n                    ),\n                ),\n            ),\n            basis2='BSplineEval_99': BSplineEval(n_basis_funcs=10, order=4),\n        ),\n    ),\n)"
+        "MultiplicativeBasis(\n                        ...\n                    ),\n                ),\n            ),\n            basis2=BSplineEval(n_basis_funcs=10, order=4),\n        ),\n    ),\n)"
     )
     assert "    ...\n" in out
 
@@ -5938,6 +5938,6 @@ def test_composite_basis_repr_wrapping():
         "AdditiveBasis(\n    basis1=AdditiveBasis(\n        basis1=AdditiveBasis(\n "
     )
     assert out.endswith(
-        "AdditiveBasis(\n                        ...\n                    ),\n                ),\n            ),\n            basis2='MSplineEval_99': MSplineEval(n_basis_funcs=10, order=4),\n        ),\n    ),\n)"
+        "AdditiveBasis(\n                        ...\n                    ),\n                ),\n            ),\n            basis2=MSplineEval(n_basis_funcs=10, order=4),\n        ),\n    ),\n)"
     )
     assert "    ...\n" in out

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -366,8 +366,8 @@ def test_transformerbasis_multiplication(basis_cls, basis_class_specific_params)
     [
         (2, does_not_raise, None),
         (5, does_not_raise, None),
-        (0.5, TypeError, "Exponent should be an integer"),
-        (-1, ValueError, "Exponent should be a non-negative integer"),
+        (0.5, TypeError, "Basis exponent should be an integer"),
+        (-1, ValueError, "Basis exponent should be a non-negative integer"),
     ],
 )
 def test_transformerbasis_exponentiation(


### PR DESCRIPTION
In this PR:
- New accept integer for `__mul__`: `basis * 3` will be equivalent to `basis + basis+basis`
- Add an `__rmul__` enabling right multiplication`n * basis`
- Improved the efficiency of `__pow__` by bisect multiply (log2(n) multiplication, less deep copy)
- Add a mechanism that do not perform a deep-copy when cloning a bases

**Old clone performance**
```
bas = nmo.basis.BSplineEval(5)**500
%timeit bas.__sklearn_clone__()
2.47 s ± 107 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**New clone performance**
```
bas = nmo.basis.BSplineEval(5)**500
%timeit bas.__sklearn_clone__()
10.9 ms ± 22 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
**Old Power Performance**
```
bas = nmo.basis.BSplineEval(5)
%timeit bas ** 500
2.49 s ± 76.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**New Power Performance**
```
bas = nmo.basis.BSplineEval(5)
%timeit bas ** 500
8.46 ms ± 79.3 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```