### PR TITLE
Dynamic version fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,5 +153,3 @@ docs/data/
 # rst generated files
 docs/stubs
 
-# created automatically by setuptools.scm, don't track
-src/nemos/version.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,11 @@ import nemos
 import sys, os
 from pathlib import Path
 
+from importlib.metadata import version as get_version
+release: str = get_version("nemos")
+# for example take major/minor
+version: str = ".".join(release.split('.')[:3])
+
 sys.path.insert(0, str(Path('..', 'src').resolve()))
 sys.path.insert(0, os.path.abspath('sphinxext'))
 
@@ -17,7 +22,6 @@ sys.path.insert(0, os.path.abspath('sphinxext'))
 project = 'nemos'
 copyright = '2024'
 author = 'E Balzani'
-version = release = nemos.__version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,6 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-import nemos
 import sys, os
 from pathlib import Path
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 from importlib.metadata import version as get_version
 release: str = get_version("nemos")
-# for example take major/minor
+# this will grab major.minor.patch (excluding any .devN afterwards, which should only
+# show up when building locally during development)
 version: str = ".".join(release.split('.')[:3])
 
 sys.path.insert(0, str(Path('..', 'src').resolve()))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,8 @@
 import sys, os
 from pathlib import Path
 
-from importlib.metadata import version as get_version
-release: str = get_version("nemos")
+from importlib.metadata import version
+release: str = version("nemos")
 # this will grab major.minor.patch (excluding any .devN afterwards, which should only
 # show up when building locally during development)
 version: str = ".".join(release.split('.')[:3])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ where = ["src"]     # The directory where package modules are located
 include = ["nemos"] # The specific package(s) to include in the distribution
 
 [tool.setuptools_scm]
-write_to = "src/nemos/version.py"
 version_scheme = 'python-simplified-semver'
 local_scheme = 'no-local-version'
 
@@ -118,7 +117,6 @@ exclude = '''
     | buck-out
     | build
     | dist
-    | version.py
     | examples))'''
 
 # Configure isort

--- a/src/nemos/__init__.py
+++ b/src/nemos/__init__.py
@@ -20,7 +20,7 @@ from . import (
 )
 
 try:
-    __version__ = _get_version("pynapple")
+    __version__ = _get_version("nemos")
 except _PackageNotFoundError:
     # package is not installed
     pass

--- a/src/nemos/__init__.py
+++ b/src/nemos/__init__.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _get_version
+
 from . import (
     basis,
     convolve,
@@ -15,4 +18,9 @@ from . import (
     type_casting,
     utils,
 )
-from .version import version as __version__
+
+try:
+    __version__ = _get_version("pynapple")
+except _PackageNotFoundError:
+    # package is not installed
+    pass


### PR DESCRIPTION
While putting together the equivalent PR for pynapple, I noticed the [setuptools_scm docs](https://setuptools-scm.readthedocs.io/en/latest/usage/#as-cli-tool) (some issues rendering the docs here, search for "at runtime" on that page) suggest *not* writing version to a file anymore, but using `importlib.metadata` instead, which comes from [PEP 566](https://peps.python.org/pep-0566/).

That's what this fix does, as well as following [their instructions](https://setuptools-scm.readthedocs.io/en/latest/usage/#usage-from-sphinx) for sphinx