### PR TITLE
Simplify API basis

### DIFF
--- a/docs/how_to_guide/plot_05_transformer_basis.md
+++ b/docs/how_to_guide/plot_05_transformer_basis.md
@@ -129,6 +129,7 @@ print(inp.shape)
 trans_bas.fit_transform(inp)
     
 ```
+
 ### Defining the Input Shape
 
 To resolve this, we need to explicitly specify the input structure using the `set_input_shape` method. This method tells `TransformerBasis` how to interpret the input columns by storing the number of columns assigned to each basis function.

--- a/docs/how_to_guide/plot_05_transformer_basis.md
+++ b/docs/how_to_guide/plot_05_transformer_basis.md
@@ -103,7 +103,7 @@ At this point, we have an object equipped with the necessary methods. So, all we
 
 ### Understanding Input Shapes in `TransformerBasis`
 
-By default, `TransformerBasis` assumes that inp has one column per input in the composition. In this example, we are composing two one-dimensional basis functions, so `TransformerBasis` expects an input of shape `(n_samples, 2)`.
+By default, `TransformerBasis` assumes that `inp` has one column per input in the composition. In this example, we are composing two one-dimensional basis functions, so `TransformerBasis` expects an input of shape `(n_samples, 2)`.
 
 However, our actual input has shape `(n_samples, 6)`:
 
@@ -117,6 +117,7 @@ This mismatch leads to an error when calling fit_transform:
 
 
 ```{code-cell} ipython3
+:tags: [raises-exception]
 
 # reinstantiate the basis transformer for illustration porpuses
 composite_basis = counts_basis + speed_basis
@@ -125,10 +126,7 @@ trans_bas = (composite_basis).to_transformer()
 inp = np.concatenate([counts, speed[:, np.newaxis]], axis=1)
 print(inp.shape)
 
-try:
-    trans_bas.fit_transform(inp)
-except ValueError as e:
-    print(repr(e))
+trans_bas.fit_transform(inp)
     
 ```
 ### Defining the Input Shape

--- a/docs/how_to_guide/plot_05_transformer_basis.md
+++ b/docs/how_to_guide/plot_05_transformer_basis.md
@@ -99,7 +99,22 @@ As with any `sckit-learn` transformer, the `TransformerBasis` implements `fit`, 
 
 ## Setting up the TransformerBasis
 
-At this point we have an object equipped with the correct methods, so now, all we have to do is concatenate the inputs into a unique array and call `fit_transform`, right? 
+At this point, we have an object equipped with the necessary methods. So, all we need to do is concatenate the inputs into a single array and call fit_transform, right? **Not quite.** The challenge is that the `TransformerBasis` does not automatically know which columns of `inp` should be processed by `count_basis` and which by `speed_basis`.
+
+### Understanding Input Shapes in `TransformerBasis`
+
+By default, `TransformerBasis` assumes that inp has one column per input in the composition. In this example, we are composing two one-dimensional basis functions, so `TransformerBasis` expects an input of shape `(n_samples, 2)`.
+
+However, our actual input has shape `(n_samples, 6)`:
+
+- `counts` consists of **5 columns**
+
+- `speed` consists of **1 column**
+
+- When concatenated, this results in a **6-column input**
+
+This mismatch leads to an error when calling fit_transform:
+
 
 ```{code-cell} ipython3
 
@@ -112,16 +127,15 @@ print(inp.shape)
 
 try:
     trans_bas.fit_transform(inp)
-except RuntimeError as e:
+except ValueError as e:
     print(repr(e))
     
 ```
+### Defining the Input Shape
 
-...Unfortunately, not yet. The problem is that the basis doesn't know which columns of `inp` should be processed by `count_basis` and which by `speed_basis`.
+To resolve this, we need to explicitly specify the input structure using the `set_input_shape` method. This method tells `TransformerBasis` how to interpret the input columns by storing the number of columns assigned to each basis function.
 
-You can provide this information by calling the `set_input_shape` method of the basis. 
-
-This can be called before or after the transformer basis is defined. The method extracts and stores the number of columns for each input. There are multiple ways to call this method:
+You can call set_input_shape before or after defining the transformer basis. There are multiple ways to specify the input shape:
 
 - It directly accepts the input: `composite_basis.set_input_shape(counts, speed)`.
 - If the input is 1D or 2D, it also accepts the number of columns: `composite_basis.set_input_shape(5, 1)`.

--- a/docs/how_to_guide/plot_05_transformer_basis.md
+++ b/docs/how_to_guide/plot_05_transformer_basis.md
@@ -99,11 +99,7 @@ As with any `sckit-learn` transformer, the `TransformerBasis` implements `fit`, 
 
 ## Setting up the TransformerBasis
 
-At this point, we have an object equipped with the necessary methods. So, all we need to do is concatenate the inputs into a single array and call fit_transform, right? **Not quite.** The problem is that the `TransformerBasis` does not automatically know which columns of `inp` should be processed by `count_basis` and which by `speed_basis`.
-
-### Understanding Input Shapes in `TransformerBasis`
-
-By default, `TransformerBasis` assumes that `inp` has one column per input in the composition. In this example, we are composing two one-dimensional basis functions, so `TransformerBasis` expects an input of shape `(n_samples, 2)`.
+At this point, we have an object equipped with the necessary methods. So, all we need to do is concatenate the inputs into a single array and call fit_transform, right? **Not quite.** By default, `TransformerBasis` assumes that `inp` has one column per input in the composition. So in this example, with two one-dimensional basis functions, `TransformerBasis` expects an input of shape `(n_samples, 2)`.
 
 However, our actual input has shape `(n_samples, 6)`:
 
@@ -111,7 +107,7 @@ However, our actual input has shape `(n_samples, 6)`:
 
 - `speed` consists of **1 column**
 
-- When concatenated, this results in a **6-column input**
+When concatenated, this results in a **6-column input**, and our `TransformerBasis` doesn't know how to split those 6 columns.
 
 This mismatch leads to an error when calling fit_transform:
 

--- a/docs/how_to_guide/plot_05_transformer_basis.md
+++ b/docs/how_to_guide/plot_05_transformer_basis.md
@@ -132,6 +132,10 @@ trans_bas.fit_transform(inp)
 
 ### Defining the Input Shape
 
+:::{note}
+If each basis accepts a single column of the input, as in [this example](sklearn-how-to), then the default behavior works fine, and `set_input_shape` does not need to be called.
+:::
+
 To resolve this, we need to explicitly specify the input structure using the `set_input_shape` method. This method tells `TransformerBasis` how to interpret the input columns by storing the number of columns assigned to each basis function.
 
 You can call set_input_shape before or after defining the transformer basis. There are multiple ways to specify the input shape:

--- a/docs/how_to_guide/plot_05_transformer_basis.md
+++ b/docs/how_to_guide/plot_05_transformer_basis.md
@@ -99,7 +99,7 @@ As with any `sckit-learn` transformer, the `TransformerBasis` implements `fit`, 
 
 ## Setting up the TransformerBasis
 
-At this point, we have an object equipped with the necessary methods. So, all we need to do is concatenate the inputs into a single array and call fit_transform, right? **Not quite.** The challenge is that the `TransformerBasis` does not automatically know which columns of `inp` should be processed by `count_basis` and which by `speed_basis`.
+At this point, we have an object equipped with the necessary methods. So, all we need to do is concatenate the inputs into a single array and call fit_transform, right? **Not quite.** The problem is that the `TransformerBasis` does not automatically know which columns of `inp` should be processed by `count_basis` and which by `speed_basis`.
 
 ### Understanding Input Shapes in `TransformerBasis`
 

--- a/docs/how_to_guide/plot_06_sklearn_pipeline_cv_demo.md
+++ b/docs/how_to_guide/plot_06_sklearn_pipeline_cv_demo.md
@@ -161,14 +161,12 @@ trans_bas = nmo.basis.TransformerBasis(bas)
 # equivalent initialization via "to_transformer"
 trans_bas = bas.to_transformer()
 
-# setup the transformer
-trans_bas.set_input_shape(1)
 ```
 
-:::{admonition} Learn More about `TransformerBasis`
-:class: note
+:::{admonition} Additional `TransformerBasis` Setup
+:class: attention
 
-To learn more about `sklearn` transformers and `TransforerBasis`, check out [this note](tansformer-vs-nemos-basis).
+`TransformerBasis` requires an additional setup step when working with multi-dimensional inputs. Learn everything you need to know about using `TransformerBasis` in [this note](tansformer-vs-nemos-basis).
 :::
 
 ### Creating and fitting a pipeline
