### PR TITLE
String obs model

### DIFF
--- a/src/nemos/_observation_model_builder.py
+++ b/src/nemos/_observation_model_builder.py
@@ -14,8 +14,12 @@ def instantiate_observation_model(observation_model: str):
 
     Returns
     -------
-        The instantiated observation model.
+        The observation model instance with default parameters.
 
+    Raises
+    ------
+    ValueError
+        If the `observation_model` provided does not match to any available observation models.
     """
     if observation_model == "Poisson":
         return PoissonObservations()

--- a/src/nemos/_observation_model_builder.py
+++ b/src/nemos/_observation_model_builder.py
@@ -1,0 +1,28 @@
+from .observation_models import GammaObservations, PoissonObservations
+
+AVAILABLE_OBSERVATION_MODELS = ["Poisson", "Gamma"]
+
+
+def instantiate_observation_model(observation_model: str):
+    """
+    Create an observation model from a given name.
+
+    Parameters
+    ----------
+    observation_model:
+        The observation model as a string.
+
+    Returns
+    -------
+        The instantiated observation model.
+
+    """
+    if observation_model == "Poisson":
+        return PoissonObservations()
+    elif observation_model == "Gamma":
+        return GammaObservations()
+    else:
+        raise ValueError(
+            f"Unknown observation model: {observation_model}. "
+            f"Observation model must be one of {AVAILABLE_OBSERVATION_MODELS}"
+        )

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -160,14 +160,14 @@ class GLM(BaseRegressor):
     >>> # define a Gamma GLM providing a string
     >>> nmo.glm.GLM(observation_model="Gamma")
     GLM(
-        observation_model=GammaObservations(inverse_link_function=1/x),
+        observation_model=GammaObservations(inverse_link_function=one_over_x),
         regularizer=UnRegularized(),
         solver_name='GradientDescent'
     )
     >>> # or equivalently, passing the observation model object
     >>> nmo.glm.GLM(observation_model=nmo.observation_models.GammaObservations())
     GLM(
-        observation_model=GammaObservations(inverse_link_function=1/x),
+        observation_model=GammaObservations(inverse_link_function=one_over_x),
         regularizer=UnRegularized(),
         solver_name='GradientDescent'
     )

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -14,6 +14,7 @@ from numpy.typing import ArrayLike
 
 from . import observation_models as obs
 from . import tree_utils, validation
+from ._observation_model_builder import instantiate_observation_model
 from .base_regressor import BaseRegressor
 from .exceptions import NotFittedError
 from .initialize_regressor import initialize_intercept_matching_mean_rate
@@ -167,7 +168,9 @@ class GLM(BaseRegressor):
 
     def __init__(
         self,
-        observation_model: obs.Observations = obs.PoissonObservations(),
+        # With python 3.11 Literal[*AVAILABLE_OBSERVATION_MODELS] will be allowed.
+        # Replace this manual list after dropping support for 3.10?
+        observation_model: obs.Observations | Literal["Poisson", "Gamma"] = "Poisson",
         regularizer: Union[str, Regularizer] = "UnRegularized",
         regularizer_strength: Optional[float] = None,
         solver_name: str = None,
@@ -196,6 +199,8 @@ class GLM(BaseRegressor):
 
     @observation_model.setter
     def observation_model(self, observation: obs.Observations):
+        if isinstance(observation, str):
+            observation = instantiate_observation_model(observation)
         # check that the model has the required attributes
         # and that the attribute can be called
         obs.check_observation_model(observation)
@@ -1283,7 +1288,7 @@ class PopulationGLM(GLM):
 
     def __init__(
         self,
-        observation_model: obs.Observations = obs.PoissonObservations(),
+        observation_model: obs.Observations | Literal["Poisson", "Gamma"] = "Poisson",
         regularizer: Union[str, Regularizer] = "UnRegularized",
         regularizer_strength: Optional[float] = None,
         solver_name: str = None,

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -157,6 +157,20 @@ class GLM(BaseRegressor):
     Regularizer type:  <class 'nemos.regularizer.UnRegularized'>
     >>> print("Observation model: ", type(model.observation_model))
     Observation model:  <class 'nemos.observation_models.PoissonObservations'>
+    >>> # define a Gamma GLM providing a string
+    >>> nmo.glm.GLM(observation_model="Gamma")
+    GLM(
+        observation_model=GammaObservations(inverse_link_function=<lambda>),
+        regularizer=UnRegularized(),
+        solver_name='GradientDescent'
+    )
+    >>> # or equivalently, passing the observation model object
+    >>> nmo.glm.GLM(observation_model=nmo.observation_models.GammaObservations())
+    GLM(
+        observation_model=GammaObservations(inverse_link_function=<lambda>),
+        regularizer=UnRegularized(),
+        solver_name='GradientDescent'
+    )
     >>> # define GLM model of PoissonObservations model with soft-plus NL
     >>> observation_models = nmo.observation_models.PoissonObservations(jax.nn.softplus)
     >>> model = nmo.glm.GLM(observation_model=observation_models, solver_name="LBFGS")

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -160,14 +160,14 @@ class GLM(BaseRegressor):
     >>> # define a Gamma GLM providing a string
     >>> nmo.glm.GLM(observation_model="Gamma")
     GLM(
-        observation_model=GammaObservations(inverse_link_function=<lambda>),
+        observation_model=GammaObservations(inverse_link_function=1/x),
         regularizer=UnRegularized(),
         solver_name='GradientDescent'
     )
     >>> # or equivalently, passing the observation model object
     >>> nmo.glm.GLM(observation_model=nmo.observation_models.GammaObservations())
     GLM(
-        observation_model=GammaObservations(inverse_link_function=<lambda>),
+        observation_model=GammaObservations(inverse_link_function=1/x),
         regularizer=UnRegularized(),
         solver_name='GradientDescent'
     )

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -660,7 +660,10 @@ class GammaObservations(Observations):
 
     """
 
