### PR TITLE
Split relative and external link checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,6 @@ jobs:
       - name: Install markdown-link-check
         run: npm install -g markdown-link-check
 
-      - name: Install markdown-link-check locally
-        run: npm ci
-
       - name: Make .sh executable
         run: chmod +x bash_scripts/check_markdown_links.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,28 +81,58 @@ jobs:
       - name: Check links
         run: ./bash_scripts/prevent_absolute_links_to_docs.sh
 
-  check-links:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+  check-relative-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Install markdown-link-check
-          run: npm install -g markdown-link-check
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
 
-        - name: Make .sh executable
-          run: chmod +x bash_scripts/check_markdown_links.sh
+      - name: Install markdown-link-check locally
+        run: npm ci
 
-        - name: Check links in root Markdown files
-          run: ./bash_scripts/check_markdown_links.sh
+      - name: Make .sh executable
+        run: chmod +x bash_scripts/check_markdown_links.sh
 
+      - name: Check relative links in root Markdown files
+        run: ./bash_scripts/check_markdown_links.sh relative
+
+  check-external-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install markdown-link-check locally
+        run: npm ci
+
+      - name: Make .sh executable
+        run: chmod +x bash_scripts/check_markdown_links.sh
+
+      - name: Check external links in root Markdown files
+        run: ./bash_scripts/check_markdown_links.sh external
   check:
     if: ${{ !github.event.pull_request.draft }}
     needs:
       - tox_tests
       - prevent_docs_absolute_links
       - tox_check
-      - check-links
+      - check-relative-links
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether all tests and notebooks succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,21 @@
 name: ci
 
 on:
-   workflow_dispatch:
-   schedule:
-     - cron: 0 0 1 * 0     # monthly
-   pull_request:
-     branches:
-       - main
-       - development
-     types:
-       - opened
-       - reopened
-       - synchronize
-       - ready_for_review
-   push:
-     branches:
-       - main
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 1 * 0     # monthly
+  pull_request:
+    branches:
+      - main
+      - development
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - main
 
 jobs:
   tox_tests:
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4 # Use v4 for compatibility with pyproject.toml
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4 # Use v4 for compatibility with pyproject.toml
+        uses: actions/setup-python@v4
         with:
           python-version: 3.12
           cache: pip
@@ -87,13 +87,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
+      - name: Install markdown-link-check
+        run: npm install -g markdown-link-check
 
       - name: Install markdown-link-check locally
         run: npm ci
@@ -110,22 +105,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-
-      - name: Install markdown-link-check locally
-        run: npm ci
+      - name: Install markdown-link-check
+        run: npm install -g markdown-link-check
 
       - name: Make .sh executable
         run: chmod +x bash_scripts/check_markdown_links.sh
 
       - name: Check external links in root Markdown files
         run: ./bash_scripts/check_markdown_links.sh external
+
   check:
     if: ${{ !github.event.pull_request.draft }}
     needs:

--- a/.mlc.external.json
+++ b/.mlc.external.json
@@ -1,0 +1,8 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^\\." },
+    { "pattern": "^/" },
+    { "pattern": "^../" },
+    { "pattern": "^README.md$" }
+  ]
+}

--- a/.mlc.relative.json
+++ b/.mlc.relative.json
@@ -1,0 +1,5 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^https?://" }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ flake8 --config=tox.ini src
 > If some files were reformatted after running `black`, make sure to commit those changes and push them to your feature branch as well.
 
 Now you are ready to make a Pull Request (PR). You can open a pull request by clicking on the big `Compare & pull request` button that appears at the top of the `nemos` repo
-after pushing to your branch (see [here](https://intersect-training.org/collaborative-git/03-pr/index.html) for a tutorial).
+after pushing to your branch (see [here](https://intersect-training.org/collaborative-git/pr.html) for a tutorial).
 
 Your pull request should include the following:
 - A summary including information on what you changed and why


### PR DESCRIPTION
- Split external and relative link checks in CI
- Add only the relative link checks to the `check` ci job, which will allow to merge even if temporarily broken links are detected.

 