@@ -181,7 +179,7 @@ pipeline = Pipeline(
     [
         (
             "transformerbasis",
-            nmo.basis.RaisedCosineLinearEval(6).set_input_shape(1).to_transformer(),
+            nmo.basis.RaisedCosineLinearEval(6).to_transformer(),
         ),
         (
             "glm",
@@ -339,7 +337,7 @@ scores = np.zeros((len(regularizer_strength) * len(n_basis_funcs), n_folds))
 coeffs = {}
 
 # initialize basis and model
-basis = nmo.basis.RaisedCosineLinearEval(6).set_input_shape(1)
+basis = nmo.basis.RaisedCosineLinearEval(6)
 basis = nmo.basis.TransformerBasis(basis)
 model = nmo.glm.GLM(regularizer="Ridge")
 
@@ -464,12 +462,12 @@ Here we include `transformerbasis__basis` in the parameter grid to try different
 param_grid = dict(
     glm__regularizer_strength=(0.1, 0.01, 0.001, 1e-6),
     transformerbasis__basis=(
-        nmo.basis.RaisedCosineLinearEval(5).set_input_shape(1),
-        nmo.basis.RaisedCosineLinearEval(10).set_input_shape(1),
-        nmo.basis.RaisedCosineLogEval(5).set_input_shape(1),
-        nmo.basis.RaisedCosineLogEval(10).set_input_shape(1),
-        nmo.basis.MSplineEval(5).set_input_shape(1),
-        nmo.basis.MSplineEval(10).set_input_shape(1),
+        nmo.basis.RaisedCosineLinearEval(5),
+        nmo.basis.RaisedCosineLinearEval(10),
+        nmo.basis.RaisedCosineLogEval(5),
+        nmo.basis.RaisedCosineLogEval(10),
+        nmo.basis.MSplineEval(5),
+        nmo.basis.MSplineEval(10),
     ),
 )
 ```
@@ -551,12 +549,12 @@ param_grid = dict(
     glm__regularizer_strength=(0.1, 0.01, 0.001, 1e-6),
     transformerbasis__n_basis_funcs=(3, 5, 10, 20, 100),
     transformerbasis__basis=(
-        nmo.basis.RaisedCosineLinearEval(5).set_input_shape(1),
-        nmo.basis.RaisedCosineLinearEval(10).set_input_shape(1),
-        nmo.basis.RaisedCosineLogEval(5).set_input_shape(1),
-        nmo.basis.RaisedCosineLogEval(10).set_input_shape(1),
-        nmo.basis.MSplineEval(5).set_input_shape(1),
-        nmo.basis.MSplineEval(10).set_input_shape(1),
+        nmo.basis.RaisedCosineLinearEval(5),
+        nmo.basis.RaisedCosineLinearEval(10),
+        nmo.basis.RaisedCosineLogEval(5),
+        nmo.basis.RaisedCosineLogEval(10),
+        nmo.basis.MSplineEval(5),
+        nmo.basis.MSplineEval(10),
     ),
 )
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -238,7 +238,7 @@ X.shape
 x_multi = np.ones((500, 3))
 
 # convolve a multiple signals
-X_multi = basis.set_input_shape(3).compute_features(x_multi)
+X_multi = basis.compute_features(x_multi)
 X_multi.shape
 
 ```

--- a/src/nemos/_documentation_utils/_myst_nb_glue.py
+++ b/src/nemos/_documentation_utils/_myst_nb_glue.py
@@ -121,7 +121,7 @@ def extract_body_exclude_def_and_return(func):
 @capture_print
 def two_step_convolve_cell_body(basis, inp, out):
     # setup the kernels
-    basis.set_kernel()
+    basis._set_kernel()
     print(f"Kernel shape (window_size, n_basis_funcs): {basis.kernel_.shape}")
 
     # apply the convolution

--- a/src/nemos/_inspect_utils/inspect_utils.py
+++ b/src/nemos/_inspect_utils/inspect_utils.py
@@ -1,6 +1,6 @@
 import abc
 import inspect
-from typing import List, Tuple
+from typing import Callable, List, Tuple
 
 
 def reimplements_method(
@@ -245,3 +245,22 @@ def trim_kwargs(cls: type, kwargs: dict, class_specific_params: dict):
         for key, value in kwargs.items()
         if key in class_specific_params[cls.__name__]
     }
+
+
+def count_params_by_kind(func: Callable, kind: set[inspect.Parameter]):
+    """Count how many parameters of the callable are of the desired kind."""
+    sig = inspect.signature(func)
+    params = sig.parameters.values()
+    return sum(1 for p in params if p.kind in kind)
+
+
+def count_positional_and_var_args(func: Callable):
+    """Count the positional arguments of a callable."""
+    num_positional_args = count_params_by_kind(
+        func,
+        {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD},
+    )
+    num_var_args = count_params_by_kind(
+        func, {inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL}
+    )
+    return num_positional_args, num_var_args

--- a/src/nemos/_inspect_utils/inspect_utils.py
+++ b/src/nemos/_inspect_utils/inspect_utils.py
@@ -248,7 +248,24 @@ def trim_kwargs(cls: type, kwargs: dict, class_specific_params: dict):
 
 
 def count_params_by_kind(func: Callable, kind: set[inspect.Parameter]):
-    """Count how many parameters of the callable are of the desired kind."""
+    """Count how many parameters of the callable are of the desired kind.
+
+    In a callable definition, the parameter kind is one of the following:
+
+    - POSITIONAL_ONLY: A parameter that can only be specified positionally
+      (i.e., it cannot be passed as a keyword argument).
+
+    - POSITIONAL_OR_KEYWORD: A parameter that can be passed either positionally or as a keyword argument.
+
+    - KEYWORD_ONLY: A parameter that must be passed as a keyword argument
+      (appears after `*args` in function signatures).
+
+    - VAR_POSITIONAL: A variable-length positional argument (`*args`),
+      which collects extra positional arguments.
+
+    - VAR_KEYWORD: A variable-length keyword argument (`**kwargs`),
+      which collects extra keyword arguments.
+    """
     sig = inspect.signature(func)
     params = sig.parameters.values()
     return sum(1 for p in params if p.kind in kind)

--- a/src/nemos/_inspect_utils/inspect_utils.py
+++ b/src/nemos/_inspect_utils/inspect_utils.py
@@ -247,7 +247,7 @@ def trim_kwargs(cls: type, kwargs: dict, class_specific_params: dict):
     }
 
 
-def count_params_by_kind(func: Callable, kind: set[inspect.Parameter]):
+def count_params_by_kind(func: Callable, kind: set[inspect.Parameter.kind]):
     """Count how many parameters of the callable are of the desired kind.
 
     In a callable definition, the parameter kind is one of the following:

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -120,18 +120,8 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
     often more compact or interpretable forms. This class provides a template for such
     transformations, with specific implementations defining the actual behavior.
 
-    Parameters
-    ----------
-    mode :
-        The mode of operation. 'eval' for evaluation at sample points,
-        'conv' for convolutional operation.
-
     Raises
     ------
-    ValueError:
-        If ``mode`` is not 'eval' or 'conv'.
-    ValueError:
-        If ``kwargs`` are not None and ``mode =="eval"``.
     ValueError:
         If ``kwargs`` include parameters not recognized or do not have
         default values in ``create_convolutional_predictor``.
@@ -141,11 +131,8 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
 
     def __init__(
         self,
-        mode: Literal["eval", "conv", "composite"] = "eval",
     ) -> None:
         self._n_input_dimensionality = getattr(self, "_n_input_dimensionality", 0)
-
-        self._mode = mode
 
         # specified only after inputs/input shapes are provided
         self._input_shape_product = getattr(self, "_input_shape_product", None)
@@ -185,11 +172,6 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
             self._n_basis_funcs = orig_n_basis
             raise e
 
-    @property
-    def mode(self):
-        """Mode of operation, either ``"conv"`` or ``"eval"``."""
-        return self._mode
-
     @check_transform_input
     def compute_features(
         self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor
@@ -212,8 +194,8 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Returns
         -------
         :
-            Transformed features. In 'eval' mode, it corresponds to the basis functions
-            evaluated at the input samples. In 'conv' mode, it consists of convolved
+            Transformed features. In 'Eval' mode, it corresponds to the basis functions
+            evaluated at the input samples. In 'Conv' mode, it consists of convolved
             input samples with the basis functions. The output shape varies based on
             the subclass and mode.
 
@@ -814,7 +796,7 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
         self, basis1: Basis, basis2: Basis, label: Optional[str] = None
     ) -> None:
         CompositeBasisMixin.__init__(self, basis1, basis2, label=label)
-        Basis.__init__(self, mode="composite")
+        Basis.__init__(self)
 
         # number of input arrays that the basis receives
         self._n_input_dimensionality = (
@@ -1255,7 +1237,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
     ) -> None:
         CompositeBasisMixin.__init__(self, basis1, basis2, label=label)
 
-        Basis.__init__(self, mode="composite")
+        Basis.__init__(self)
         self._n_input_dimensionality = (
             basis1._n_input_dimensionality + basis2._n_input_dimensionality
         )

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -855,7 +855,7 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
     @check_one_dimensional
     def evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
-        Evaluate the basis at the input samples.
+        Evaluate the basis at the sample points.
 
         Parameters
         ----------
@@ -1268,7 +1268,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
     @check_one_dimensional
     def evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
-        Evaluate the basis at the input samples.
+        Evaluate the basis at the sample points.
 
         Parameters
         ----------

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -204,10 +204,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Subclasses should implement how to handle the transformation specific to their
         basis function types and operation modes.
         """
-        kern = getattr(self, "kernel_", None)
-        input_shape = getattr(self, "_input_shape_product", None)
-        if kern is None or input_shape is None:
-            self.setup_basis(*xi)
+        self.setup_basis(*xi)
         self._check_input_shape_consistency(*xi)
         return self._compute_features(*xi)
 

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -382,11 +382,11 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Returns
         -------
         X :
-           Array of shape (n_samples,) containing the equi-spaced sample
+           Array of shape ``(n_samples,)`` containing the equi-spaced sample
            points where we've evaluated the basis.
         basis_funcs :
            Evaluated exponentially decaying basis functions, numerically
-           orthogonalized, shape (n_samples, n_basis_funcs)
+           orthogonalized, shape ``(n_samples, n_basis_funcs)``
         """
         self._check_input_dimensionality(n_samples)
 

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -204,10 +204,11 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Subclasses should implement how to handle the transformation specific to their
         basis function types and operation modes.
         """
-        if self._input_shape_product is None:
-            self.set_input_shape(*xi)
+        kern = getattr(self, "kernel_", None)
+        input_shape = getattr(self, "_input_shape_product", None)
+        if kern is None or input_shape is None:
+            self.setup_basis(*xi)
         self._check_input_shape_consistency(*xi)
-        self._set_input_independent_states()
         return self._compute_features(*xi)
 
     @abc.abstractmethod

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -6,7 +6,7 @@ import copy
 from collections import OrderedDict
 from copy import deepcopy
 from functools import wraps
-from typing import Callable, Generator, List, Literal, Optional, Tuple, Union
+from typing import Callable, Generator, List, Optional, Tuple, Union
 
 import jax
 import numpy as np

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -40,7 +40,7 @@ def check_transform_input(func: Callable) -> Callable:
     """Check input before calling basis.
 
     This decorator allows to raise an exception that is more readable
-    when the wrong number of input is provided to _evaluate.
+    when the wrong number of input is provided to evaluate.
     """
 
     @wraps(func)
@@ -266,7 +266,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         pass
 
     @abc.abstractmethod
-    def _evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Abstract method to evaluate the basis functions at given points.
 
@@ -382,7 +382,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Xs = np.meshgrid(*sample_tuple, indexing="ij")
 
         # evaluates the basis on a flat NDArray and reshape to match meshgrid output
-        Y = self._evaluate(*tuple(grid_axis.flatten() for grid_axis in Xs)).reshape(
+        Y = self.evaluate(*(grid_axis.flatten() for grid_axis in Xs)).reshape(
             (*n_samples, self.n_basis_funcs)
         )
 
@@ -853,7 +853,7 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Evaluate the basis at the input samples.
 
@@ -881,13 +881,13 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
         >>> additive_basis = basis_1 + basis_2
 
         >>> # call the basis.
-        >>> out = additive_basis._evaluate(x, y)
+        >>> out = additive_basis.evaluate(x, y)
 
         """
         X = np.hstack(
             (
-                self.basis1._evaluate(*xi[: self.basis1._n_input_dimensionality]),
-                self.basis2._evaluate(*xi[self.basis1._n_input_dimensionality :]),
+                self.basis1.evaluate(*xi[: self.basis1._n_input_dimensionality]),
+                self.basis2.evaluate(*xi[self.basis1._n_input_dimensionality :]),
             )
         )
         return X
@@ -1266,7 +1266,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
     @support_pynapple(conv_type="numpy")
     @check_transform_input
     @check_one_dimensional
-    def _evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
+    def evaluate(self, *xi: ArrayLike | Tsd | TsdFrame | TsdTensor) -> FeatureMatrix:
         """
         Evaluate the basis at the input samples.
 
@@ -1287,12 +1287,12 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
         >>> import nemos as nmo
         >>> mult_basis = nmo.basis.BSplineEval(5) * nmo.basis.RaisedCosineLinearEval(6)
         >>> x, y = np.random.randn(2, 30)
-        >>> X = mult_basis._evaluate(x, y)
+        >>> X = mult_basis.evaluate(x, y)
         """
         X = np.asarray(
             row_wise_kron(
-                self.basis1._evaluate(*xi[: self.basis1._n_input_dimensionality]),
-                self.basis2._evaluate(*xi[self.basis1._n_input_dimensionality :]),
+                self.basis1.evaluate(*xi[: self.basis1._n_input_dimensionality]),
+                self.basis2.evaluate(*xi[self.basis1._n_input_dimensionality :]),
                 transpose=False,
             )
         )

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -825,8 +825,7 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
     >>> additive_basis = basis_1 + basis_2
     >>> additive_basis
     '(BSplineEval + RaisedCosineLinearEval)': AdditiveBasis(
-        basis1=BSplineEval(n_basis_funcs=10, order=4),
-        basis2=RaisedCosineLinearEval(n_basis_funcs=15, width=2.0),
+        ...
     )
     >>> # can add another basis to the AdditiveBasis object
     >>> X = np.random.normal(size=(30, 3))
@@ -834,11 +833,7 @@ class AdditiveBasis(CompositeBasisMixin, Basis):
     >>> additive_basis_2 = additive_basis + basis_3
     >>> additive_basis_2
     '((BSplineEval + RaisedCosineLinearEval) + RaisedCosineLogEval)': AdditiveBasis(
-        basis1='(BSplineEval + RaisedCosineLinearEval)': AdditiveBasis(
-            basis1=BSplineEval(n_basis_funcs=10, order=4),
-            basis2=RaisedCosineLinearEval(n_basis_funcs=15, width=2.0),
-        ),
-        basis2=RaisedCosineLogEval(n_basis_funcs=100, width=2.0, time_scaling=50.0, enforce_decay_to_zero=True),
+        ...
     )
     """
 
@@ -1259,8 +1254,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
     >>> multiplicative_basis = basis_1 * basis_2
     >>> multiplicative_basis
     '(BSplineEval * RaisedCosineLinearEval)': MultiplicativeBasis(
-        basis1=BSplineEval(n_basis_funcs=10, order=4),
-        basis2=RaisedCosineLinearEval(n_basis_funcs=15, width=2.0),
+        ...
     )
 
     >>> # Can multiply or add another basis to the AdditiveBasis object
@@ -1269,11 +1263,7 @@ class MultiplicativeBasis(CompositeBasisMixin, Basis):
     >>> multiplicative_basis_2 = multiplicative_basis * basis_3
     >>> multiplicative_basis_2
     '((BSplineEval * RaisedCosineLinearEval) * RaisedCosineLogEval)': MultiplicativeBasis(
-        basis1='(BSplineEval * RaisedCosineLinearEval)': MultiplicativeBasis(
-            basis1=BSplineEval(n_basis_funcs=10, order=4),
-            basis2=RaisedCosineLinearEval(n_basis_funcs=15, width=2.0),
-        ),
-        basis2=RaisedCosineLogEval(n_basis_funcs=100, width=2.0, time_scaling=50.0, enforce_decay_to_zero=True),
+        ...
     )
     """
 

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -240,17 +240,6 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         pass
 
     @abc.abstractmethod
-    def _set_input_independent_states(self):
-        """
-        Compute all the basis states that do not depend on the input.
-
-        An example of such state is the kernel_ for Conv bases, which can be computed
-        without any input (it only depends on the basis type, the window size and the
-        number of basis elements).
-        """
-        pass
-
-    @abc.abstractmethod
     def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
         """
         Set the expected input shape for the basis object.

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -239,7 +239,6 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         basis function types and operation modes.
         """
         self.setup_basis(*xi)
-        self._check_input_shape_consistency(*xi)
         return self._compute_features(*xi)
 
     @abc.abstractmethod

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -297,7 +297,7 @@ class EvalBasisMixin:
             A matrix with the transformed features.
 
         """
-        out = self._evaluate(*(np.reshape(x, (x.shape[0], -1)) for x in xi))
+        out = self.evaluate(*(np.reshape(x, (x.shape[0], -1)) for x in xi))
         return np.reshape(out, (out.shape[0], -1))
 
     def setup_basis(self, *xi: NDArray) -> Basis:
@@ -458,7 +458,7 @@ class ConvBasisMixin:
         computed and how the input parameters are utilized.
 
         """
-        self.kernel_ = self._evaluate(np.linspace(0, 1, self.window_size))
+        self.kernel_ = self.evaluate(np.linspace(0, 1, self.window_size))
         return self
 
     @property

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -425,7 +425,7 @@ class ConvBasisMixin:
         :
             The basis with ready for evaluation.
         """
-        self.set_kernel()
+        self._set_kernel()
         self.set_input_shape(*xi)
         return self
 
@@ -435,9 +435,9 @@ class ConvBasisMixin:
 
         For Conv mixin the only attribute is the kernel.
         """
-        return self.set_kernel()
+        return self._set_kernel()
 
-    def set_kernel(self) -> "ConvBasisMixin":
+    def _set_kernel(self) -> "ConvBasisMixin":
         """
         Prepare or compute the convolutional kernel for the basis functions.
 

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -23,6 +23,7 @@ from ._composition_utils import (
     _composite_basis_setter_logic,
     _get_root,
     _recompute_all_default_labels,
+    infer_input_dimensionality,
 )
 from ._transformer_basis import TransformerBasis
 
@@ -611,6 +612,11 @@ class CompositeBasisMixin:
         self._label = None
         # use setter to check & set provided label
         self.label = label
+
+        # number of input arrays that the basis receives
+        self._n_input_dimensionality = infer_input_dimensionality(
+            basis1
+        ) + infer_input_dimensionality(basis2)
 
     @property
     def basis1(self):

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -240,28 +240,6 @@ class AtomicBasisMixin:
         self._input_shape_product = n_inputs
         return self
 
-    def _check_input_shape_consistency(self, x: NDArray):
-        """Check input consistency across calls."""
-        # remove sample axis and squeeze
-        shape = x.shape[1:]
-
-        initialized = self._input_shape_ is not None
-        is_shape_match = self._input_shape_[0] == shape
-        if initialized and not is_shape_match:
-            expected_shape_str = "(n_samples, " + f"{self._input_shape_[0]}"[1:]
-            expected_shape_str = expected_shape_str.replace(",)", ")")
-            raise ValueError(
-                f"Input shape mismatch detected.\n\n"
-                f"The basis `{self.__class__.__name__}` with label '{self.label}' expects inputs with "
-                f"a consistent shape (excluding the sample axis). Specifically, the shape should be:\n"
-                f"  Expected: {expected_shape_str}\n"
-                f"  But got:  {x.shape}.\n\n"
-                "Note: The number of samples (`n_samples`) can vary between calls of `compute_features`, "
-                "but all other dimensions must remain the same. If you need to process inputs with a "
-                "different shape, please create a new basis instance, or set a new input shape by calling "
-                "`set_input_shape`."
-            )
-
     @property
     def input_shape(self) -> NDArray:
         return self._input_shape_[0] if self._input_shape_ else None
@@ -831,15 +809,6 @@ class CompositeBasisMixin:
         """
         self.basis1._set_input_independent_states()
         self.basis2._set_input_independent_states()
-
-    def _check_input_shape_consistency(self, *xi: NDArray):
-        """Check the input shape consistency for all basis elements."""
-        self.basis1._check_input_shape_consistency(
-            *xi[: self.basis1._n_input_dimensionality]
-        )
-        self.basis2._check_input_shape_consistency(
-            *xi[self.basis1._n_input_dimensionality :]
-        )
 
     def _iterate_over_components(self):
         """Return a generator that iterates over all basis components.

--- a/src/nemos/basis/_composition_utils.py
+++ b/src/nemos/basis/_composition_utils.py
@@ -35,6 +35,15 @@ __PUBLIC_BASES__ = [
 ]
 
 
+def _iterate_over_components(basis: "Basis"):
+    components = (
+        basis._iterate_over_components()
+        if hasattr(basis, "_iterate_over_components")
+        else [basis]
+    )
+    yield from components
+
+
 def _get_root(bas: "AtomicBasisMixin | CompositeBasisMixin"):
     """Get the basis root"""
     parent = bas
@@ -81,12 +90,7 @@ def _recompute_class_default_labels(bas: "AtomicBasisMixin | CompositeBasisMixin
     bas_id = 0
     # if root is one of our bases it will have the iteration method, if custom from user
     # I assume it is atomic
-    components = (
-        root._iterate_over_components()
-        if hasattr(root, "_iterate_over_components")
-        else [root]
-    )
-    for comp_bas in components:
+    for comp_bas in _iterate_over_components(root):
         if re.match(pattern, comp_bas._label):
             comp_bas._label = f"{cls_name}_{bas_id}" if bas_id else cls_name
             bas_id += 1
@@ -95,12 +99,7 @@ def _recompute_class_default_labels(bas: "AtomicBasisMixin | CompositeBasisMixin
 def _recompute_all_default_labels(root: "Basis") -> "Basis":
     """Recompute default all labels."""
     updated = []
-    components = (
-        root._iterate_over_components()
-        if hasattr(root, "_iterate_over_components")
-        else [root]
-    )
-    for bas in components:
+    for bas in _iterate_over_components(root):
         if _has_default_label(bas) and bas.__class__.__name__ not in updated:
             _recompute_class_default_labels(bas)
             updated.append(bas.__class__.__name__)
@@ -128,12 +127,7 @@ def _update_label_from_root(
     current_id = int(match.group(1)[1:]) if match.group(1) else 0
     # subtract one to the ID of any other default label with ID > current_id
     root = _get_root(bas)
-    components = (
-        root._iterate_over_components()
-        if hasattr(root, "_iterate_over_components")
-        else [root]
-    )
-    for bas in components:
+    for bas in _iterate_over_components(root):
         match = re.match(pattern, bas._label)
         if match:
             bas_id = int(match.group(1)[1:]) if match.group(1) else 0

--- a/src/nemos/basis/_composition_utils.py
+++ b/src/nemos/basis/_composition_utils.py
@@ -8,6 +8,8 @@ with no to minimal re
 import re
 from typing import TYPE_CHECKING
 
+from .._inspect_utils.inspect_utils import count_positional_and_var_args
+
 if TYPE_CHECKING:
     from ._basis import Basis
     from ._basis_mixin import AtomicBasisMixin, CompositeBasisMixin
@@ -232,3 +234,12 @@ def _check_input_consistency(bas, *x):
             "different shape, please create a new basis instance, or set a new input shape by calling "
             "`set_input_shape`."
         )
+
+
+def infer_input_dimensionality(bas: "Basis") -> int:
+    n_input_dim = getattr(bas, "_n_input_dimensionality", None)
+    if n_input_dim is None:
+        # infer from compute_features (facilitate custom basis compatibility).
+        # assume compute_features is always implemented.
+        n_input_dim, _ = count_positional_and_var_args(bas.compute_features)
+    return n_input_dim

--- a/src/nemos/basis/_composition_utils.py
+++ b/src/nemos/basis/_composition_utils.py
@@ -207,29 +207,6 @@ def _atomic_basis_label_setter_logic(
     return
 
 
-def _check_input_consistency(bas, *x):
-    """Check input consistency across calls."""
-    # remove sample axis and squeeze
-    shape = x.shape[1:]
-
-    initialized = bas._input_shape_ is not None
-    is_shape_match = bas._input_shape_[0] == shape
-    if initialized and not is_shape_match:
-        expected_shape_str = "(n_samples, " + f"{bas._input_shape_[0]}"[1:]
-        expected_shape_str = expected_shape_str.replace(",)", ")")
-        raise ValueError(
-            f"Input shape mismatch detected.\n\n"
-            f"The basis `{bas.__class__.__name__}` with label '{bas.label}' expects inputs with "
-            f"a consistent shape (excluding the sample axis). Specifically, the shape should be:\n"
-            f"  Expected: {expected_shape_str}\n"
-            f"  But got:  {x.shape}.\n\n"
-            "Note: The number of samples (`n_samples`) can vary between calls of `compute_features`, "
-            "but all other dimensions must remain the same. If you need to process inputs with a "
-            "different shape, please create a new basis instance, or set a new input shape by calling "
-            "`set_input_shape`."
-        )
-
-
 def infer_input_dimensionality(bas: "Basis") -> int:
     n_input_dim = getattr(bas, "_n_input_dimensionality", None)
     if n_input_dim is None:

--- a/src/nemos/basis/_composition_utils.py
+++ b/src/nemos/basis/_composition_utils.py
@@ -209,3 +209,26 @@ def _atomic_basis_label_setter_logic(
         )
         bas._label = new_label
     return
+
+
+def _check_input_consistency(bas, *x):
+    """Check input consistency across calls."""
+    # remove sample axis and squeeze
+    shape = x.shape[1:]
+
+    initialized = bas._input_shape_ is not None
+    is_shape_match = bas._input_shape_[0] == shape
+    if initialized and not is_shape_match:
+        expected_shape_str = "(n_samples, " + f"{bas._input_shape_[0]}"[1:]
+        expected_shape_str = expected_shape_str.replace(",)", ")")
+        raise ValueError(
+            f"Input shape mismatch detected.\n\n"
+            f"The basis `{bas.__class__.__name__}` with label '{bas.label}' expects inputs with "
+            f"a consistent shape (excluding the sample axis). Specifically, the shape should be:\n"
+            f"  Expected: {expected_shape_str}\n"
+            f"  But got:  {x.shape}.\n\n"
+            "Note: The number of samples (`n_samples`) can vary between calls of `compute_features`, "
+            "but all other dimensions must remain the same. If you need to process inputs with a "
+            "different shape, please create a new basis instance, or set a new input shape by calling "
+            "`set_input_shape`."
+        )

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -127,7 +127,7 @@ class OrthExponentialBasis(Basis, AtomicBasisMixin, abc.ABC):
         self,
         sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
-        """Generate basis functions with given spacing.
+        """Evaluate the OrthExponential basis at the given sample points.
 
         Parameters
         ----------

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -26,9 +26,6 @@ class OrthExponentialBasis(Basis, AtomicBasisMixin, abc.ABC):
             Number of basis functions.
     decay_rates :
             Decay rates of the exponentials, shape ``(n_basis_funcs,)``.
-    mode :
-        The mode of operation. ``'eval'`` for evaluation at sample points,
-        ``'conv'`` for convolutional operation.
     label :
         The label of the basis, intended to be descriptive of the task variable being processed.
         For example: velocity, position, spike_counts.
@@ -38,13 +35,11 @@ class OrthExponentialBasis(Basis, AtomicBasisMixin, abc.ABC):
         self,
         n_basis_funcs: int,
         decay_rates: NDArray[np.floating],
-        mode="eval",
         label: Optional[str] = "OrthExponentialBasis",
     ):
         AtomicBasisMixin.__init__(self, n_basis_funcs=n_basis_funcs, label=label)
         Basis.__init__(
             self,
-            mode=mode,
         )
         self.decay_rates = decay_rates
         self._check_rates()

--- a/src/nemos/basis/_decaying_exponential.py
+++ b/src/nemos/basis/_decaying_exponential.py
@@ -123,7 +123,7 @@ class OrthExponentialBasis(Basis, AtomicBasisMixin, abc.ABC):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(
+    def evaluate(
         self,
         sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
@@ -141,7 +141,6 @@ class OrthExponentialBasis(Basis, AtomicBasisMixin, abc.ABC):
         basis_funcs
             Evaluated exponentially decaying basis functions, numerically
             orthogonalized, shape ``(n_samples, n_basis_funcs)``.
-
         """
         self._check_sample_size(sample_pts)
         sample_pts, _ = min_max_rescale_samples(

--- a/src/nemos/basis/_identity.py
+++ b/src/nemos/basis/_identity.py
@@ -130,7 +130,7 @@ class HistoryBasis(Basis, AtomicBasisMixin):
         self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
     ) -> FeatureMatrix:
         """
-        Returns an identity matrix of size len(samples).
+        Returns an identity matrix of shape (len(samples), n_basis_funcs).
 
         The output is the convolutional kernels for spike history.
 
@@ -147,7 +147,7 @@ class HistoryBasis(Basis, AtomicBasisMixin):
         """
         sample_pts = np.squeeze(np.asarray(sample_pts))
         if sample_pts.ndim != 1:
-            raise ValueError("`evaluate` for HistoryBasis allows 1D input only.")
+            raise ValueError("`_evaluate` for HistoryBasis allows 1D input only.")
         # this is called by set kernel.
         return np.eye(np.asarray(sample_pts).shape[0], self.n_basis_funcs)
 

--- a/src/nemos/basis/_identity.py
+++ b/src/nemos/basis/_identity.py
@@ -35,7 +35,6 @@ class IdentityBasis(Basis, AtomicBasisMixin):
         AtomicBasisMixin.__init__(self, n_basis_funcs=n_basis_funcs, label=label)
         Basis.__init__(
             self,
-            mode="eval",
         )
         self._n_input_dimensionality = 1
 
@@ -122,7 +121,6 @@ class HistoryBasis(Basis, AtomicBasisMixin):
         AtomicBasisMixin.__init__(self, n_basis_funcs=n_basis_funcs, label=label)
         Basis.__init__(
             self,
-            mode="conv",
         )
         self._n_input_dimensionality = 1
 

--- a/src/nemos/basis/_identity.py
+++ b/src/nemos/basis/_identity.py
@@ -147,7 +147,7 @@ class HistoryBasis(Basis, AtomicBasisMixin):
         """
         sample_pts = np.squeeze(np.asarray(sample_pts))
         if sample_pts.ndim != 1:
-            raise ValueError("`_evaluate` for HistoryBasis allows 1D input only.")
+            raise ValueError("`evaluate` for HistoryBasis allows 1D input only.")
         # this is called by set kernel.
         return np.eye(np.asarray(sample_pts).shape[0], self.n_basis_funcs)
 

--- a/src/nemos/basis/_identity.py
+++ b/src/nemos/basis/_identity.py
@@ -129,8 +129,8 @@ class HistoryBasis(Basis, AtomicBasisMixin):
     def evaluate(
         self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
     ) -> FeatureMatrix:
-        """
-        Returns an identity matrix of shape (len(samples), n_basis_funcs).
+        r"""
+        Returns an identity matrix of shape ``(len(samples), n_basis_funcs)``.
 
         The output is the convolutional kernels for spike history.
 
@@ -142,7 +142,7 @@ class HistoryBasis(Basis, AtomicBasisMixin):
         Returns
         -------
         :
-            np.eye(*samples.shape, n_basis_funcs).
+            Identity matrix of shape ``(*samples.shape, n_basis_funcs)``.
 
         """
         sample_pts = np.squeeze(np.asarray(sample_pts))

--- a/src/nemos/basis/_identity.py
+++ b/src/nemos/basis/_identity.py
@@ -40,7 +40,7 @@ class IdentityBasis(Basis, AtomicBasisMixin):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(
+    def evaluate(
         self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
     ) -> FeatureMatrix:
         """
@@ -126,7 +126,7 @@ class HistoryBasis(Basis, AtomicBasisMixin):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(
+    def evaluate(
         self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
     ) -> FeatureMatrix:
         """
@@ -147,7 +147,7 @@ class HistoryBasis(Basis, AtomicBasisMixin):
         """
         sample_pts = np.squeeze(np.asarray(sample_pts))
         if sample_pts.ndim != 1:
-            raise ValueError("`_evaluate` for HistoryBasis allows 1D input only.")
+            raise ValueError("`evaluate` for HistoryBasis allows 1D input only.")
         # this is called by set kernel.
         return np.eye(np.asarray(sample_pts).shape[0], self.n_basis_funcs)
 

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -104,7 +104,7 @@ class RaisedCosineBasisLinear(Basis, AtomicBasisMixin, abc.ABC):
         self,
         sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
-        """Generate basis functions with given samples.
+        """Evaluate the raised cosine basis at the sample points.
 
         Parameters
         ----------
@@ -339,7 +339,7 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         self,
         sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
-        """Generate log-spaced raised cosine basis with given samples.
+        """Evaluate the log-spaced raised cosine basis at the sample points.
 
         Parameters
         ----------

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -24,9 +24,6 @@ class RaisedCosineBasisLinear(Basis, AtomicBasisMixin, abc.ABC):
     ----------
     n_basis_funcs :
         The number of basis functions.
-    mode :
-        The mode of operation. 'eval' for evaluation at sample points,
-        'conv' for convolutional operation.
     width :
         Width of the raised cosine. Must be $x/2$ for any integer $x\geq 3$ (e.g., 1.5,
         2, 2.5, 3, etc.)
@@ -53,14 +50,12 @@ class RaisedCosineBasisLinear(Basis, AtomicBasisMixin, abc.ABC):
     def __init__(
         self,
         n_basis_funcs: int,
-        mode="eval",
         width: float = 2.0,
         label: Optional[str] = "RaisedCosineBasisLinear",
     ) -> None:
         AtomicBasisMixin.__init__(self, n_basis_funcs=n_basis_funcs, label=label)
         Basis.__init__(
             self,
-            mode=mode,
         )
         self._n_input_dimensionality = 1
         self._check_width(width)
@@ -218,9 +213,6 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
     ----------
     n_basis_funcs :
         The number of basis functions.
-    mode :
-        The mode of operation. 'eval' for evaluation at sample points,
-        'conv' for convolutional operation.
     width :
         Width of the raised cosine. Must be $x/2$ for any integer $x\geq 3$ (e.g., 1.5,
         2, 2.5, 3, etc.)
@@ -248,7 +240,6 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
     def __init__(
         self,
         n_basis_funcs: int,
-        mode="eval",
         width: float = 2.0,
         time_scaling: float = None,
         enforce_decay_to_zero: bool = True,
@@ -256,7 +247,6 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
     ) -> None:
         super().__init__(
             n_basis_funcs,
-            mode=mode,
             width=width,
             label=label,
         )

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -15,7 +15,7 @@ from ._basis_mixin import AtomicBasisMixin
 
 
 class RaisedCosineBasisLinear(Basis, AtomicBasisMixin, abc.ABC):
-    """Represent linearly-spaced raised cosine basis functions.
+    r"""Represent linearly-spaced raised cosine basis functions.
 
     This implementation is based on the cosine bumps used by Pillow et al. [1]_
     to uniformly tile the internal points of the domain.
@@ -100,7 +100,7 @@ class RaisedCosineBasisLinear(Basis, AtomicBasisMixin, abc.ABC):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(  # call these _evaluate
+    def evaluate(  # call these evaluate
         self,
         sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
@@ -126,7 +126,7 @@ class RaisedCosineBasisLinear(Basis, AtomicBasisMixin, abc.ABC):
             # basis1 = nmo.basis.RaisedCosineBasisLinear(5)
             # basis2 = nmo.basis.RaisedCosineBasisLog(5)
             # additive_basis = basis1 + basis2
-            # additive_basis._evaluate(*([x] * 2)) would modify both inputs
+            # additive_basis.evaluate(*([x] * 2)) would modify both inputs
             sample_pts, _ = min_max_rescale_samples(
                 np.copy(sample_pts), getattr(self, "bounds", None)
             )
@@ -203,7 +203,7 @@ class RaisedCosineBasisLinear(Basis, AtomicBasisMixin, abc.ABC):
 
 
 class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
-    """Represent log-spaced raised cosine basis functions.
+    r"""Represent log-spaced raised cosine basis functions.
 
     Similar to ``RaisedCosineBasisLinear`` but the basis functions are log-spaced.
     This implementation is based on the cosine bumps used by Pillow et al. [1]_
@@ -335,7 +335,7 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(
+    def evaluate(
         self,
         sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:
@@ -358,4 +358,4 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         ValueError
             If the sample provided do not lie in [0,1].
         """
-        return super()._evaluate(self._transform_samples(sample_pts))
+        return super().evaluate(self._transform_samples(sample_pts))

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import abc
 import copy
-from typing import Literal, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -203,7 +203,7 @@ class MSplineBasis(SplineBasis, abc.ABC):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(
+    def evaluate(
         self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
     ) -> FeatureMatrix:
         """
@@ -328,7 +328,7 @@ class BSplineBasis(SplineBasis, abc.ABC):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(
+    def evaluate(
         self, sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor
     ) -> FeatureMatrix:
         """
@@ -442,7 +442,7 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input
-    def _evaluate(
+    def evaluate(
         self,
         sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
     ) -> FeatureMatrix:

--- a/src/nemos/basis/_spline_basis.py
+++ b/src/nemos/basis/_spline_basis.py
@@ -24,9 +24,6 @@ class SplineBasis(Basis, AtomicBasisMixin, abc.ABC):
     ----------
     n_basis_funcs :
         Number of basis functions.
-    mode :
-        The mode of operation. 'eval' for evaluation at sample points,
-        'conv' for convolutional operation.
     order : optional
         Spline order.
     label :
@@ -44,13 +41,11 @@ class SplineBasis(Basis, AtomicBasisMixin, abc.ABC):
         n_basis_funcs: int,
         order: int = 2,
         label: Optional[str] = None,
-        mode: Literal["conv", "eval"] = "eval",
     ) -> None:
         self.order = order
         AtomicBasisMixin.__init__(self, n_basis_funcs=n_basis_funcs, label=label)
         Basis.__init__(
             self,
-            mode=mode,
         )
 
         self._n_input_dimensionality = 1
@@ -162,9 +157,6 @@ class MSplineBasis(SplineBasis, abc.ABC):
     n_basis_funcs :
         The number of basis functions to generate. More basis functions allow for
         more flexible data modeling but can lead to overfitting.
-    mode :
-        The mode of operation. 'eval' for evaluation at sample points,
-        'conv' for convolutional operation.
     order :
         The order of the splines used in basis functions. Must be between [1,
         n_basis_funcs]. Default is 2. Higher order splines have more continuous
@@ -200,13 +192,11 @@ class MSplineBasis(SplineBasis, abc.ABC):
     def __init__(
         self,
         n_basis_funcs: int,
-        mode: Literal["eval", "conv"] = "eval",
         order: int = 2,
         label: Optional[str] = "MSplineEval",
     ) -> None:
         super().__init__(
             n_basis_funcs,
-            mode=mode,
             order=order,
             label=label,
         )
@@ -304,9 +294,6 @@ class BSplineBasis(SplineBasis, abc.ABC):
     ----------
     n_basis_funcs :
         Number of basis functions.
-    mode :
-        The mode of operation. ``'eval'`` for evaluation at sample points,
-        'conv' for convolutional operation.
     order :
         Order of the splines used in basis functions. Must lie within ``[1, n_basis_funcs]``.
         The B-splines have (order-2) continuous derivatives at each interior knot.
@@ -330,13 +317,11 @@ class BSplineBasis(SplineBasis, abc.ABC):
     def __init__(
         self,
         n_basis_funcs: int,
-        mode="eval",
         order: int = 4,
         label: Optional[str] = "BSplineBasis",
     ):
         super().__init__(
             n_basis_funcs,
-            mode=mode,
             order=order,
             label=label,
         )
@@ -422,9 +407,6 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
     ----------
     n_basis_funcs :
         Number of basis functions.
-    mode :
-        The mode of operation. 'eval' for evaluation at sample points,
-        'conv' for convolutional operation.
     order :
         Order of the splines used in basis functions. Order must lie within [2, n_basis_funcs].
         The B-splines have (order-2) continuous derivatives at each interior knot.
@@ -444,13 +426,11 @@ class CyclicBSplineBasis(SplineBasis, abc.ABC):
     def __init__(
         self,
         n_basis_funcs: int,
-        mode="eval",
         order: int = 4,
         label: Optional[str] = "CyclicBSplineBasis",
     ):
         super().__init__(
             n_basis_funcs,
-            mode=mode,
             order=order,
             label=label,
         )

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Generator
 import numpy as np
 
 from ..typing import FeatureMatrix
+from ._composition_utils import _iterate_over_components, infer_input_dimensionality
 
 if TYPE_CHECKING:
     from ._basis import Basis
@@ -97,7 +98,26 @@ class TransformerBasis:
                 f"\nMissing methods: {missing_attrs}."
             )
         self.basis = copy.deepcopy(basis)
+        self._assign_input_shape(self.basis)
+        self.basis._parent = None
         self._wrapped_methods = {}  # Cache for wrapped methods
+
+    @staticmethod
+    def _assign_input_shape(basis):
+        # iterate over atomic or custom components
+        default_shape = []
+        for bas in _iterate_over_components(basis):
+            ishape = getattr(bas, "input_shape", None)
+            # handles the case of a multi-dim basis with set shape
+            if isinstance(ishape, list):
+                default_shape.extend(ishape)
+            # handles the case of a 1dim basis with set shape
+            elif ishape is not None:
+                default_shape.append(ishape)
+            # handles custom or 1dim with no set shape
+            else:
+                default_shape.extend([()] * infer_input_dimensionality(bas))
+        basis.set_input_shape(*default_shape)
 
     @staticmethod
     def _check_initialized(basis):

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -69,7 +69,6 @@ class BSplineEval(EvalBasisMixin, BSplineBasis):
         BSplineBasis.__init__(
             self,
             n_basis_funcs,
-            mode="eval",
             order=order,
             label=label,
         )
@@ -223,7 +222,6 @@ class BSplineConv(ConvBasisMixin, BSplineBasis):
         BSplineBasis.__init__(
             self,
             n_basis_funcs,
-            mode="conv",
             order=order,
             label=label,
         )
@@ -363,7 +361,6 @@ class CyclicBSplineEval(EvalBasisMixin, CyclicBSplineBasis):
         CyclicBSplineBasis.__init__(
             self,
             n_basis_funcs,
-            mode="eval",
             order=order,
             label=label,
         )
@@ -508,7 +505,6 @@ class CyclicBSplineConv(ConvBasisMixin, CyclicBSplineBasis):
         CyclicBSplineBasis.__init__(
             self,
             n_basis_funcs,
-            mode="conv",
             order=order,
             label=label,
         )
@@ -672,7 +668,6 @@ class MSplineEval(EvalBasisMixin, MSplineBasis):
         MSplineBasis.__init__(
             self,
             n_basis_funcs,
-            mode="eval",
             order=order,
             label=label,
         )
@@ -841,7 +836,6 @@ class MSplineConv(ConvBasisMixin, MSplineBasis):
         MSplineBasis.__init__(
             self,
             n_basis_funcs,
-            mode="conv",
             order=order,
             label=label,
         )
@@ -990,7 +984,6 @@ class RaisedCosineLinearEval(EvalBasisMixin, RaisedCosineBasisLinear):
             self,
             n_basis_funcs,
             width=width,
-            mode="eval",
             label=label,
         )
 
@@ -1135,7 +1128,6 @@ class RaisedCosineLinearConv(ConvBasisMixin, RaisedCosineBasisLinear):
         RaisedCosineBasisLinear.__init__(
             self,
             n_basis_funcs,
-            mode="conv",
             width=width,
             label=label,
         )
@@ -1285,7 +1277,6 @@ class RaisedCosineLogEval(EvalBasisMixin, RaisedCosineBasisLog):
             width=width,
             time_scaling=time_scaling,
             enforce_decay_to_zero=enforce_decay_to_zero,
-            mode="eval",
             label=label,
         )
 
@@ -1440,7 +1431,6 @@ class RaisedCosineLogConv(ConvBasisMixin, RaisedCosineBasisLog):
         RaisedCosineBasisLog.__init__(
             self,
             n_basis_funcs,
-            mode="conv",
             width=width,
             time_scaling=time_scaling,
             enforce_decay_to_zero=enforce_decay_to_zero,
@@ -1578,7 +1568,6 @@ class OrthExponentialEval(EvalBasisMixin, OrthExponentialBasis):
             self,
             n_basis_funcs,
             decay_rates=decay_rates,
-            mode="eval",
             label=label,
         )
 
@@ -1719,7 +1708,6 @@ class OrthExponentialConv(ConvBasisMixin, OrthExponentialBasis):
         OrthExponentialBasis.__init__(
             self,
             n_basis_funcs,
-            mode="conv",
             decay_rates=decay_rates,
             label=label,
         )

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -120,8 +120,6 @@ class BSplineEval(EvalBasisMixin, BSplineBasis):
         """
         Examples
         --------
-        Evaluate and visualize 4 B-spline basis functions of order 3:
-
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
         >>> from nemos.basis import BSplineEval
@@ -138,6 +136,20 @@ class BSplineEval(EvalBasisMixin, BSplineBasis):
         >>> l = plt.legend()
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", BSplineBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import BSplineEval
+        >>> bspline_basis = BSplineEval(n_basis_funcs=4, order=3)
+        >>> out = bspline_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("set_input_shape", AtomicBasisMixin)
     def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
@@ -272,8 +284,6 @@ class BSplineConv(ConvBasisMixin, BSplineBasis):
         """
         Examples
         --------
-        Evaluate and visualize 4 B-spline basis functions of order 3:
-
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
         >>> from nemos.basis import BSplineConv
@@ -290,6 +300,20 @@ class BSplineConv(ConvBasisMixin, BSplineBasis):
         >>> l = plt.legend()
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", BSplineBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import BSplineConv
+        >>> bspline_basis = BSplineConv(n_basis_funcs=4, window_size=20, order=3)
+        >>> out = bspline_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("set_input_shape", AtomicBasisMixin)
     def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
@@ -429,6 +453,20 @@ class CyclicBSplineEval(EvalBasisMixin, CyclicBSplineBasis):
         >>> l = plt.legend()
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", CyclicBSplineBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import CyclicBSplineEval
+        >>> cbspline_basis = CyclicBSplineEval(n_basis_funcs=4, order=3)
+        >>> out = cbspline_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("set_input_shape", AtomicBasisMixin)
     def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
@@ -573,6 +611,20 @@ class CyclicBSplineConv(ConvBasisMixin, CyclicBSplineBasis):
         >>> l = plt.legend()
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", CyclicBSplineBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import CyclicBSplineConv
+        >>> cbspline_basis = CyclicBSplineConv(n_basis_funcs=4, window_size=20, order=3)
+        >>> out = cbspline_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("set_input_shape", AtomicBasisMixin)
     def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
@@ -736,6 +788,20 @@ class MSplineEval(EvalBasisMixin, MSplineBasis):
         >>> l = plt.legend()
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", MSplineBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import MSplineEval
+        >>> mspline_basis = MSplineEval(n_basis_funcs=4, order=3)
+        >>> out = mspline_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("set_input_shape", AtomicBasisMixin)
     def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
@@ -905,6 +971,20 @@ class MSplineConv(ConvBasisMixin, MSplineBasis):
         """
         return super().evaluate_on_grid(n_samples)
 
+    @add_docstring("evaluate", MSplineBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import MSplineConv
+        >>> mspline_basis = MSplineConv(n_basis_funcs=4, window_size=20, order=3)
+        >>> out = mspline_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
+
     @add_docstring("set_input_shape", AtomicBasisMixin)
     def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
         """
@@ -996,13 +1076,26 @@ class RaisedCosineLinearEval(EvalBasisMixin, RaisedCosineBasisLinear):
         >>> import matplotlib.pyplot as plt
         >>> from nemos.basis import RaisedCosineLinearEval
         >>> n_basis_funcs = 5
-        >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05]) # sample decay rates
         >>> window_size=10
-        >>> ortho_basis = RaisedCosineLinearEval(n_basis_funcs)
-        >>> sample_points, basis_values = ortho_basis.evaluate_on_grid(100)
+        >>> raised_cos_basis = RaisedCosineLinearEval(n_basis_funcs)
+        >>> sample_points, basis_values = raised_cos_basis.evaluate_on_grid(100)
 
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", RaisedCosineBasisLinear)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import RaisedCosineLinearEval
+        >>> raised_cos = RaisedCosineLinearEval(n_basis_funcs=4)
+        >>> out = raised_cos.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
@@ -1148,6 +1241,20 @@ class RaisedCosineLinearConv(ConvBasisMixin, RaisedCosineBasisLinear):
 
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", RaisedCosineBasisLinear)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import RaisedCosineLinearConv
+        >>> raised_cos = RaisedCosineLinearConv(n_basis_funcs=4, window_size=20)
+        >>> out = raised_cos.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
@@ -1296,6 +1403,20 @@ class RaisedCosineLogEval(EvalBasisMixin, RaisedCosineBasisLog):
 
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", RaisedCosineBasisLog)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import RaisedCosineLogEval
+        >>> raised_cos = RaisedCosineLogEval(n_basis_funcs=4)
+        >>> out = raised_cos.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
@@ -1454,6 +1575,20 @@ class RaisedCosineLogConv(ConvBasisMixin, RaisedCosineBasisLog):
         """
         return super().evaluate_on_grid(n_samples)
 
+    @add_docstring("evaluate", RaisedCosineBasisLog)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import RaisedCosineLogConv
+        >>> raised_cos = RaisedCosineLogConv(n_basis_funcs=4, window_size=20)
+        >>> out = raised_cos.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
+
     @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
@@ -1587,6 +1722,21 @@ class OrthExponentialEval(EvalBasisMixin, OrthExponentialBasis):
 
         """
         return super().evaluate_on_grid(n_samples=n_samples)
+
+    @add_docstring("evaluate", OrthExponentialBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import OrthExponentialEval
+        >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05])
+        >>> ortho_basis = OrthExponentialEval(n_basis_funcs=5, decay_rates=decay_rates)
+        >>> out = ortho_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
@@ -1732,6 +1882,21 @@ class OrthExponentialConv(ConvBasisMixin, OrthExponentialBasis):
         """
         return super().evaluate_on_grid(n_samples)
 
+    @add_docstring("evaluate", OrthExponentialBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import OrthExponentialConv
+        >>> decay_rates = np.array([0.01, 0.02, 0.03, 0.04, 0.05])
+        >>> ortho_basis = OrthExponentialConv(n_basis_funcs=5, window_size=20, decay_rates=decay_rates)
+        >>> out = ortho_basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 4)
+        """
+        return super().evaluate(sample_pts)
+
     @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
         """
@@ -1847,7 +2012,7 @@ class IdentityEval(EvalBasisMixin, IdentityBasis):
             label=label,
         )
 
-    @add_docstring("evaluate_on_grid", OrthExponentialBasis)
+    @add_docstring("evaluate_on_grid", IdentityBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
@@ -1860,6 +2025,20 @@ class IdentityEval(EvalBasisMixin, IdentityBasis):
 
         """
         return super().evaluate_on_grid(n_samples=n_samples)
+
+    @add_docstring("evaluate", IdentityBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import IdentityEval
+        >>> basis = IdentityEval()
+        >>> out = basis.evaluate(np.random.randn(100, 5, 2))
+        >>> out.shape
+        (100, 5, 2, 1)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("_compute_features", EvalBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
@@ -1979,6 +2158,21 @@ class HistoryConv(ConvBasisMixin, HistoryBasis):
 
         """
         return super().evaluate_on_grid(n_samples)
+
+    @add_docstring("evaluate", HistoryBasis)
+    def evaluate(self, sample_pts: NDArray) -> NDArray:
+        """
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from nemos.basis import HistoryConv
+        >>> basis = HistoryConv(window_size=20)
+        >>> # evaluate for HistoryConv require a 1d input
+        >>> out = basis.evaluate(np.random.randn(100, ))
+        >>> out.shape
+        (100, 20)
+        """
+        return super().evaluate(sample_pts)
 
     @add_docstring("_compute_features", ConvBasisMixin)
     def compute_features(self, xi: ArrayLike) -> FeatureMatrix:

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -1734,7 +1734,7 @@ class OrthExponentialEval(EvalBasisMixin, OrthExponentialBasis):
         >>> ortho_basis = OrthExponentialEval(n_basis_funcs=5, decay_rates=decay_rates)
         >>> out = ortho_basis.evaluate(np.random.randn(100, 5, 2))
         >>> out.shape
-        (100, 5, 2, 4)
+        (100, 5, 2, 5)
         """
         return super().evaluate(sample_pts)
 
@@ -1893,7 +1893,7 @@ class OrthExponentialConv(ConvBasisMixin, OrthExponentialBasis):
         >>> ortho_basis = OrthExponentialConv(n_basis_funcs=5, window_size=20, decay_rates=decay_rates)
         >>> out = ortho_basis.evaluate(np.random.randn(100, 5, 2))
         >>> out.shape
-        (100, 5, 2, 4)
+        (100, 5, 2, 5)
         """
         return super().evaluate(sample_pts)
 

--- a/src/nemos/simulation.py
+++ b/src/nemos/simulation.py
@@ -269,12 +269,12 @@ def simulate_recurrent(
     >>> import jax
     >>> import matplotlib.pyplot as plt
     >>> from nemos.simulation import simulate_recurrent
-    >>>
+    >>> np.random.seed(42)
     >>> n_neurons = 2
     >>> coupling_duration = 100
     >>> feedforward_input = np.random.normal(size=(1000, n_neurons, 1))
     >>> coupling_basis = np.random.normal(size=(coupling_duration, 10))
-    >>> coupling_coef = np.random.normal(size=(n_neurons, n_neurons, 10))
+    >>> coupling_coef = 0.5*np.random.normal(size=(n_neurons, n_neurons, 10))
     >>> intercept = -9 * np.ones(n_neurons)
     >>> init_spikes = np.zeros((coupling_duration, n_neurons))
     >>> random_key = jax.random.key(123)

--- a/src/nemos/tree_utils.py
+++ b/src/nemos/tree_utils.py
@@ -205,3 +205,11 @@ def tree_l2_norm(tree_x, squared=False):
 def tree_zeros_like(tree_x):
     """Creates an all-zero tree with the same structure as tree_x."""
     return jax.tree_util.tree_map(jnp.zeros_like, tree_x)
+
+
+def has_matching_axis_pytree(*trees: Any, axis: int = 0):
+    """Check if an arbitrary number of trees have matching axis length."""
+    ax_lengths = {
+        xi.shape[axis] for tree in trees for xi in jax.tree_util.tree_leaves(tree)
+    }
+    return len(ax_lengths) == 1

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -577,9 +577,9 @@ class TestSharedMethods:
         "n_input, expectation",
         [
             (2, does_not_raise()),
-            (0, pytest.raises(ValueError, match="Input shape mismatch detected")),
-            (1, pytest.raises(ValueError, match="Input shape mismatch detected")),
-            (3, pytest.raises(ValueError, match="Input shape mismatch detected")),
+            (0, pytest.raises(ValueError, match="Empty array provided")),
+            (1, does_not_raise()),
+            (3, does_not_raise()),
         ],
     )
     def test_expected_input_number(self, n_input, expectation, cls):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1630,23 +1630,23 @@ class TestSharedMethods:
             (
                 np.ones((10, 1)),
                 1,
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
             (np.ones((10, 2)), 2, does_not_raise()),
             (
                 np.ones((10, 1)),
                 2,
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
             (
                 np.ones((10, 2, 1)),
                 2,
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
             (
                 np.ones((10, 1, 2)),
                 2,
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
             (np.ones((10, 1)), (1,), does_not_raise()),
             (np.ones((10,)), tuple(), does_not_raise()),
@@ -1654,22 +1654,22 @@ class TestSharedMethods:
             (
                 np.ones((10,)),
                 (1,),
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
             (
                 np.ones((10, 1)),
                 (),
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
             (
                 np.ones((10, 1)),
                 np.zeros((12,)),
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
             (
                 np.ones((10)),
                 np.zeros((12, 1)),
-                pytest.raises(ValueError, match="Input shape mismatch detected"),
+                does_not_raise(),
             ),
         ],
     )
@@ -3379,9 +3379,9 @@ class TestAdditiveBasis(CombinedBasis):
         "n_input, expectation",
         [
             (3, does_not_raise()),
-            (0, pytest.raises(ValueError, match="Input shape mismatch detected")),
-            (1, pytest.raises(ValueError, match="Input shape mismatch detected")),
-            (4, pytest.raises(ValueError, match="Input shape mismatch detected")),
+            (0, pytest.raises(ValueError, match="Empty array provided")),
+            (1, does_not_raise()),
+            (4, does_not_raise()),
         ],
     )
     def test_expected_input_number(self, n_input, expectation):
@@ -3391,7 +3391,11 @@ class TestAdditiveBasis(CombinedBasis):
         x = np.random.randn(20, 2), np.random.randn(20, 3)
         bas.compute_features(*x)
         with expectation:
-            bas.compute_features(np.random.randn(30, 2), np.random.randn(30, n_input))
+            x = np.random.randn(30, 2), np.random.randn(30, n_input)
+            bas.compute_features(*x)
+            assert all(
+                xi.shape[1:] == ishape  if xi.ndim != 1 else () == ishape for ishape, xi in zip(bas.input_shape, x)
+            )
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
@@ -3423,14 +3427,10 @@ class TestAdditiveBasis(CombinedBasis):
         add = basis_a + basis_b
 
         add.set_input_shape(shape_a, shape_b)
-        if add_shape_a == () and add_shape_b == ():
-            expectation = does_not_raise()
-        else:
-            expectation = pytest.raises(
-                ValueError, match="Input shape mismatch detected"
-            )
-        with expectation:
-            add.compute_features(*x)
+        add.compute_features(*x)
+        assert all(
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(add.input_shape, x)
+        )
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
@@ -3462,14 +3462,10 @@ class TestAdditiveBasis(CombinedBasis):
         add = basis_a + basis_b
 
         add.set_input_shape(shape_a, shape_b)
-        if add_shape_a == () and add_shape_b == ():
-            expectation = does_not_raise()
-        else:
-            expectation = pytest.raises(
-                ValueError, match="Input shape mismatch detected"
-            )
-        with expectation:
-            add.compute_features(*x)
+        add.compute_features(*x)
+        assert all(
+            xi.shape[1:] == ishape  if xi.ndim != 1 else () == ishape for ishape, xi in zip(add.input_shape, x)
+        )
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
@@ -3501,14 +3497,10 @@ class TestAdditiveBasis(CombinedBasis):
         add = basis_a + basis_b
 
         add.set_input_shape(shape_a, shape_b)
-        if add_shape_a == () and add_shape_b == ():
-            expectation = does_not_raise()
-        else:
-            expectation = pytest.raises(
-                ValueError, match="Input shape mismatch detected"
-            )
-        with expectation:
-            add.compute_features(*x)
+        add.compute_features(*x)
+        assert all(
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(add.input_shape, x)
+        )
 
     @pytest.mark.parametrize(
         "inp_shape, expectation",
@@ -4535,9 +4527,9 @@ class TestMultiplicativeBasis(CombinedBasis):
         "n_input, expectation",
         [
             (3, does_not_raise()),
-            (0, pytest.raises(ValueError, match="Input shape mismatch detected")),
-            (1, pytest.raises(ValueError, match="Input shape mismatch detected")),
-            (4, pytest.raises(ValueError, match="Input shape mismatch detected")),
+            (0, pytest.raises(ValueError, match="Empty array provided")),
+            (1, does_not_raise()),
+            (4, does_not_raise()),
         ],
     )
     def test_expected_input_number(self, n_input, expectation):
@@ -4547,7 +4539,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         x = np.random.randn(20, 2), np.random.randn(20, 3)
         bas.compute_features(*x)
         with expectation:
-            bas.compute_features(np.random.randn(30, 2), np.random.randn(30, n_input))
+            x = np.random.randn(30, 2), np.random.randn(30, n_input)
+            bas.compute_features(*x)
 
     @pytest.mark.parametrize("n_basis_input1", [1, 2, 3])
     @pytest.mark.parametrize("n_basis_input2", [1, 2, 3])
@@ -4590,14 +4583,10 @@ class TestMultiplicativeBasis(CombinedBasis):
         mul = basis_a * basis_b
 
         mul.set_input_shape(shape_a, shape_b)
-        if add_shape_a == () and add_shape_b == ():
-            expectation = does_not_raise()
-        else:
-            expectation = pytest.raises(
-                ValueError, match="Input shape mismatch detected"
-            )
-        with expectation:
-            mul.compute_features(*x)
+        mul.compute_features(*x)
+        assert all(
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(mul.input_shape, x)
+        )
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
@@ -4629,14 +4618,10 @@ class TestMultiplicativeBasis(CombinedBasis):
         mul = basis_a * basis_b
 
         mul.set_input_shape(shape_a, shape_b)
-        if add_shape_a == () and add_shape_b == ():
-            expectation = does_not_raise()
-        else:
-            expectation = pytest.raises(
-                ValueError, match="Input shape mismatch detected"
-            )
-        with expectation:
-            mul.compute_features(*x)
+        mul.compute_features(*x)
+        assert all(
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(mul.input_shape, x)
+        )
 
     @pytest.mark.parametrize(
         "basis_a", list_all_basis_classes("Eval") + list_all_basis_classes("Conv")
@@ -4668,14 +4653,10 @@ class TestMultiplicativeBasis(CombinedBasis):
         mul = basis_a * basis_b
 
         mul.set_input_shape(shape_a, shape_b)
-        if add_shape_a == () and add_shape_b == ():
-            expectation = does_not_raise()
-        else:
-            expectation = pytest.raises(
-                ValueError, match="Input shape mismatch detected"
-            )
-        with expectation:
-            mul.compute_features(*x)
+        mul.compute_features(*x)
+        assert all(
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(mul.input_shape, x)
+        )
 
     @pytest.mark.parametrize(
         "inp_shape, expectation",

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1356,7 +1356,7 @@ class TestSharedMethods:
             window_size=30,
             **extra_decay_rates(cls["conv"], 5),
         )
-        bas.set_kernel()
+        bas._set_kernel()
         assert bas.kernel_ is not None
 
     def test_fit_kernel_shape(self, cls):
@@ -1367,7 +1367,7 @@ class TestSharedMethods:
             window_size=30,
             **extra_decay_rates(cls["conv"], n_basis),
         )
-        bas.set_kernel()
+        bas._set_kernel()
         assert bas.kernel_.shape == (30, n_basis)
 
     @pytest.mark.parametrize(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -802,9 +802,10 @@ class TestSharedMethods:
     @pytest.mark.parametrize(
         "num_input, expectation",
         [
-            (0, pytest.raises(TypeError, match="Input dimensionality mismatch")),
+            (0, pytest.raises(TypeError, match="missing 1 required positional argument")),
             (1, does_not_raise()),
-            (2, pytest.raises(TypeError, match="Input dimensionality mismatch")),
+            (2, pytest.raises(TypeError, match="takes 2 positional arguments but 3 were given"
+                                               "")),
         ],
     )
     @pytest.mark.parametrize(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -122,11 +122,17 @@ def test_all_basis_are_tested() -> None:
             "set_input_shape",
             "Set the expected input shape for the basis object",
         ),
+        (
+            "evaluate",
+            "Evaluate the .+ sample points",
+        ),
     ],
 )
 def test_example_docstrings_add(
     basis_cls, method_name, descr_match, basis_class_specific_params
 ):
+    if basis_cls.__name__ in ["HistoryConv", "IdentityEval"] and method_name == "evaluate":
+        return
 
     basis_instance = CombinedBasis().instantiate_basis(
         5, basis_cls, basis_class_specific_params, window_size=10

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -3310,7 +3310,7 @@ class TestAdditiveBasis(CombinedBasis):
                 has_kern += check_kernel(basis_obj.basis2)
             else:
                 has_kern += [
-                    basis_obj.kernel_ is not None if basis_obj.mode == "conv" else True
+                    basis_obj.kernel_ is not None if basis_obj.__class__.__name__.endswith("Conv") else True
                 ]
             return has_kern
 
@@ -4462,7 +4462,7 @@ class TestMultiplicativeBasis(CombinedBasis):
                 has_kern += check_kernel(basis_obj.basis2)
             else:
                 has_kern += [
-                    basis_obj.kernel_ is not None if basis_obj.mode == "conv" else True
+                    basis_obj.kernel_ is not None if basis_obj.__class__.__name__.endswith("Conv") else True
                 ]
             return has_kern
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -131,7 +131,10 @@ def test_all_basis_are_tested() -> None:
 def test_example_docstrings_add(
     basis_cls, method_name, descr_match, basis_class_specific_params
 ):
-    if basis_cls.__name__ in ["HistoryConv", "IdentityEval"] and method_name == "evaluate":
+    if (
+        basis_cls.__name__ in ["HistoryConv", "IdentityEval"]
+        and method_name == "evaluate"
+    ):
         return
 
     basis_instance = CombinedBasis().instantiate_basis(
@@ -802,10 +805,19 @@ class TestSharedMethods:
     @pytest.mark.parametrize(
         "num_input, expectation",
         [
-            (0, pytest.raises(TypeError, match="missing 1 required positional argument")),
+            (
+                0,
+                pytest.raises(
+                    TypeError, match="missing 1 required positional argument"
+                ),
+            ),
             (1, does_not_raise()),
-            (2, pytest.raises(TypeError, match="takes 2 positional arguments but 3 were given"
-                                               "")),
+            (
+                2,
+                pytest.raises(
+                    TypeError, match="takes 2 positional arguments but 3 were given" ""
+                ),
+            ),
         ],
     )
     @pytest.mark.parametrize(
@@ -3394,7 +3406,8 @@ class TestAdditiveBasis(CombinedBasis):
             x = np.random.randn(30, 2), np.random.randn(30, n_input)
             bas.compute_features(*x)
             assert all(
-                xi.shape[1:] == ishape  if xi.ndim != 1 else () == ishape for ishape, xi in zip(bas.input_shape, x)
+                xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape
+                for ishape, xi in zip(bas.input_shape, x)
             )
 
     @pytest.mark.parametrize(
@@ -3429,7 +3442,8 @@ class TestAdditiveBasis(CombinedBasis):
         add.set_input_shape(shape_a, shape_b)
         add.compute_features(*x)
         assert all(
-            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(add.input_shape, x)
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape
+            for ishape, xi in zip(add.input_shape, x)
         )
 
     @pytest.mark.parametrize(
@@ -3464,7 +3478,8 @@ class TestAdditiveBasis(CombinedBasis):
         add.set_input_shape(shape_a, shape_b)
         add.compute_features(*x)
         assert all(
-            xi.shape[1:] == ishape  if xi.ndim != 1 else () == ishape for ishape, xi in zip(add.input_shape, x)
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape
+            for ishape, xi in zip(add.input_shape, x)
         )
 
     @pytest.mark.parametrize(
@@ -3499,7 +3514,8 @@ class TestAdditiveBasis(CombinedBasis):
         add.set_input_shape(shape_a, shape_b)
         add.compute_features(*x)
         assert all(
-            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(add.input_shape, x)
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape
+            for ishape, xi in zip(add.input_shape, x)
         )
 
     @pytest.mark.parametrize(
@@ -4585,7 +4601,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         mul.set_input_shape(shape_a, shape_b)
         mul.compute_features(*x)
         assert all(
-            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(mul.input_shape, x)
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape
+            for ishape, xi in zip(mul.input_shape, x)
         )
 
     @pytest.mark.parametrize(
@@ -4620,7 +4637,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         mul.set_input_shape(shape_a, shape_b)
         mul.compute_features(*x)
         assert all(
-            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(mul.input_shape, x)
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape
+            for ishape, xi in zip(mul.input_shape, x)
         )
 
     @pytest.mark.parametrize(
@@ -4655,7 +4673,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         mul.set_input_shape(shape_a, shape_b)
         mul.compute_features(*x)
         assert all(
-            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape for ishape, xi in zip(mul.input_shape, x)
+            xi.shape[1:] == ishape if xi.ndim != 1 else () == ishape
+            for ishape, xi in zip(mul.input_shape, x)
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -933,8 +933,7 @@ class TestSharedMethods:
             cls[mode], n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5)
         )
         assert (
-            bas.evaluate(np.linspace(0, 1, time_axis_shape)).shape[0]
-            == time_axis_shape
+            bas.evaluate(np.linspace(0, 1, time_axis_shape)).shape[0] == time_axis_shape
         )
 
     @pytest.mark.parametrize(
@@ -3310,7 +3309,11 @@ class TestAdditiveBasis(CombinedBasis):
                 has_kern += check_kernel(basis_obj.basis2)
             else:
                 has_kern += [
-                    basis_obj.kernel_ is not None if basis_obj.__class__.__name__.endswith("Conv") else True
+                    (
+                        basis_obj.kernel_ is not None
+                        if basis_obj.__class__.__name__.endswith("Conv")
+                        else True
+                    )
                 ]
             return has_kern
 
@@ -4462,7 +4465,11 @@ class TestMultiplicativeBasis(CombinedBasis):
                 has_kern += check_kernel(basis_obj.basis2)
             else:
                 has_kern += [
-                    basis_obj.kernel_ is not None if basis_obj.__class__.__name__.endswith("Conv") else True
+                    (
+                        basis_obj.kernel_ is not None
+                        if basis_obj.__class__.__name__.endswith("Conv")
+                        else True
+                    )
                 ]
             return has_kern
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -4,6 +4,7 @@ import re
 from contextlib import nullcontext as does_not_raise
 from functools import partial
 from typing import Literal
+from unittest.mock import patch
 
 import jax.numpy
 import numpy as np
@@ -414,16 +415,17 @@ def test_expected_output_split_by_feature(basis_instance, super_class):
 
 @pytest.mark.parametrize("label", [None, "", "default-behavior", "CoolFeature"])
 def test_repr_label(label):
-    if label == "default-behavior":
-        bas = basis.RaisedCosineLinearEval(n_basis_funcs=5)
-    else:
-        bas = basis.RaisedCosineLinearEval(n_basis_funcs=5, label=label)
-    if label in [None, "default-behavior"]:
-        expected = "RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
-    else:
-        expected = f"'{label}': RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
-    out = repr(bas)
-    assert out == expected
+    with patch("os.get_terminal_size", return_value=(80, 24)):
+        if label == "default-behavior":
+            bas = basis.RaisedCosineLinearEval(n_basis_funcs=5)
+        else:
+            bas = basis.RaisedCosineLinearEval(n_basis_funcs=5, label=label)
+        if label in [None, "default-behavior"]:
+            expected = "RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+        else:
+            expected = f"'{label}': RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+        out = repr(bas)
+        assert out == expected
 
 
 @pytest.mark.parametrize("composite_op", ["add", "multiply"])
@@ -3774,36 +3776,38 @@ class TestAdditiveBasis(CombinedBasis):
     def test_repr_out(
         self, basis_a, basis_b, basis_class_specific_params, expected_out
     ):
-        basis_a_obj = self.instantiate_basis(
-            5, basis_a, basis_class_specific_params, window_size=10
-        )
-        basis_b_obj = self.instantiate_basis(
-            6, basis_b, basis_class_specific_params, window_size=10
-        )
-        basis_obj = basis_a_obj + basis_b_obj
-        assert repr(basis_obj) == expected_out[basis_a]
+        with patch("os.get_terminal_size", return_value=(80, 24)):
+            basis_a_obj = self.instantiate_basis(
+                5, basis_a, basis_class_specific_params, window_size=10
+            )
+            basis_b_obj = self.instantiate_basis(
+                6, basis_b, basis_class_specific_params, window_size=10
+            )
+            basis_obj = basis_a_obj + basis_b_obj
+            assert repr(basis_obj) == expected_out[basis_a]
 
     @pytest.mark.parametrize("label", [None, "", "default-behavior", "CoolFeature"])
     def test_repr_label(self, label, basis_class_specific_params):
-        if label == "default-behavior":
-            bas = basis.RaisedCosineLinearEval(n_basis_funcs=5)
-        else:
-            bas = basis.RaisedCosineLinearEval(n_basis_funcs=5, label=label)
+        with patch("os.get_terminal_size", return_value=(80, 24)):
+            if label == "default-behavior":
+                bas = basis.RaisedCosineLinearEval(n_basis_funcs=5)
+            else:
+                bas = basis.RaisedCosineLinearEval(n_basis_funcs=5, label=label)
 
-        if label in [None, "default-behavior"]:
-            expected_a = "RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
-            exp_name = "RaisedCosineLinearEval"
-        else:
-            expected_a = (
-                f"'{label}': RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+            if label in [None, "default-behavior"]:
+                expected_a = "RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+                exp_name = "RaisedCosineLinearEval"
+            else:
+                expected_a = (
+                    f"'{label}': RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+                )
+                exp_name = label
+            bas = bas + self.instantiate_basis(
+                6, basis.MSplineEval, basis_class_specific_params
             )
-            exp_name = label
-        bas = bas + self.instantiate_basis(
-            6, basis.MSplineEval, basis_class_specific_params
-        )
-        expected = f"'({exp_name} + MSplineEval)': AdditiveBasis(\n    basis1={expected_a},\n    basis2=MSplineEval(n_basis_funcs=6, order=4),\n)"
-        out = repr(bas)
-        assert out == expected
+            expected = f"'({exp_name} + MSplineEval)': AdditiveBasis(\n    basis1={expected_a},\n    basis2=MSplineEval(n_basis_funcs=6, order=4),\n)"
+            out = repr(bas)
+            assert out == expected
 
 
 class TestMultiplicativeBasis(CombinedBasis):
@@ -3959,36 +3963,38 @@ class TestMultiplicativeBasis(CombinedBasis):
     def test_repr_out(
         self, basis_a, basis_b, basis_class_specific_params, expected_out
     ):
-        basis_a_obj = self.instantiate_basis(
-            5, basis_a, basis_class_specific_params, window_size=10
-        )
-        basis_b_obj = self.instantiate_basis(
-            6, basis_b, basis_class_specific_params, window_size=10
-        )
-        basis_obj = basis_a_obj * basis_b_obj
-        assert repr(basis_obj) == expected_out[basis_a]
+        with patch("os.get_terminal_size", return_value=(80, 24)):
+            basis_a_obj = self.instantiate_basis(
+                5, basis_a, basis_class_specific_params, window_size=10
+            )
+            basis_b_obj = self.instantiate_basis(
+                6, basis_b, basis_class_specific_params, window_size=10
+            )
+            basis_obj = basis_a_obj * basis_b_obj
+            assert repr(basis_obj) == expected_out[basis_a]
 
     @pytest.mark.parametrize("label", [None, "", "default-behavior", "CoolFeature"])
     def test_repr_label(self, label, basis_class_specific_params):
-        if label == "default-behavior":
-            bas = basis.RaisedCosineLinearEval(n_basis_funcs=5)
-        else:
-            bas = basis.RaisedCosineLinearEval(n_basis_funcs=5, label=label)
+        with patch("os.get_terminal_size", return_value=(80, 24)):
+            if label == "default-behavior":
+                bas = basis.RaisedCosineLinearEval(n_basis_funcs=5)
+            else:
+                bas = basis.RaisedCosineLinearEval(n_basis_funcs=5, label=label)
 
-        if label in [None, "default-behavior"]:
-            expected_a = "RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
-            exp_name = "RaisedCosineLinearEval"
-        else:
-            expected_a = (
-                f"'{label}': RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+            if label in [None, "default-behavior"]:
+                expected_a = "RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+                exp_name = "RaisedCosineLinearEval"
+            else:
+                expected_a = (
+                    f"'{label}': RaisedCosineLinearEval(n_basis_funcs=5, width=2.0)"
+                )
+                exp_name = label
+            bas = bas * self.instantiate_basis(
+                6, basis.MSplineEval, basis_class_specific_params
             )
-            exp_name = label
-        bas = bas * self.instantiate_basis(
-            6, basis.MSplineEval, basis_class_specific_params
-        )
-        expected = f"'({exp_name} * MSplineEval)': MultiplicativeBasis(\n    basis1={expected_a},\n    basis2=MSplineEval(n_basis_funcs=6, order=4),\n)"
-        out = repr(bas)
-        assert out == expected
+            expected = f"'({exp_name} * MSplineEval)': MultiplicativeBasis(\n    basis1={expected_a},\n    basis2=MSplineEval(n_basis_funcs=6, order=4),\n)"
+            out = repr(bas)
+            assert out == expected
 
     @pytest.mark.parametrize("n_basis_a", [5, 6])
     @pytest.mark.parametrize("n_basis_b", [5, 6])
@@ -6185,40 +6191,41 @@ def test_split_feature_axis(
 
 
 def test_composite_basis_repr_wrapping():
-    # check multi
-    bas = basis.BSplineEval(10) ** 100
-    out = repr(bas)
-    assert out.startswith(
-        "MultiplicativeBasis(\n    basis1=MultiplicativeBasis(\n        basis1=MultiplicativeBasis(\n "
-    )
-    assert out.endswith(
-        "'BSplineEval_98': BSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='BSplineEval_99': BSplineEval(n_basis_funcs=10, order=4),\n)"
-    )
-    assert "    ...\n" in out
+    with patch("os.get_terminal_size", return_value=(80, 24)):
+        # check multi
+        bas = basis.BSplineEval(10) ** 100
+        out = repr(bas)
+        assert out.startswith(
+            "MultiplicativeBasis(\n    basis1=MultiplicativeBasis(\n        basis1=MultiplicativeBasis(\n "
+        )
+        assert out.endswith(
+            "'BSplineEval_98': BSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='BSplineEval_99': BSplineEval(n_basis_funcs=10, order=4),\n)"
+        )
+        assert "    ...\n" in out
 
-    bas = basis.MSplineEval(10, label="0")
-    for k in range(1, 100):
-        bas = bas + basis.MSplineEval(10, label=str(k))
+        bas = basis.MSplineEval(10, label="0")
+        for k in range(1, 100):
+            bas = bas + basis.MSplineEval(10, label=str(k))
 
-    # large additive basis
-    out = repr(bas)
-    assert out.startswith(
-        "AdditiveBasis(\n    basis1=AdditiveBasis(\n        basis1=AdditiveBasis(\n "
-    )
-    assert out.endswith(
-        "        basis2='98': MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='99': MSplineEval(n_basis_funcs=10, order=4),\n)"
-    )
-    assert "    ...\n" in out
+        # large additive basis
+        out = repr(bas)
+        assert out.startswith(
+            "AdditiveBasis(\n    basis1=AdditiveBasis(\n        basis1=AdditiveBasis(\n "
+        )
+        assert out.endswith(
+            "        basis2='98': MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='99': MSplineEval(n_basis_funcs=10, order=4),\n)"
+        )
+        assert "    ...\n" in out
 
-    bas = basis.MSplineEval(10) * 100
-    out = repr(bas)
-    assert out.startswith(
-        "AdditiveBasis(\n    basis1=AdditiveBasis(\n        basis1=AdditiveBasis(\n "
-    )
-    assert out.endswith(
-        "'MSplineEval_98': MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='MSplineEval_99': MSplineEval(n_basis_funcs=10, order=4),\n)"
-    )
-    assert "    ...\n" in out
+        bas = basis.MSplineEval(10) * 100
+        out = repr(bas)
+        assert out.startswith(
+            "AdditiveBasis(\n    basis1=AdditiveBasis(\n        basis1=AdditiveBasis(\n "
+        )
+        assert out.endswith(
+            "'MSplineEval_98': MSplineEval(n_basis_funcs=10, order=4),\n    ),\n    basis2='MSplineEval_99': MSplineEval(n_basis_funcs=10, order=4),\n)"
+        )
+        assert "    ...\n" in out
 
 
 def test_all_public_importable_bases_equal():

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -474,7 +474,7 @@ class TestSharedMethods:
             **extra_decay_rates(cls["eval"], 5),
         )
         with expectation:
-            bas._evaluate(samples)
+            bas.evaluate(samples)
 
     @pytest.mark.parametrize("n_basis", [5, 6])
     @pytest.mark.parametrize("vmin, vmax", [(0, 1), (-1, 1)])
@@ -772,7 +772,7 @@ class TestSharedMethods:
             **extra_decay_rates(cls[mode], n_basis),
         )
         x = np.linspace(0, 1, 10)
-        assert bas._evaluate(x).shape[1] == n_basis
+        assert bas.evaluate(x).shape[1] == n_basis
 
     @pytest.mark.parametrize("n_basis", [6])
     def test_call_equivalent_in_conv(self, n_basis, cls):
@@ -791,7 +791,7 @@ class TestSharedMethods:
             **extra_decay_rates(cls["eval"], n_basis),
         )
         x = np.linspace(0, 1, 10)
-        assert np.all(bas_con._evaluate(x) == bas_eval._evaluate(x))
+        assert np.all(bas_con.evaluate(x) == bas_eval.evaluate(x))
 
     @pytest.mark.parametrize(
         "num_input, expectation",
@@ -813,7 +813,7 @@ class TestSharedMethods:
             **extra_decay_rates(cls[mode], n_basis),
         )
         with expectation:
-            bas._evaluate(*([np.linspace(0, 1, 10)] * num_input))
+            bas.evaluate(*([np.linspace(0, 1, 10)] * num_input))
 
     @pytest.mark.parametrize(
         "inp, expectation",
@@ -841,7 +841,7 @@ class TestSharedMethods:
             if inp.ndim != 1:
                 return
         with expectation:
-            out = bas._evaluate(inp)
+            out = bas.evaluate(inp)
             out2 = bas.evaluate_on_grid(inp.shape[0])[1]
             assert np.all((out.reshape(out.shape[0], -1, n_basis) - out2[:, None]) == 0)
             assert out.shape == tuple((*inp.shape, n_basis))
@@ -864,7 +864,7 @@ class TestSharedMethods:
         inp = np.random.randn(10, 2, 3)
         inp[2, 0, [0, 2]] = np.nan
         inp[4, 1, 1] = np.nan
-        out = bas._evaluate(inp)
+        out = bas.evaluate(inp)
         assert np.all(np.isnan(out[2, 0, [0, 2]]))
         assert np.all(np.isnan(out[4, 1, 1]))
         assert np.isnan(out).sum() == 3 * n_basis
@@ -887,14 +887,14 @@ class TestSharedMethods:
             **extra_decay_rates(cls["eval"], n_basis),
         )  # Only eval mode is relevant here
         with expectation:
-            bas._evaluate(samples)
+            bas.evaluate(samples)
 
     @pytest.mark.parametrize(
         "mode, kwargs", [("eval", {}), ("conv", {"window_size": 8})]
     )
     def test_call_nan(self, mode, kwargs, cls):
         if cls[mode] is HistoryConv:
-            # eval simply returns the _evaluate...
+            # eval simply returns the evaluate...
             return
         elif cls[mode] is IdentityEval:
             n_basis = 1
@@ -908,7 +908,7 @@ class TestSharedMethods:
         )
         x = np.linspace(0, 1, 10)
         x[3] = np.nan
-        assert all(np.isnan(bas._evaluate(x)[3]))
+        assert all(np.isnan(bas.evaluate(x)[3]))
 
     @pytest.mark.parametrize("n_basis", [6, 7])
     @pytest.mark.parametrize(
@@ -922,7 +922,7 @@ class TestSharedMethods:
             **extra_decay_rates(cls[mode], n_basis),
         )
         with pytest.raises(ValueError, match="All sample provided must"):
-            bas._evaluate(np.array([]))
+            bas.evaluate(np.array([]))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
     @pytest.mark.parametrize(
@@ -933,7 +933,7 @@ class TestSharedMethods:
             cls[mode], n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5)
         )
         assert (
-            bas._evaluate(np.linspace(0, 1, time_axis_shape)).shape[0]
+            bas.evaluate(np.linspace(0, 1, time_axis_shape)).shape[0]
             == time_axis_shape
         )
 
@@ -952,7 +952,7 @@ class TestSharedMethods:
             cls[mode], n_basis_funcs=5, **kwargs, **extra_decay_rates(cls[mode], 5)
         )
         with expectation:
-            bas._evaluate(np.linspace(mn, mx, 10))
+            bas.evaluate(np.linspace(mn, mx, 10))
 
     @pytest.mark.parametrize(
         "kwargs, input1_shape, expectation",
@@ -1420,8 +1420,8 @@ class TestSharedMethods:
         )
         x = np.linspace(0, 1, 10)
         x_nap = nap.Tsd(t=np.arange(10), d=x)
-        y = bas._evaluate(x)
-        y_nap = bas._evaluate(x_nap)
+        y = bas.evaluate(x)
+        y_nap = bas.evaluate(x_nap)
         assert isinstance(y_nap, nap.TsdFrame)
         assert np.all(y == y_nap.d)
         assert np.all(y_nap.t == x_nap.t)
@@ -3032,7 +3032,7 @@ class TestAdditiveBasis(CombinedBasis):
                 TypeError, match="Input dimensionality mismatch"
             )
         with expectation:
-            basis_obj._evaluate(*([np.linspace(0, 1, 10)] * num_input))
+            basis_obj.evaluate(*([np.linspace(0, 1, 10)] * num_input))
 
     @pytest.mark.parametrize(
         "inp, expectation",
@@ -3065,7 +3065,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj + basis_b_obj
         with expectation:
-            basis_obj._evaluate(*([inp] * basis_obj._n_input_dimensionality))
+            basis_obj.evaluate(*([inp] * basis_obj._n_input_dimensionality))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
     @pytest.mark.parametrize(" window_size", [8])
@@ -3091,7 +3091,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj + basis_b_obj
         inp = [np.linspace(0, 1, time_axis_shape)] * basis_obj._n_input_dimensionality
-        assert basis_obj._evaluate(*inp).shape[0] == time_axis_shape
+        assert basis_obj.evaluate(*inp).shape[0] == time_axis_shape
 
     @pytest.mark.parametrize(" window_size", [8])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -3130,7 +3130,7 @@ class TestAdditiveBasis(CombinedBasis):
         inp = [np.linspace(0, 1, 10)] * basis_obj._n_input_dimensionality
         for x in inp:
             x[3] = np.nan
-        assert all(np.isnan(basis_obj._evaluate(*inp)[3]))
+        assert all(np.isnan(basis_obj.evaluate(*inp)[3]))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
@@ -3159,7 +3159,7 @@ class TestAdditiveBasis(CombinedBasis):
         bas_con = basis_a_obj + basis_b_obj
 
         x = [np.linspace(0, 1, 10)] * bas_con._n_input_dimensionality
-        assert np.all(bas_con._evaluate(*x) == bas_eva._evaluate(*x))
+        assert np.all(bas_con.evaluate(*x) == bas_eva.evaluate(*x))
 
     @pytest.mark.parametrize(" window_size", [8])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -3185,8 +3185,8 @@ class TestAdditiveBasis(CombinedBasis):
         x = np.linspace(0, 1, 10)
         x_nap = [nap.Tsd(t=np.arange(10), d=x)] * bas._n_input_dimensionality
         x = [x] * bas._n_input_dimensionality
-        y = bas._evaluate(*x)
-        y_nap = bas._evaluate(*x_nap)
+        y = bas.evaluate(*x)
+        y_nap = bas.evaluate(*x_nap)
         assert isinstance(y_nap, nap.TsdFrame)
         assert np.all(y == y_nap.d)
         assert np.all(y_nap.t == x_nap[0].t)
@@ -3214,7 +3214,7 @@ class TestAdditiveBasis(CombinedBasis):
         bas = basis_a_obj + basis_b_obj
         x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
         assert (
-            bas._evaluate(*x).shape[1]
+            bas.evaluate(*x).shape[1]
             == basis_a_obj.n_basis_funcs + basis_b_obj.n_basis_funcs
         )
 
@@ -3240,7 +3240,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         bas = basis_a_obj + basis_b_obj
         with pytest.raises(ValueError, match="All sample provided must"):
-            bas._evaluate(*([np.array([])] * bas._n_input_dimensionality))
+            bas.evaluate(*([np.array([])] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize(
         "mn, mx, expectation",
@@ -3285,7 +3285,7 @@ class TestAdditiveBasis(CombinedBasis):
         )
         bas = basis_a_obj + basis_b_obj
         with expectation:
-            bas._evaluate(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
+            bas.evaluate(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
@@ -4190,7 +4190,7 @@ class TestMultiplicativeBasis(CombinedBasis):
                 TypeError, match="Input dimensionality mismatch"
             )
         with expectation:
-            basis_obj._evaluate(*([np.linspace(0, 1, 10)] * num_input))
+            basis_obj.evaluate(*([np.linspace(0, 1, 10)] * num_input))
 
     @pytest.mark.parametrize(
         "inp, expectation",
@@ -4223,7 +4223,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj * basis_b_obj
         with expectation:
-            basis_obj._evaluate(*([inp] * basis_obj._n_input_dimensionality))
+            basis_obj.evaluate(*([inp] * basis_obj._n_input_dimensionality))
 
     @pytest.mark.parametrize("time_axis_shape", [10, 11, 12])
     @pytest.mark.parametrize(" window_size", [8])
@@ -4249,7 +4249,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         basis_obj = basis_a_obj * basis_b_obj
         inp = [np.linspace(0, 1, time_axis_shape)] * basis_obj._n_input_dimensionality
-        assert basis_obj._evaluate(*inp).shape[0] == time_axis_shape
+        assert basis_obj.evaluate(*inp).shape[0] == time_axis_shape
 
     @pytest.mark.parametrize(" window_size", [8])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -4282,7 +4282,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         inp = [np.linspace(0, 1, 10)] * basis_obj._n_input_dimensionality
         for x in inp:
             x[3] = np.nan
-        assert all(np.isnan(basis_obj._evaluate(*inp)[3]))
+        assert all(np.isnan(basis_obj.evaluate(*inp)[3]))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())
@@ -4311,7 +4311,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         bas_con = basis_a_obj * basis_b_obj
 
         x = [np.linspace(0, 1, 10)] * bas_con._n_input_dimensionality
-        assert np.all(bas_con._evaluate(*x) == bas_eva._evaluate(*x))
+        assert np.all(bas_con.evaluate(*x) == bas_eva.evaluate(*x))
 
     @pytest.mark.parametrize(" window_size", [8])
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
@@ -4337,8 +4337,8 @@ class TestMultiplicativeBasis(CombinedBasis):
         x = np.linspace(0, 1, 10)
         x_nap = [nap.Tsd(t=np.arange(10), d=x)] * bas._n_input_dimensionality
         x = [x] * bas._n_input_dimensionality
-        y = bas._evaluate(*x)
-        y_nap = bas._evaluate(*x_nap)
+        y = bas.evaluate(*x)
+        y_nap = bas.evaluate(*x_nap)
         assert isinstance(y_nap, nap.TsdFrame)
         assert np.all(y == y_nap.d)
         assert np.all(y_nap.t == x_nap[0].t)
@@ -4366,7 +4366,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         bas = basis_a_obj * basis_b_obj
         x = [np.linspace(0, 1, 10)] * bas._n_input_dimensionality
         assert (
-            bas._evaluate(*x).shape[1]
+            bas.evaluate(*x).shape[1]
             == basis_a_obj.n_basis_funcs * basis_b_obj.n_basis_funcs
         )
 
@@ -4392,7 +4392,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         bas = basis_a_obj * basis_b_obj
         with pytest.raises(ValueError, match="All sample provided must"):
-            bas._evaluate(*([np.array([])] * bas._n_input_dimensionality))
+            bas.evaluate(*([np.array([])] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize(
         "mn, mx, expectation",
@@ -4437,7 +4437,7 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
         bas = basis_a_obj * basis_b_obj
         with expectation:
-            bas._evaluate(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
+            bas.evaluate(*([np.linspace(mn, mx, 10)] * bas._n_input_dimensionality))
 
     @pytest.mark.parametrize("basis_a", list_all_basis_classes())
     @pytest.mark.parametrize("basis_b", list_all_basis_classes())

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -200,6 +200,68 @@ def test_example_docstrings_add(
         assert f" {basis_name}" not in doc_components[1]
 
 
+@pytest.mark.parametrize(
+    "public_class, meth_super",
+    [
+        ("IdentityEval", "IdentityBasis"),
+        ("HistoryConv", "HistoryBasis"),
+        ("MSplineEval", "MSplineBasis"),
+        ("MSplineConv", "MSplineBasis"),
+        ("BSplineEval", "BSplineBasis"),
+        ("BSplineConv", "BSplineBasis"),
+        ("CyclicBSplineEval", "CyclicBSplineBasis"),
+        ("CyclicBSplineConv", "CyclicBSplineBasis"),
+        ("RaisedCosineLinearEval", "RaisedCosineBasisLinear"),
+        ("RaisedCosineLinearConv", "RaisedCosineBasisLinear"),
+        ("RaisedCosineLogEval", "RaisedCosineBasisLog"),
+        ("RaisedCosineLogConv", "RaisedCosineBasisLog"),
+        ("OrthExponentialEval", "OrthExponentialBasis"),
+        ("OrthExponentialConv", "OrthExponentialBasis"),
+    ],
+)
+@pytest.mark.parametrize("method", ["evaluate", "split_by_feature", "evaluate_on_grid"])
+def test_docstrings_decorator_superclass(public_class, meth_super, method):
+    cls_pub = getattr(basis, public_class)
+    cls_sup = getattr(basis, meth_super)
+    meth_pub = getattr(cls_pub, method)
+    meth_super = getattr(cls_sup, method)
+    assert meth_pub.__doc__.startswith(meth_super.__doc__)
+
+
+@pytest.mark.parametrize(
+    "public_class",
+    [
+        "IdentityEval",
+        "HistoryConv",
+        "MSplineEval",
+        "MSplineConv",
+        "BSplineEval",
+        "BSplineConv",
+        "CyclicBSplineEval",
+        "CyclicBSplineConv",
+        "RaisedCosineLinearEval",
+        "RaisedCosineLinearConv",
+        "RaisedCosineLogEval",
+        "RaisedCosineLogConv",
+        "OrthExponentialEval",
+        "OrthExponentialConv",
+    ],
+)
+@pytest.mark.parametrize(
+    "method, mixin",
+    [("set_input_shape", "AtomicBasisMixin"), ("compute_features", None)],
+)
+def test_docstrings_decorator_mixinclass(public_class, mixin, method):
+    cls_pub = getattr(basis, public_class)
+    if mixin is None:
+        mixin = "EvalBasisMixin" if public_class.endswith("Eval") else "ConvBasisMixin"
+        mixin_meth = getattr(getattr(basis, mixin), "_" + method)
+    else:
+        mixin_meth = getattr(getattr(basis, mixin), method)
+    meth_pub = getattr(cls_pub, method)
+    assert meth_pub.__doc__.startswith(mixin_meth.__doc__)
+
+
 def test_add_docstring():
 
     class CustomClass:

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -403,7 +403,6 @@ def test_transformerbasis_dir(basis_cls, basis_class_specific_params):
         "transform",
         "fit_transform",
         "n_basis_funcs",
-        "mode",
         "window_size",
     ):
         if (

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -1,6 +1,7 @@
 import pickle
 from contextlib import nullcontext as does_not_raise
 from copy import deepcopy
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -68,9 +69,9 @@ def test_to_transformer_and_constructor_are_equivalent(
 
     # they both just have a _basis
     assert (
-        list(trans_bas_a.__dict__.keys())
-        == list(trans_bas_b.__dict__.keys())
-        == ["basis", "_wrapped_methods"]
+        set(trans_bas_a.__dict__.keys())
+        == set(trans_bas_b.__dict__.keys())
+        == {"_basis", "_wrapped_methods"}
     )
     # and those bases are the same
     assert np.all(
@@ -996,14 +997,17 @@ def test_check_input(inp, expectation, basis_cls, basis_class_specific_params, m
     ],
 )
 def test_repr_out(basis_cls, basis_class_specific_params, expected_out):
-    bas = CombinedBasis().instantiate_basis(
-        5, basis_cls, basis_class_specific_params, window_size=10
-    )
-    bas = bas.set_input_shape(*([10] * bas._n_input_dimensionality)).to_transformer()
-    out = expected_out.get(basis_cls, "")
-    if out == "":
-        raise ValueError(f"Missing test case for {basis_cls}!")
-    assert repr(bas) == out
+    with patch("os.get_terminal_size", return_value=(80, 24)):
+        bas = CombinedBasis().instantiate_basis(
+            5, basis_cls, basis_class_specific_params, window_size=10
+        )
+        bas = bas.set_input_shape(
+            *([10] * bas._n_input_dimensionality)
+        ).to_transformer()
+        out = expected_out.get(basis_cls, "")
+        if out == "":
+            raise ValueError(f"Missing test case for {basis_cls}!")
+        assert repr(bas) == out
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## API Simplifications
This PR is intended as a step towards simplifying the definition of a custom basis. In particular the following simplifications to the API have been carried on:

- removed the `mode` attribute in basis.
- re-computed input shape at every `compute_features` call, by always invoking `setup_basis`
- removed the abstract method `_set_input_independent_states`. This is called internally by the setup_basis of our NeMoS implementation but won't be needed for a valid custom basis.
- `_evaluate` moved to public method. This is used to compute the kernels and by `evaluate_on_grid`.
- rely on function to get equi-spaced samples in `_get_samples`. This would make it easier to generalize the behavior of `evaluate_on_grid` for a custom basis. Note that evaluate on grid may not make sense for a general basis. For example, if the basis is handling videos, i.e. the input is very high dimensional, then creating a grid in such high dimension is unfeasible and the visualization does not make sense for that. We should probably implement a try/catch if the basis do not implement `evaluate_on_grid`, then raise a `NotImplementedError` and it is up to a user to define the method if needed. 
- Infer input dimensionality from `compute_features` signature if private attribute is not available.
- `set_kernel` method of ConvBasisMixin made private.

### Basis Mechanics

#### Initialization of Composite basis
- Moved input dimensionality computation to `CompositeBasis`. 
- Infer input dim based on `compute_features` if attribute `_n_input_dimensionality` is not found.

#### Abstract Methods
- `setup_basis`: compute states like the input shape and kernels for convolution.
- `set_input_shape`: sets the input shape without requiring the `compute_features` call.
- `evaluate`: performs the evaluation of the basis at provided sample points. it is the non-linearity itself, it is used by `evaluate_on_grid` and `setup_basis` in `ConvBasisMixin` bases to compute the kernels. Apply the non-linearity to all elements of a ND array. does not reshape the input, add an extra dimension of size `n_basis_funcs`.
- `_compute_features`: calls evaluate and reshape to 2D by flattening all the dimensions but the first. This private method is an "unsafe" `compute_features` that does not call `setup_basis` nor perform checks. `CompositeBasisMixin` rely on this method to avoid setting up the sub-bases multiple times. If in the future we will want to guarantee that the basis are auto-differentiable, this is the method we should target.

#### Public Concrete Methods
- `compute_features`: calls `setup_basis`, then `_check_input_shape_consistency`, finally  `_compute_features`.
- `evaluate_on_grid`: gets the samples. As a default relies on the function `get_equi_spaced_samples` but behavior can be overwritten by re-implementing a `_get_samples` method.
- `split_by_feature`: splits the an array over its feature axis into a bunch of slices, one for each additive component. For our basis, it further reshape the output to  `(*input.shape[1:], n_basis_funcs)`. For a custom basis, the best we will be able to do is split by component (since we will could store the output shape once compute feature is called), but we won't know a priori how to reshape the feature axis.
- `get_params`/`set_params`/`to_transformer`: sklearn compatibility methods.
- `set_kernel`: this is for `ConvBasisMixin` and should be probably dropped, requiring only a `setup_basis` for simplicity.

#### Improved Private methods
- `_check_input_dimensionality` won't rely on the attribute `_n_input_dimensionality`, and try to infer the number of time series input based on `compute_features` if not provided.

### Unexpected failure of doctests 
Adding more examples for the now public method evaluate changed the state of the numpy seed, this resulted in divergent recurrent simulations. I enforced a seed and reduced the coefficient magnitude to assure stability.