### PR TITLE
Drop NaNs in `GLM.initialize_state`

### DIFF
--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -982,6 +982,7 @@ class GLM(BaseRegressor):
 
         return init_params
 
+    @cast_to_jax
     def initialize_state(
         self,
         X: DESIGN_INPUT_TYPE,

--- a/src/nemos/glm.py
+++ b/src/nemos/glm.py
@@ -1019,10 +1019,15 @@ class GLM(BaseRegressor):
         >>> opt_state = model.initialize_state(X, y, params)
         >>> # Now ready to run optimization or update steps
         """
-        if isinstance(X, FeaturePytree):
-            data = X.data
-        else:
-            data = X
+        # find non-nans
+        is_valid = tree_utils.get_valid_multitree(X, y)
+
+        # drop nans
+        X = jax.tree_util.tree_map(lambda x: x[is_valid], X)
+        y = jax.tree_util.tree_map(lambda x: x[is_valid], y)
+
+        # grab the data
+        data = X.data if isinstance(X, FeaturePytree) else X
 
         # check if mask has been set is using group lasso
         # if mask has not been set, use a single group as default
@@ -1485,7 +1490,6 @@ class PopulationGLM(GLM):
         self._check_mask(X, y, params)
 
     def _check_mask(self, X, y, params):
-
         if isinstance(X, FeaturePytree):
             data = X.data
         else:


### PR DESCRIPTION
Fitting a GLM to data containing NaNs with the `jaxopt.LBFGS` solver worked when using `GLM.fit`, but not when writing the training loop in Python and calling `GLM.update` repeatedly.
The problem was that this solver uses the data to initialize its state, and the state was populated with NaNs by `GLM.initialize_state`.
Dropping NaNs from the input data in `GLM.initialize_state` -- as is done in `GLM.update` and `GLM.run` -- solved this problem.