### PR TITLE
add inspect utils to modules (otherwise it won't be packaged for dist)

### DIFF
--- a/src/nemos/__init__.py
+++ b/src/nemos/__init__.py
@@ -3,6 +3,7 @@ from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
 from importlib.metadata import version as _get_version
 
 from . import (
+    _inspect_utils,
     basis,
     convolve,
     exceptions,


### PR DESCRIPTION
`_inspect_utils` is now used in the main code and needs to be added to the modules in order to be added to the build.