### PR TITLE
Install statsmodels from main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dev = [
     "flake8",                       # Code linter
     "coverage",                     # Test coverage measurement
     "pytest-cov",                   # Test coverage plugin for pytest
-    "statsmodels",                  # Used to compare model pseudo-r2 in testing
+    # TODO: remove intstall statsmodels from main after release > 0.14.4
+    "statsmodels @ git+https://github.com/statsmodels/statsmodels.git@main", # Used to compare model pseudo-r2 in testing
     "scikit-learn",                 # Testing compatibility with CV & pipelines
     "matplotlib>=3.7",              # Needed by doctest to run docstrings examples
     "pooch",                        # Required by doctest for fetch module


### PR DESCRIPTION
Temporarily installs `statsmodels` from main until next release (> 0.14.4). 

## Additional context
The current `statsmodels` release (0.14.4) is incompatible with the newer `scipy`. The bug is already fixed in main but the package as not being released yet.