-    def __init__(self, inverse_link_function=lambda x: jnp.power(x, -1)):
+    def __init__(
+        self,
+        inverse_link_function=utils.NamedFunction(lambda x: jnp.power(x, -1), "1/x"),
+    ):
         super().__init__(inverse_link_function=inverse_link_function)
         self.scale = 1.0
 

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -890,6 +890,10 @@ def check_observation_model(observation_model):
     ...                     jnp.sum((y_true - y_true.mean()) ** 2))
     ...     def sample_generator(self, key, params, scale=1.):
     ...         return jax.random.bernoulli(key, params)
+    ...     def estimate_scale(self, y, predicted_rate, dof_resid):
+    ...         return 1
+    ...     def log_likelihood(self, params, y_true, aggregate_sample_scores=jnp.mean):
+    ...         return -self._negative_log_likelihood(params, y_true, aggregate_sample_scores)
     >>> model = MyObservationModel()
     >>> check_observation_model(model)  # Should pass without error if the model is correctly implemented.
     """

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -662,7 +662,7 @@ class GammaObservations(Observations):
 
     def __init__(
         self,
-        inverse_link_function=utils.NamedFunction(lambda x: jnp.power(x, -1), "1/x"),
+        inverse_link_function=utils.one_over_x,
     ):
         super().__init__(inverse_link_function=inverse_link_function)
         self.scale = 1.0

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -593,3 +593,15 @@ def _get_terminal_size():
         cols, rows = shutil.get_terminal_size()
 
     return cols, rows
+
+
+class NamedFunction:
+    def __init__(self, func, name=None):
+        self.func = func
+        self.name = name or func.__name__
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    def __repr__(self):
+        return self.name

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -595,13 +595,5 @@ def _get_terminal_size():
     return cols, rows
 
 
-class NamedFunction:
-    def __init__(self, func: Callable, name: Optional[str]=None):
-        self.func = func
-        self.name = name or func.__name__
-
-    def __call__(self, *args, **kwargs):
-        return self.func(*args, **kwargs)
-
-    def __repr__(self):
-        return self.name
+def one_over_x(x):
+    return jnp.power(x, -1)

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -596,7 +596,7 @@ def _get_terminal_size():
 
 
 class NamedFunction:
-    def __init__(self, func, name=None):
+    def __init__(self, func: Callable, name: Optional[str]=None):
         self.func = func
         self.name = name or func.__name__
 

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -54,6 +54,7 @@ def test_glm_instantiation_from_string_at_init(
 )
 @pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
 def test_glm_setter_observation_model(obs_model_string, glm_class, expectation):
+    """Test that the observation model can be set after the init providing the string."""
     if obs_model_string == "Gamma":
         obs = nmo.observation_models.PoissonObservations()
     else:

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -54,7 +54,7 @@ def test_glm_instantiation_from_string_at_init(
 )
 @pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
 def test_glm_setter_observation_model(obs_model_string, glm_class, expectation):
-    """Test that the observation model can be set after the init providing the string."""
+    """Test that the observation model can be set after the init providing a string."""
     if obs_model_string == "Gamma":
         obs = nmo.observation_models.PoissonObservations()
     else:

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -34,7 +34,9 @@ def gamma_observations():
     ],
 )
 @pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
-def test_glm_instantiation_from_string_at_init(obs_model_string, glm_class, expectation):
+def test_glm_instantiation_from_string_at_init(
+    obs_model_string, glm_class, expectation
+):
     with expectation:
         glm_class(observation_model=obs_model_string)
 

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -23,7 +23,7 @@ def gamma_observations():
 
 
 @pytest.mark.parametrize(
-    "obs_mode_string, expectation",
+    "obs_model_string, expectation",
     [
         ("Poisson", does_not_raise()),
         ("Gamma", does_not_raise()),
@@ -34,13 +34,13 @@ def gamma_observations():
     ],
 )
 @pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
-def test_glm_instantiation_from_string_at_init(obs_mode_string, glm_class, expectation):
+def test_glm_instantiation_from_string_at_init(obs_model_string, glm_class, expectation):
     with expectation:
-        glm_class(observation_model=obs_mode_string)
+        glm_class(observation_model=obs_model_string)
 
 
 @pytest.mark.parametrize(
-    "obs_mode_string, expectation",
+    "obs_model_string, expectation",
     [
         ("Poisson", does_not_raise()),
         ("Gamma", does_not_raise()),
@@ -51,19 +51,19 @@ def test_glm_instantiation_from_string_at_init(obs_mode_string, glm_class, expec
     ],
 )
 @pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
-def test_glm_setter_observation_model(obs_mode_string, glm_class, expectation):
-    if obs_mode_string == "Gamma":
+def test_glm_setter_observation_model(obs_model_string, glm_class, expectation):
+    if obs_model_string == "Gamma":
         obs = nmo.observation_models.PoissonObservations()
     else:
         obs = nmo.observation_models.GammaObservations()
     model = glm_class(observation_model=obs)
     with expectation:
-        model.observation_model = obs_mode_string
-    if obs_mode_string == "Gamma":
+        model.observation_model = obs_model_string
+    if obs_model_string == "Gamma":
         assert isinstance(
             model.observation_model, nmo.observation_models.GammaObservations
         )
-    elif obs_mode_string == "Poisson":
+    elif obs_model_string == "Poisson":
         assert isinstance(
             model.observation_model, nmo.observation_models.PoissonObservations
         )

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -22,6 +22,53 @@ def gamma_observations():
     return nmo.observation_models.GammaObservations
 
 
+@pytest.mark.parametrize(
+    "obs_mode_string, expectation",
+    [
+        ("Poisson", does_not_raise()),
+        ("Gamma", does_not_raise()),
+        (
+            "invalid",
+            pytest.raises(ValueError, match="Unknown observation model: invalid"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
+def test_glm_instantiation_from_string_at_init(obs_mode_string, glm_class, expectation):
+    with expectation:
+        glm_class(observation_model=obs_mode_string)
+
+
+@pytest.mark.parametrize(
+    "obs_mode_string, expectation",
+    [
+        ("Poisson", does_not_raise()),
+        ("Gamma", does_not_raise()),
+        (
+            "invalid",
+            pytest.raises(ValueError, match="Unknown observation model: invalid"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
+def test_glm_setter_observation_model(obs_mode_string, glm_class, expectation):
+    if obs_mode_string == "Gamma":
+        obs = nmo.observation_models.PoissonObservations()
+    else:
+        obs = nmo.observation_models.GammaObservations()
+    model = glm_class(observation_model=obs)
+    with expectation:
+        model.observation_model = obs_mode_string
+    if obs_mode_string == "Gamma":
+        assert isinstance(
+            model.observation_model, nmo.observation_models.GammaObservations
+        )
+    elif obs_mode_string == "Poisson":
+        assert isinstance(
+            model.observation_model, nmo.observation_models.PoissonObservations
+        )
+
+
 class TestPoissonObservations:
     @pytest.mark.parametrize("link_function", [jnp.exp, jax.nn.softplus, 1])
     def test_initialization_link_is_callable(self, link_function, poisson_observations):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -635,22 +635,3 @@ def test_shape_param_exclusion():
 
     obj = Example(a=np.arange(3), b=1, c=None)
     assert utils.format_repr(obj) == "Example(b=1, d=1)"
-
-
-def test_named_func_repr():
-    f = utils.NamedFunction(lambda x: x, "identity")
-    assert repr(f) == "identity"
-
-
-def test_named_func_call():
-    f = utils.NamedFunction(lambda x: x, "identity")
-    x = np.random.rand(10, 2)
-    assert np.all(f(x) == x)
-
-
-def test_named_func_jax_diff():
-    f = utils.NamedFunction(lambda x: jnp.exp(2 * x).sum(), "exp")
-    # this is lazy, must try to compute to get the error
-    fgrad = jax.grad(f)
-    x = np.linspace(0, 1, 4)
-    assert np.all(fgrad(x) == 2 * jnp.exp(2 * x))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -635,3 +635,22 @@ def test_shape_param_exclusion():
 
     obj = Example(a=np.arange(3), b=1, c=None)
     assert utils.format_repr(obj) == "Example(b=1, d=1)"
+
+
+def test_named_func_repr():
+    f = utils.NamedFunction(lambda x: x, "identity")
+    assert repr(f) == "identity"
+
+
+def test_named_func_call():
+    f = utils.NamedFunction(lambda x: x, "identity")
+    x = np.random.rand(10, 2)
+    assert np.all(f(x) == x)
+
+
+def test_named_func_jax_diff():
+    f = utils.NamedFunction(lambda x: jnp.exp(2 * x).sum(), "exp")
+    # this is lazy, must try to compute to get the error
+    fgrad = jax.grad(f)
+    x = np.linspace(0, 1, 4)
+    assert np.all(fgrad(x) == 2 * jnp.exp(2 * x))


### PR DESCRIPTION
This PR adds the possibility of defining an observation model from a string, in the same way one can initialize the regularizer with a string. The implementation mimics the regularizer builder.

Addresses #319 