### PR TITLE
Fix convergence tests not testing (Prox)SVRG

### DIFF
--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -35,11 +35,11 @@ def test_unregularized_convergence(solver_names):
     rate = jax.numpy.exp(jax.numpy.einsum("k,tk->t", w_true, X) + b_true)
     y = np.random.poisson(rate)
 
-    # instantiate and fit unregularized GLM with GradientDescent
+    # instantiate and fit unregularized GLM with GradientDescent or SVRG
     model_GD = nmo.glm.GLM(solver_name=solver_names[0], solver_kwargs=dict(tol=10**-12))
     model_GD.fit(X, y)
 
-    # instantiate and fit unregularized GLM with ProximalGradient
+    # instantiate and fit unregularized GLM with ProximalGradient or ProxSVRG
     model_PG = nmo.glm.GLM(solver_name=solver_names[1], solver_kwargs=dict(tol=10**-12))
     model_PG.fit(X, y)
 
@@ -73,7 +73,7 @@ def test_ridge_convergence(solver_names):
     rate = jax.numpy.exp(jax.numpy.einsum("k,tk->t", w_true, X) + b_true)
     y = np.random.poisson(rate)
 
-    # instantiate and fit ridge GLM with GradientDescent
+    # instantiate and fit ridge GLM with GradientDescent or SVRG
     model_GD = nmo.glm.GLM(
         solver_name=solver_names[0],
         regularizer_strength=1.0,
@@ -82,7 +82,7 @@ def test_ridge_convergence(solver_names):
     )
     model_GD.fit(X, y)
 
-    # instantiate and fit ridge GLM with ProximalGradient
+    # instantiate and fit ridge GLM with ProximalGradient or ProxSVRG
     model_PG = nmo.glm.GLM(
         solver_name=solver_names[1],
         regularizer_strength=1.0,
@@ -109,7 +109,7 @@ def test_lasso_convergence(solver_name):
     w = [0.5]  # define some weights
     y = np.random.poisson(np.exp(X.dot(w)))  # observed counts
 
-    # instantiate and fit GLM with ProximalGradient
+    # instantiate and fit GLM with ProximalGradient or ProxSVRG
     model_PG = nmo.glm.GLM(
         regularizer="Lasso",
         regularizer_strength=1.0,
@@ -158,7 +158,7 @@ def test_group_lasso_convergence(solver_name):
     mask[0] = [1, 1, 0]  # Group 0 includes features 0 and 1
     mask[1] = [0, 0, 1]  # Group 1 includes features 1
 
-    # instantiate and fit GLM with ProximalGradient
+    # instantiate and fit GLM with ProximalGradient or ProxSVRG
     model_PG = nmo.glm.GLM(
         solver_name=solver_name,
         regularizer=nmo.regularizer.GroupLasso(mask=mask),

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -16,6 +16,7 @@ def test_unregularized_convergence(solver_names):
     """
     Assert that solution found when using GradientDescent vs ProximalGradient with an
     unregularized GLM is the same.
+    Also for SVRG vs ProxSVRG.
     """
     jax.config.update("jax_enable_x64", True)
 
@@ -55,6 +56,7 @@ def test_ridge_convergence(solver_names):
     """
     Assert that solution found when using GradientDescent vs ProximalGradient with an
     ridge GLM is the same.
+    Also for SVRG vs ProxSVRG.
     """
     jax.config.update("jax_enable_x64", True)
     # generate toy data
@@ -99,7 +101,7 @@ def test_ridge_convergence(solver_names):
 @pytest.mark.parametrize("solver_name", ["ProximalGradient", "ProxSVRG"])
 def test_lasso_convergence(solver_name):
     """
-    Assert that solution found when using ProximalGradient versus Nelder-Mead method using
+    Assert that solution found when using ProximalGradient or ProxSVRG versus Nelder-Mead method using
     lasso GLM is the same.
     """
     jax.config.update("jax_enable_x64", True)
@@ -144,7 +146,7 @@ def test_lasso_convergence(solver_name):
 @pytest.mark.parametrize("solver_name", ["ProximalGradient", "ProxSVRG"])
 def test_group_lasso_convergence(solver_name):
     """
-    Assert that solution found when using ProximalGradient versus Nelder-Mead method using
+    Assert that solution found when using ProximalGradient or ProxSVRG versus Nelder-Mead method using
     group lasso GLM is the same.
     """
     jax.config.update("jax_enable_x64", True)

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -36,13 +36,11 @@ def test_unregularized_convergence(solver_names):
     y = np.random.poisson(rate)
 
     # instantiate and fit unregularized GLM with GradientDescent
-    model_GD = nmo.glm.GLM(solver_kwargs=dict(tol=10**-12))
+    model_GD = nmo.glm.GLM(solver_name=solver_names[0], solver_kwargs=dict(tol=10**-12))
     model_GD.fit(X, y)
 
     # instantiate and fit unregularized GLM with ProximalGradient
-    model_PG = nmo.glm.GLM(
-        solver_name="ProximalGradient", solver_kwargs=dict(tol=10**-12)
-    )
+    model_PG = nmo.glm.GLM(solver_name=solver_names[1], solver_kwargs=dict(tol=10**-12))
     model_PG.fit(X, y)
 
     # assert weights are the same
@@ -77,15 +75,18 @@ def test_ridge_convergence(solver_names):
 
     # instantiate and fit ridge GLM with GradientDescent
     model_GD = nmo.glm.GLM(
-        regularizer_strength=1.0, regularizer="Ridge", solver_kwargs=dict(tol=10**-12)
+        solver_name=solver_names[0],
+        regularizer_strength=1.0,
+        regularizer="Ridge",
+        solver_kwargs=dict(tol=10**-12),
     )
     model_GD.fit(X, y)
 
     # instantiate and fit ridge GLM with ProximalGradient
     model_PG = nmo.glm.GLM(
+        solver_name=solver_names[1],
         regularizer_strength=1.0,
         regularizer="Ridge",
-        solver_name="ProximalGradient",
         solver_kwargs=dict(tol=10**-12),
     )
     model_PG.fit(X, y)
@@ -112,7 +113,7 @@ def test_lasso_convergence(solver_name):
     model_PG = nmo.glm.GLM(
         regularizer="Lasso",
         regularizer_strength=1.0,
-        solver_name="ProximalGradient",
+        solver_name=solver_name,
         solver_kwargs=dict(tol=10**-12),
     )
     model_PG.regularizer_strength = 0.1
@@ -159,6 +160,7 @@ def test_group_lasso_convergence(solver_name):
 
     # instantiate and fit GLM with ProximalGradient
     model_PG = nmo.glm.GLM(
+        solver_name=solver_name,
         regularizer=nmo.regularizer.GroupLasso(mask=mask),
         solver_kwargs=dict(tol=10**-14, maxiter=10000),
         regularizer_strength=0.2,


### PR DESCRIPTION
The tests were originally implemented for `GradientDescent` and `ProximalGradient`, then later parametrized to include `SVRG` and `ProxSVRG`, but the function bodies didn't actually use the parameters.
This fixes that, actually running the tests for `(Prox)SVRG`.