### PR TITLE
Log likelihood

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -899,9 +899,9 @@ def population_bernoulliGLM_model_instantiation():
 def population_bernoulliGLM_model_instantiation_pytree(
     population_bernoulliGLM_model_instantiation,
 ):
-    """Set up a population Poisson GLM for testing purposes.
+    """Set up a population Bernoulli GLM for testing purposes.
 
-    This fixture initializes a Poisson GLM with random parameters, simulates its response, and
+    This fixture initializes a Bernoulli GLM with random parameters, simulates its response, and
     returns the test data, expected output, the model instance, true parameters, and the rate
     of response.
 

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from contextlib import nullcontext as does_not_raise
 
@@ -11,6 +12,39 @@ import statsmodels.api as sm
 from numba import njit
 
 import nemos as nmo
+from nemos._observation_model_builder import (
+    AVAILABLE_OBSERVATION_MODELS,
+    instantiate_observation_model,
+)
+
+
+@pytest.fixture
+def observation_model_rate_and_samples(observation_model_string, shape=None):
+    """
+    Fixture that returns rate and samples for each observation model.
+    """
+    if shape is None:
+        shape = (10,)
+    obs = instantiate_observation_model(observation_model_string)
+    rate = jax.random.uniform(
+        jax.random.PRNGKey(122), shape=shape, minval=0.1, maxval=10
+    )
+    if observation_model_string == "Poisson":
+        y = jax.random.poisson(jax.random.PRNGKey(123), rate)
+    elif observation_model_string == "Gamma":
+        theta = 3
+        y = jax.random.gamma(jax.random.PRNGKey(123), rate / theta) * theta
+    elif observation_model_string == "Bernoulli":
+        rate = rate / (1 + jnp.max(rate))
+        y = jax.random.bernoulli(jax.random.PRNGKey(123), rate)
+    elif observation_model_string == "NegativeBinomial":
+        r = 1.0
+        gamma_key, poisson_key = jax.random.split(jax.random.PRNGKey(123))
+        gamma_sample = jax.random.gamma(gamma_key, r, shape=rate.shape) * (rate / r)
+        y = jax.random.poisson(poisson_key, gamma_sample)
+    else:
+        raise ValueError(f"Unknown observation model {observation_model_string}.")
+    return obs, y, rate
 
 
 @pytest.fixture()
@@ -96,93 +130,6 @@ def test_glm_setter_observation_model(obs_model_string, glm_class, expectation):
 
 
 class TestPoissonObservations:
-    @pytest.mark.parametrize("link_function", [jnp.exp, jax.nn.softplus, 1])
-    def test_initialization_link_is_callable(self, link_function, poisson_observations):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = not callable(link_function)
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` function must be a Callable",
-            ):
-                poisson_observations(link_function)
-        else:
-            poisson_observations(link_function)
-
-    @pytest.mark.parametrize(
-        "link_function", [jnp.exp, np.exp, lambda x: x, sm.families.links.Log()]
-    )
-    def test_initialization_link_is_jax(self, link_function, poisson_observations):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = isinstance(link_function, np.ufunc) | isinstance(
-            link_function, sm.families.links.Link
-        )
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must return a jax.numpy.ndarray",
-            ):
-                poisson_observations(link_function)
-        else:
-            poisson_observations(link_function)
-
-    @pytest.mark.parametrize("link_function", [jnp.exp, jax.nn.softplus, 1])
-    def test_initialization_link_is_callable_set_params(
-        self, link_function, poisson_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        observation_model = poisson_observations()
-        raise_exception = not callable(link_function)
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` function must be a Callable",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
-
-    @pytest.mark.parametrize(
-        "link_function", [jnp.exp, np.exp, lambda x: x, sm.families.links.Log()]
-    )
-    def test_initialization_link_is_jax_set_params(
-        self, link_function, poisson_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = isinstance(link_function, np.ufunc) | isinstance(
-            link_function, sm.families.links.Link
-        )
-        observation_model = poisson_observations()
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must return a jax.numpy.ndarray!",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
-
-    @pytest.mark.parametrize(
-        "link_function",
-        [
-            jnp.exp,
-            lambda x: jnp.exp(x) if isinstance(x, jnp.ndarray) else "not a number",
-        ],
-    )
-    def test_initialization_link_returns_scalar(
-        self, link_function, poisson_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = not isinstance(link_function(1.0), (jnp.ndarray, float))
-        observation_model = poisson_observations()
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must handle scalar inputs correctly",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
 
     def test_get_params(self, poisson_observations):
         """Test get_params() returns expected values."""
@@ -214,32 +161,6 @@ class TestPoissonObservations:
         if not np.allclose(ll_model, ll_scipy):
             raise ValueError("Log-likelihood doesn't match scipy!")
 
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_range(self, score_type, poissonGLM_model_instantiation):
-        """
-        Compute the pseudo-r2 and check that is < 1.
-        """
-        _, y, model, _, firing_rate = poissonGLM_model_instantiation
-        pseudo_r2 = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type
-        )
-        if (pseudo_r2 > 1) or (pseudo_r2 < 0):
-            raise ValueError(f"pseudo-r2 of {pseudo_r2} outside the [0,1] range!")
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_mean(self, score_type, poissonGLM_model_instantiation):
-        """
-        Check that the pseudo-r2 of the null model is 0.
-        """
-        _, y, model, _, _ = poissonGLM_model_instantiation
-        pseudo_r2 = model.observation_model.pseudo_r2(
-            y, y.mean(), score_type=score_type
-        )
-        if not np.allclose(pseudo_r2, 0, atol=10**-7, rtol=0.0):
-            raise ValueError(
-                f"pseudo-r2 of {pseudo_r2} for the null model. Should be equal to 0!"
-            )
-
     def test_emission_probability(selfself, poissonGLM_model_instantiation):
         """
         Test the poisson emission probability.
@@ -253,58 +174,6 @@ class TestPoissonObservations:
             raise ValueError(
                 "The emission probability should output the results of a call to jax.random.poisson."
             )
-
-    @pytest.mark.parametrize(
-        "score_type, expectation",
-        [
-            ("pseudo-r2-McFadden", does_not_raise()),
-            (
-                "not-implemented",
-                pytest.raises(
-                    NotImplementedError, match="Score not-implemented not implemented"
-                ),
-            ),
-        ],
-    )
-    def test_not_implemented_score(
-        self, score_type, expectation, poissonGLM_model_instantiation
-    ):
-        _, y, model, _, firing_rate = poissonGLM_model_instantiation
-        with expectation:
-            model.observation_model.pseudo_r2(y, firing_rate, score_type)
-
-    @pytest.mark.parametrize(
-        "scale, expectation",
-        [
-            (1, does_not_raise()),
-            (
-                "invalid",
-                pytest.raises(
-                    ValueError, match="The `scale` parameter must be of numeric type"
-                ),
-            ),
-        ],
-    )
-    def test_scale_setter(self, scale, expectation, poissonGLM_model_instantiation):
-        _, _, model, _, firing_rate = poissonGLM_model_instantiation
-        with expectation:
-            model.observation_model.scale = scale
-
-    def test_scale_getter(self, poissonGLM_model_instantiation):
-        _, _, model, _, firing_rate = poissonGLM_model_instantiation
-        assert model.observation_model.scale == 1
-
-    def test_non_differentiable_inverse_link(self, poissonGLM_model_instantiation):
-        _, _, model, _, _ = poissonGLM_model_instantiation
-
-        # define a jax non-diff function
-        non_diff = lambda y: jnp.asarray(njit(lambda x: x)(np.atleast_1d(y)))
-
-        with pytest.raises(
-            TypeError,
-            match="The `inverse_link_function` function cannot be differentiated",
-        ):
-            model.observation_model.inverse_link_function = non_diff
 
     def test_pseudo_r2_vs_statsmodels(self, poissonGLM_model_instantiation):
         """
@@ -325,53 +194,6 @@ class TestPoissonObservations:
         if not np.allclose(pr2_model, pr2_sms):
             raise ValueError("Log-likelihood doesn't match statsmodels!")
 
-    def test_aggregation_score_neg_ll(self, poissonGLM_model_instantiation):
-        X, y, model, _, firing_rate = poissonGLM_model_instantiation
-        sm = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.sum)
-        mn = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.mean)
-        assert np.allclose(sm, mn * y.shape[0])
-
-    def test_aggregation_score_ll(self, poissonGLM_model_instantiation):
-        X, y, model, _, firing_rate = poissonGLM_model_instantiation
-        sm = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn * y.shape[0])
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-McFadden", "pseudo-r2-Cohen"])
-    def test_aggregation_score_pr2(self, score_type, poissonGLM_model_instantiation):
-        X, y, model, _, firing_rate = poissonGLM_model_instantiation
-        sm = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_mcfadden(self, poissonGLM_model_instantiation):
-        X, y, model, _, firing_rate = poissonGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_choen(self, poissonGLM_model_instantiation):
-        X, y, model, _, firing_rate = poissonGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
     @pytest.mark.parametrize(
         "link_func, link_func_name", [(jnp.exp, "exp"), (jax.nn.softplus, "softplus")]
     )
@@ -385,93 +207,6 @@ class TestPoissonObservations:
 
 
 class TestGammaObservations:
-    @pytest.mark.parametrize("link_function", [jnp.exp, lambda x: 1 / x, 1])
-    def test_initialization_link_is_callable(self, link_function, gamma_observations):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = not callable(link_function)
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` function must be a Callable",
-            ):
-                gamma_observations(link_function)
-        else:
-            gamma_observations(link_function)
-
-    @pytest.mark.parametrize(
-        "link_function", [jnp.exp, np.exp, lambda x: 1 / x, sm.families.links.Log()]
-    )
-    def test_initialization_link_is_jax(self, link_function, gamma_observations):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = isinstance(link_function, np.ufunc) | isinstance(
-            link_function, sm.families.links.Link
-        )
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must return a jax.numpy.ndarray",
-            ):
-                gamma_observations(link_function)
-        else:
-            gamma_observations(link_function)
-
-    @pytest.mark.parametrize("link_function", [jnp.exp, jax.nn.softplus, 1])
-    def test_initialization_link_is_callable_set_params(
-        self, link_function, gamma_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        observation_model = gamma_observations()
-        raise_exception = not callable(link_function)
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` function must be a Callable",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
-
-    @pytest.mark.parametrize(
-        "link_function", [jnp.exp, np.exp, lambda x: x, sm.families.links.Log()]
-    )
-    def test_initialization_link_is_jax_set_params(
-        self, link_function, gamma_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = isinstance(link_function, np.ufunc) | isinstance(
-            link_function, sm.families.links.Link
-        )
-        observation_model = gamma_observations()
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must return a jax.numpy.ndarray!",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
-
-    @pytest.mark.parametrize(
-        "link_function",
-        [
-            jnp.exp,
-            lambda x: jnp.exp(x) if isinstance(x, jnp.ndarray) else "not a number",
-        ],
-    )
-    def test_initialization_link_returns_scalar(
-        self, link_function, gamma_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = not isinstance(link_function(1.0), (jnp.ndarray, float))
-        observation_model = gamma_observations()
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must handle scalar inputs correctly",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
 
     def test_get_params(self, gamma_observations):
         """Test get_params() returns expected values."""
@@ -503,38 +238,6 @@ class TestGammaObservations:
         if not np.allclose(ll_model, ll_sms):
             raise ValueError("Log-likelihood doesn't match statsmodels!")
 
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_range(self, score_type, gammaGLM_model_instantiation):
-        """
-        Compute the pseudo-r2 and check that is < 1.
-        """
-        X, y, model, true_params, firing_rate = gammaGLM_model_instantiation
-        model.coef_ = true_params[0]
-        model.intercept_ = true_params[1]
-        model.scale_ = 0.5
-
-        rate = model.predict(X)
-        ysim, _ = model.simulate(jax.random.PRNGKey(123), X)
-        pseudo_r2 = nmo.observation_models.GammaObservations(
-            inverse_link_function=lambda x: 1 / x
-        ).pseudo_r2(ysim, rate, score_type=score_type)
-        if (pseudo_r2 > 1) or (pseudo_r2 < 0):
-            raise ValueError(f"pseudo-r2 of {pseudo_r2} outside the [0,1] range!")
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_mean(self, score_type, gammaGLM_model_instantiation):
-        """
-        Check that the pseudo-r2 of the null model is 0.
-        """
-        _, y, model, _, _ = gammaGLM_model_instantiation
-        pseudo_r2 = model.observation_model.pseudo_r2(
-            y, y.mean(), score_type=score_type
-        )
-        if not np.allclose(pseudo_r2, 0, atol=10**-7, rtol=0.0):
-            raise ValueError(
-                f"pseudo-r2 of {pseudo_r2} for the null model. Should be equal to 0!"
-            )
-
     def test_emission_probability(self, gammaGLM_model_instantiation):
         """
         Test the gamma emission probability.
@@ -548,58 +251,6 @@ class TestGammaObservations:
             raise ValueError(
                 "The emission probability should output the results of a call to jax.random.gamma."
             )
-
-    @pytest.mark.parametrize(
-        "score_type, expectation",
-        [
-            ("pseudo-r2-McFadden", does_not_raise()),
-            (
-                "not-implemented",
-                pytest.raises(
-                    NotImplementedError, match="Score not-implemented not implemented"
-                ),
-            ),
-        ],
-    )
-    def test_not_implemented_score(
-        self, score_type, expectation, gammaGLM_model_instantiation
-    ):
-        _, y, model, _, firing_rate = gammaGLM_model_instantiation
-        with expectation:
-            model.observation_model.pseudo_r2(y, firing_rate, score_type)
-
-    @pytest.mark.parametrize(
-        "scale, expectation",
-        [
-            (1, does_not_raise()),
-            (
-                "invalid",
-                pytest.raises(
-                    ValueError, match="The `scale` parameter must be of numeric type"
-                ),
-            ),
-        ],
-    )
-    def test_scale_setter(self, scale, expectation, gammaGLM_model_instantiation):
-        _, _, model, _, firing_rate = gammaGLM_model_instantiation
-        with expectation:
-            model.observation_model.scale = scale
-
-    def test_scale_getter(self, gammaGLM_model_instantiation):
-        _, _, model, _, firing_rate = gammaGLM_model_instantiation
-        assert model.observation_model.scale == 1
-
-    def test_non_differentiable_inverse_link(self, gammaGLM_model_instantiation):
-        _, _, model, _, _ = gammaGLM_model_instantiation
-
-        # define a jax non-diff function
-        non_diff = lambda y: jnp.asarray(njit(lambda x: x)(np.atleast_1d(y)))
-
-        with pytest.raises(
-            TypeError,
-            match="The `inverse_link_function` function cannot be differentiated",
-        ):
-            model.observation_model.inverse_link_function = non_diff
 
     def test_pseudo_r2_vs_statsmodels(self, gammaGLM_model_instantiation):
         """
@@ -625,53 +276,6 @@ class TestGammaObservations:
         if not np.allclose(pr2_model, pr2_sms):
             raise ValueError("Log-likelihood doesn't match statsmodels!")
 
-    def test_aggregation_score_neg_ll(self, gammaGLM_model_instantiation):
-        X, y, model, _, firing_rate = gammaGLM_model_instantiation
-        sm = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.sum)
-        mn = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.mean)
-        assert np.allclose(sm, mn * y.shape[0])
-
-    def test_aggregation_score_ll(self, gammaGLM_model_instantiation):
-        X, y, model, _, firing_rate = gammaGLM_model_instantiation
-        sm = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn * y.shape[0])
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-McFadden", "pseudo-r2-Cohen"])
-    def test_aggregation_score_pr2(self, score_type, gammaGLM_model_instantiation):
-        X, y, model, _, firing_rate = gammaGLM_model_instantiation
-        sm = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_mcfadden(self, gammaGLM_model_instantiation):
-        X, y, model, _, firing_rate = gammaGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_choen(self, gammaGLM_model_instantiation):
-        X, y, model, _, firing_rate = gammaGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
     @pytest.mark.parametrize(
         "link_func, link_func_name",
         [
@@ -686,125 +290,6 @@ class TestGammaObservations:
 
 
 class TestBernoulliObservations:
-    @pytest.mark.parametrize(
-        "link_function",
-        [jax.lax.logistic, jax.scipy.special.expit, jax.scipy.stats.norm.cdf, 1],
-    )
-    def test_initialization_link_is_callable(
-        self, link_function, bernoulli_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = not callable(link_function)
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` function must be a Callable",
-            ):
-                bernoulli_observations(link_function)
-        else:
-            bernoulli_observations(link_function)
-
-    @pytest.mark.parametrize(
-        "link_function",
-        [
-            jax.scipy.special.expit,
-            sp.special.expit,
-            jax.scipy.stats.norm.cdf,
-            sts.norm.cdf,
-            np.exp,
-            lambda x: x,
-            sm.families.links.Log(),
-        ],
-    )
-    def test_initialization_link_is_jax(self, link_function, bernoulli_observations):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = (
-            isinstance(link_function, np.ufunc)
-            | isinstance(link_function, sm.families.links.Link)
-            | isinstance(link_function, type(sts.norm.cdf))
-        )
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must return a jax.numpy.ndarray",
-            ):
-                bernoulli_observations(link_function)
-        else:
-            bernoulli_observations(link_function)
-
-    @pytest.mark.parametrize(
-        "link_function",
-        [jax.lax.logistic, jax.scipy.special.expit, jax.scipy.stats.norm.cdf, 1],
-    )
-    def test_initialization_link_is_callable_set_params(
-        self, link_function, bernoulli_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        observation_model = bernoulli_observations()
-        raise_exception = not callable(link_function)
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` function must be a Callable",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
-
-    @pytest.mark.parametrize(
-        "link_function",
-        [
-            jax.scipy.special.expit,
-            sp.special.expit,
-            jax.scipy.stats.norm.cdf,
-            sts.norm.cdf,
-            np.exp,
-            lambda x: x,
-            sm.families.links.Log(),
-        ],
-    )
-    def test_initialization_link_is_jax_set_params(
-        self, link_function, bernoulli_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = (
-            isinstance(link_function, np.ufunc)
-            | isinstance(link_function, sm.families.links.Link)
-            | isinstance(link_function, type(sts.norm.cdf))
-        )
-        observation_model = bernoulli_observations()
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must return a jax.numpy.ndarray!",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
-
-    @pytest.mark.parametrize(
-        "link_function",
-        [
-            jax.lax.logistic,
-            lambda x: (
-                jax.lax.logistic(x) if isinstance(x, jnp.ndarray) else "not a number"
-            ),
-        ],
-    )
-    def test_initialization_link_returns_scalar(
-        self, link_function, bernoulli_observations
-    ):
-        """Check that the observation model initializes when a callable is passed."""
-        raise_exception = not isinstance(link_function(1.0), (jnp.ndarray, float))
-        observation_model = bernoulli_observations()
-        if raise_exception:
-            with pytest.raises(
-                TypeError,
-                match="The `inverse_link_function` must handle scalar inputs correctly",
-            ):
-                observation_model.set_params(inverse_link_function=link_function)
-        else:
-            observation_model.set_params(inverse_link_function=link_function)
 
     def test_get_params(self, bernoulli_observations):
         """Test get_params() returns expected values."""
@@ -836,33 +321,6 @@ class TestBernoulliObservations:
         if not np.allclose(ll_model, ll_scipy):
             raise ValueError("Log-likelihood doesn't match scipy!")
 
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_range(self, score_type, bernoulliGLM_model_instantiation):
-        """
-        Compute the pseudo-r2 and check that is < 1.
-        """
-        _, y, model, _, firing_rate = bernoulliGLM_model_instantiation
-        pseudo_r2 = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type
-        )
-        if (pseudo_r2 > 1) or (pseudo_r2 < 0):
-            raise ValueError(f"pseudo-r2 of {pseudo_r2} outside the [0,1] range!")
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_mean(self, score_type, bernoulliGLM_model_instantiation):
-        """
-        Check that the pseudo-r2 of the null model is 0.
-        """
-        _, y, model, _, _ = bernoulliGLM_model_instantiation
-        pseudo_r2 = model.observation_model.pseudo_r2(
-            y, y.mean(), score_type=score_type
-        )
-        # fails with atol=10**-7
-        if not np.allclose(pseudo_r2, 0, atol=10**-6, rtol=0.0):
-            raise ValueError(
-                f"pseudo-r2 of {pseudo_r2} for the null model. Should be equal to 0!"
-            )
-
     def test_emission_probability(selfself, bernoulliGLM_model_instantiation):
         """
         Test the poisson emission probability.
@@ -877,58 +335,6 @@ class TestBernoulliObservations:
             raise ValueError(
                 "The emission probability should output the results of a call to jax.random.poisson."
             )
-
-    @pytest.mark.parametrize(
-        "score_type, expectation",
-        [
-            ("pseudo-r2-McFadden", does_not_raise()),
-            (
-                "not-implemented",
-                pytest.raises(
-                    NotImplementedError, match="Score not-implemented not implemented"
-                ),
-            ),
-        ],
-    )
-    def test_not_implemented_score(
-        self, score_type, expectation, bernoulliGLM_model_instantiation
-    ):
-        _, y, model, _, firing_rate = bernoulliGLM_model_instantiation
-        with expectation:
-            model.observation_model.pseudo_r2(y, firing_rate, score_type)
-
-    @pytest.mark.parametrize(
-        "scale, expectation",
-        [
-            (1, does_not_raise()),
-            (
-                "invalid",
-                pytest.raises(
-                    ValueError, match="The `scale` parameter must be of numeric type"
-                ),
-            ),
-        ],
-    )
-    def test_scale_setter(self, scale, expectation, bernoulliGLM_model_instantiation):
-        _, _, model, _, firing_rate = bernoulliGLM_model_instantiation
-        with expectation:
-            model.observation_model.scale = scale
-
-    def test_scale_getter(self, bernoulliGLM_model_instantiation):
-        _, _, model, _, firing_rate = bernoulliGLM_model_instantiation
-        assert model.observation_model.scale == 1
-
-    def test_non_differentiable_inverse_link(self, bernoulliGLM_model_instantiation):
-        _, _, model, _, _ = bernoulliGLM_model_instantiation
-
-        # define a jax non-diff function
-        non_diff = lambda y: jnp.asarray(njit(lambda x: x)(np.atleast_1d(y)))
-
-        with pytest.raises(
-            TypeError,
-            match="The `inverse_link_function` function cannot be differentiated",
-        ):
-            model.observation_model.inverse_link_function = non_diff
 
     def test_pseudo_r2_vs_statsmodels(self, bernoulliGLM_model_instantiation):
         """
@@ -949,53 +355,6 @@ class TestBernoulliObservations:
         if not np.allclose(pr2_model, pr2_sms):
             raise ValueError("Log-likelihood doesn't match statsmodels!")
 
-    def test_aggregation_score_neg_ll(self, bernoulliGLM_model_instantiation):
-        X, y, model, _, firing_rate = bernoulliGLM_model_instantiation
-        sm = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.sum)
-        mn = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.mean)
-        assert np.allclose(sm, mn * y.shape[0])
-
-    def test_aggregation_score_ll(self, bernoulliGLM_model_instantiation):
-        X, y, model, _, firing_rate = bernoulliGLM_model_instantiation
-        sm = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn * y.shape[0])
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-McFadden", "pseudo-r2-Cohen"])
-    def test_aggregation_score_pr2(self, score_type, bernoulliGLM_model_instantiation):
-        X, y, model, _, firing_rate = bernoulliGLM_model_instantiation
-        sm = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_mcfadden(self, bernoulliGLM_model_instantiation):
-        X, y, model, _, firing_rate = bernoulliGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_choen(self, bernoulliGLM_model_instantiation):
-        X, y, model, _, firing_rate = bernoulliGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
     @pytest.mark.parametrize(
         "link_func, link_func_name",
         [
@@ -1015,75 +374,291 @@ class TestBernoulliObservations:
 
 
 class TestNegativeBinomialObservations:
+
+    def test_get_params(self, negative_binomial_observations):
+        observation_model = negative_binomial_observations()
+        assert observation_model.get_params() == {
+            "inverse_link_function": observation_model.inverse_link_function,
+            "scale": 1.0,
+        }
+
+    def test_deviance_against_statsmodels(
+        self, negativeBinomialGLM_model_instantiation
+    ):
+        jax.config.update("jax_enable_x64", True)
+        _, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
+        dev = sm.families.NegativeBinomial(
+            alpha=model.observation_model.scale
+        ).deviance(y, firing_rate)
+        dev_model = model.observation_model.deviance(y, firing_rate).sum()
+        if not np.allclose(dev, dev_model):
+            raise ValueError("Deviance doesn't match statsmodels!")
+
+    def test_loglikelihood_against_scipy(self, negativeBinomialGLM_model_instantiation):
+        _, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
+        r = 1.0 / model.observation_model.scale
+        p = r / (r + firing_rate)
+        ll_model = model.observation_model.log_likelihood(y, firing_rate)
+        ll_scipy = sts.nbinom.logpmf(y, r, p).mean()
+        if not np.allclose(ll_model, ll_scipy, atol=1e-5):
+            raise ValueError("Log-likelihood doesn't match scipy!")
+
+    def test_emission_probability(self, negativeBinomialGLM_model_instantiation):
+        _, _, model, _, _ = negativeBinomialGLM_model_instantiation
+        key_array = jax.random.key(123)
+        gkey, pkey = jax.random.split(key_array)
+        p = np.random.rand(10)
+        counts = model.observation_model.sample_generator(
+            key_array, p, scale=model.observation_model.scale
+        )
+        r = 1.0 / model.observation_model.scale
+        gamma_sample = jax.random.gamma(gkey, r, shape=p.shape) * (p / r)
+        expected_counts = jax.random.poisson(pkey, gamma_sample)
+        if not jnp.allclose(counts, expected_counts):
+            raise ValueError(
+                "The emission probability doesn't match expected NB sampling."
+            )
+
+    def test_pseudo_r2_vs_statsmodels(self, negativeBinomialGLM_model_instantiation):
+        X, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
+        mdl = sm.GLM(
+            y,
+            sm.add_constant(X),
+            family=sm.families.NegativeBinomial(alpha=model.observation_model.scale),
+        ).fit()
+        pr2_sms = mdl.pseudo_rsquared("mcf")
+        pr2_model = model.observation_model.pseudo_r2(
+            y,
+            mdl.mu,
+            scale=model.observation_model.scale,
+            score_type="pseudo-r2-McFadden",
+        )
+        if not np.allclose(pr2_model, pr2_sms, atol=1e-5):
+            raise ValueError("Pseudo-r2 doesn't match statsmodels!")
+
     @pytest.mark.parametrize(
-        "link_function, expectation",
+        "link_func, link_func_name",
         [
-            (jax.numpy.exp, does_not_raise()),
-            (jax.nn.softplus, does_not_raise()),
+            (jax.nn.softplus, "softplus"),
+            (jax.numpy.exp, "exp"),
+        ],
+    )
+    def test_repr_out(self, link_func, link_func_name):
+        obs = nmo.observation_models.NegativeBinomialObservations(
+            inverse_link_function=link_func
+        )
+        assert (
+            repr(obs)
+            == f"NegativeBinomialObservations(inverse_link_function={link_func_name}, scale=1.0)"
+        )
+
+
+@pytest.mark.parametrize("observation_model_string", AVAILABLE_OBSERVATION_MODELS)
+class TestCommonObservationModels:
+
+    @pytest.mark.parametrize("shape", [(10,), (10, 5), (10, 5, 2)])
+    def test_likelihood_matching(
+        self, shape, observation_model_string, observation_model_rate_and_samples
+    ):
+        jax.config.update("jax_enable_x64", True)
+        obs, y, rate = observation_model_rate_and_samples
+        like1 = jnp.exp(
+            obs.log_likelihood(y, rate, aggregate_sample_scores=lambda x: x)
+        )
+        like2 = obs.likelihood(y, rate, aggregate_sample_scores=lambda x: x)
+        assert jnp.allclose(like1, like2)
+
+    @pytest.mark.parametrize("shape", [(10,), (10, 5), (10, 5, 2)])
+    def test_aggregation_score_mcfadden(
+        self, shape, observation_model_string, observation_model_rate_and_samples
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+        sm = obs._pseudo_r2_mcfadden(y, rate, aggregate_sample_scores=jnp.sum)
+        mn = obs._pseudo_r2_mcfadden(y, rate, aggregate_sample_scores=jnp.mean)
+        assert np.allclose(sm, mn)
+
+    @pytest.mark.parametrize("shape", [(10,), (10, 5), (10, 5, 2)])
+    def test_aggregation_score_choen(
+        self, shape, observation_model_string, observation_model_rate_and_samples
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+        sm = obs._pseudo_r2_cohen(y, rate, aggregate_sample_scores=jnp.sum)
+        mn = obs._pseudo_r2_cohen(y, rate, aggregate_sample_scores=jnp.mean)
+        assert np.allclose(sm, mn)
+
+    @pytest.mark.parametrize("score_type", ["pseudo-r2-McFadden", "pseudo-r2-Cohen"])
+    @pytest.mark.parametrize("shape", [(10,), (10, 5), (10, 5, 2)])
+    def test_aggregation_score_pr2(
+        self,
+        score_type,
+        shape,
+        observation_model_string,
+        observation_model_rate_and_samples,
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+        sm = obs.pseudo_r2(
+            y, rate, score_type=score_type, aggregate_sample_scores=jnp.sum
+        )
+        mn = obs.pseudo_r2(
+            y, rate, score_type=score_type, aggregate_sample_scores=jnp.mean
+        )
+        assert np.allclose(sm, mn)
+
+    @pytest.mark.parametrize("shape", [(10,), (10, 5), (10, 5, 2)])
+    def test_aggregation_score_ll(
+        self, shape, observation_model_string, observation_model_rate_and_samples
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+        sm = obs.log_likelihood(y, rate, aggregate_sample_scores=jnp.sum)
+        mn = obs.log_likelihood(y, rate, aggregate_sample_scores=jnp.mean)
+        assert np.allclose(sm, mn * math.prod(y.shape))
+
+    @pytest.mark.parametrize("shape", [(10,), (10, 5), (10, 5, 2)])
+    def test_aggregation_score_neg_ll(
+        self, shape, observation_model_string, observation_model_rate_and_samples
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+        sm = obs._negative_log_likelihood(y, rate, jnp.sum)
+        mn = obs._negative_log_likelihood(y, rate, jnp.mean)
+        assert np.allclose(sm, mn * math.prod(y.shape))
+
+    def test_non_differentiable_inverse_link(
+        self, observation_model_string, observation_model_rate_and_samples
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+
+        from numba import njit
+
+        non_diff = lambda y: jnp.asarray(njit(lambda x: x)(np.atleast_1d(y)))
+
+        with pytest.raises(
+            TypeError,
+            match="The `inverse_link_function` function cannot be differentiated",
+        ):
+            obs.inverse_link_function = non_diff
+
+    def test_scale_getter(
+        self, observation_model_string, observation_model_rate_and_samples
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+        assert obs.scale == 1
+
+    @pytest.mark.parametrize(
+        "scale, expectation",
+        [
+            (1, does_not_raise()),
             (
-                1,
+                "invalid",
                 pytest.raises(
-                    TypeError,
-                    match="The `inverse_link_function` function must be a Callable",
+                    ValueError, match="The `scale` parameter must be of numeric type"
                 ),
             ),
         ],
     )
-    def test_initialization_link_is_callable(
-        self, link_function, negative_binomial_observations, expectation
+    def test_scale_setter(
+        self,
+        scale,
+        expectation,
+        observation_model_string,
+        observation_model_rate_and_samples,
     ):
+        obs, y, rate = observation_model_rate_and_samples
         with expectation:
-            negative_binomial_observations(link_function)
+            obs.scale = scale
 
     @pytest.mark.parametrize(
-        "link_function, expectation",
+        "score_type, expectation",
         [
-            (jax.numpy.exp, does_not_raise()),
-            (jax.nn.softplus, does_not_raise()),
+            ("pseudo-r2-McFadden", does_not_raise()),
             (
-                np.exp,
+                "not-implemented",
                 pytest.raises(
-                    TypeError,
-                    match="The `inverse_link_function` must return a jax.numpy.ndarray",
-                ),
-            ),
-            (lambda x: x, does_not_raise()),
-            (
-                sm.families.links.Log(),
-                pytest.raises(
-                    TypeError,
-                    match="The `inverse_link_function` must return a jax.numpy.ndarray",
+                    NotImplementedError, match="Score not-implemented not implemented"
                 ),
             ),
         ],
+    )
+    def test_not_implemented_score(
+        self,
+        score_type,
+        expectation,
+        observation_model_string,
+        observation_model_rate_and_samples,
+    ):
+        obs, y, rate = observation_model_rate_and_samples
+        with expectation:
+            obs.pseudo_r2(y, rate, score_type)
+
+    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
+    def test_pseudo_r2_mean(
+        self, score_type, observation_model_string, observation_model_rate_and_samples
+    ):
+        """
+        Check that the pseudo-r2 of the null model is 0.
+        """
+        obs, y, rate = observation_model_rate_and_samples
+        pseudo_r2 = obs.pseudo_r2(y, y.mean(), score_type=score_type)
+        if not np.allclose(pseudo_r2, 0, atol=10**-7, rtol=0.0):
+            raise ValueError(
+                f"pseudo-r2 of {pseudo_r2} for the null model. Should be equal to 0!"
+            )
+
+    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
+    def test_pseudo_r2_range(
+        self, score_type, observation_model_string, observation_model_rate_and_samples
+    ):
+        """
+        Compute the pseudo-r2 and check that is < 1.
+        """
+        obs, y, rate = observation_model_rate_and_samples
+        pseudo_r2 = obs.pseudo_r2(y, rate, score_type=score_type)
+        if (pseudo_r2 > 1) or (pseudo_r2 < 0):
+            raise ValueError(f"pseudo-r2 of {pseudo_r2} outside the [0,1] range!")
+
+    @pytest.mark.parametrize(
+        "link_function",
+        [
+            jnp.exp,
+            lambda x: jnp.exp(x) if isinstance(x, jnp.ndarray) else "not a number",
+        ],
+    )
+    def test_initialization_link_returns_scalar(
+        self,
+        link_function,
+        observation_model_string,
+        observation_model_rate_and_samples,
+    ):
+        """Check that the observation model initializes when a callable is passed."""
+        raise_exception = not isinstance(link_function(1.0), (jnp.ndarray, float))
+        obs, y, rate = observation_model_rate_and_samples
+        if raise_exception:
+            with pytest.raises(
+                TypeError,
+                match="The `inverse_link_function` must handle scalar inputs correctly",
+            ):
+                obs.set_params(inverse_link_function=link_function)
+        else:
+            obs.set_params(inverse_link_function=link_function)
+
+    @pytest.mark.parametrize(
+        "link_function", [jnp.exp, np.exp, lambda x: 1 / x, sm.families.links.Log()]
     )
     def test_initialization_link_is_jax(
-        self, link_function, negative_binomial_observations, expectation
+        self, link_function, observation_model_rate_and_samples
     ):
-        with expectation:
-            negative_binomial_observations(link_function)
-
-    @pytest.mark.parametrize(
-        "link_function, expectation",
-        [
-            (jax.lax.logistic, does_not_raise()),
-            (jax.scipy.special.expit, does_not_raise()),
-            (jax.scipy.stats.norm.cdf, does_not_raise()),
-            (
-                1,
-                pytest.raises(
-                    TypeError,
-                    match="The `inverse_link_function` function must be a Callable",
-                ),
-            ),
-        ],
-    )
-    def test_initialization_link_is_callable_set_params(
-        self, link_function, negative_binomial_observations, expectation
-    ):
-        observation_model = negative_binomial_observations()
-        with expectation:
-            observation_model.set_params(inverse_link_function=link_function)
+        """Check that the observation model initializes when a callable is passed."""
+        obs, y, rate = observation_model_rate_and_samples
+        raise_exception = isinstance(link_function, np.ufunc) | isinstance(
+            link_function, sm.families.links.Link
+        )
+        if raise_exception:
+            with pytest.raises(
+                TypeError,
+                match="The `inverse_link_function` must return a jax.numpy.ndarray",
+            ):
+                obs.__class__(link_function)
+        else:
+            obs.__class__(link_function)
 
     @pytest.mark.parametrize(
         "link_function, expectation",
@@ -1122,235 +697,25 @@ class TestNegativeBinomialObservations:
         ],
     )
     def test_initialization_link_is_jax_set_params(
-        self, link_function, negative_binomial_observations, expectation
+        self, link_function, observation_model_rate_and_samples, expectation
     ):
-        observation_model = negative_binomial_observations()
+        obs, _, _ = observation_model_rate_and_samples
 
         with expectation:
-            observation_model.set_params(inverse_link_function=link_function)
+            obs.set_params(inverse_link_function=link_function)
 
-    @pytest.mark.parametrize(
-        "link_function, expectation",
-        [
-            (jax.numpy.exp, does_not_raise()),
-            (
-                lambda x: (
-                    jax.numpy.exp(x) if isinstance(x, jnp.ndarray) else "not a number"
-                ),
-                pytest.raises(
-                    TypeError,
-                    match="The `inverse_link_function` must handle scalar inputs correctly",
-                ),
-            ),
-        ],
-    )
-    def test_initialization_link_returns_scalar(
-        self, link_function, negative_binomial_observations, expectation
+    @pytest.mark.parametrize("link_function", [jnp.exp, jax.nn.softplus, 1])
+    def test_initialization_link_is_callable(
+        self, link_function, observation_model_rate_and_samples
     ):
-        observation_model = negative_binomial_observations()
-        with expectation:
-            observation_model.set_params(inverse_link_function=link_function)
-
-    def test_get_params(self, negative_binomial_observations):
-        observation_model = negative_binomial_observations()
-        assert observation_model.get_params() == {
-            "inverse_link_function": observation_model.inverse_link_function,
-            "scale": 1.0,
-        }
-
-    def test_deviance_against_statsmodels(
-        self, negativeBinomialGLM_model_instantiation
-    ):
-        jax.config.update("jax_enable_x64", True)
-        _, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        dev = sm.families.NegativeBinomial(
-            alpha=model.observation_model.scale
-        ).deviance(y, firing_rate)
-        dev_model = model.observation_model.deviance(y, firing_rate).sum()
-        if not np.allclose(dev, dev_model):
-            raise ValueError("Deviance doesn't match statsmodels!")
-
-    def test_loglikelihood_against_scipy(self, negativeBinomialGLM_model_instantiation):
-        _, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        r = 1.0 / model.observation_model.scale
-        p = r / (r + firing_rate)
-        ll_model = model.observation_model.log_likelihood(y, firing_rate)
-        ll_scipy = sts.nbinom.logpmf(y, r, p).mean()
-        if not np.allclose(ll_model, ll_scipy, atol=1e-5):
-            raise ValueError("Log-likelihood doesn't match scipy!")
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_range(self, score_type, negativeBinomialGLM_model_instantiation):
-        X, y, model, params, _ = negativeBinomialGLM_model_instantiation
-        model.fit(X, y)
-        pseudo_r2 = model.observation_model.pseudo_r2(
-            y, model.predict(X), score_type=score_type
-        )
-        if (pseudo_r2 > 1) or (pseudo_r2 < 0):
-            raise ValueError(f"pseudo-r2 of {pseudo_r2} outside the [0,1] range!")
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-Cohen", "pseudo-r2-McFadden"])
-    def test_pseudo_r2_mean(self, score_type, negativeBinomialGLM_model_instantiation):
-        _, y, model, _, _ = negativeBinomialGLM_model_instantiation
-        pseudo_r2 = model.observation_model.pseudo_r2(
-            y, y.mean(), score_type=score_type
-        )
-        if not np.allclose(pseudo_r2, 0, atol=1e-6, rtol=0.0):
-            raise ValueError(
-                f"pseudo-r2 of {pseudo_r2} for the null model. Should be equal to 0!"
-            )
-
-    def test_emission_probability(self, negativeBinomialGLM_model_instantiation):
-        _, _, model, _, _ = negativeBinomialGLM_model_instantiation
-        key_array = jax.random.key(123)
-        gkey, pkey = jax.random.split(key_array)
-        p = np.random.rand(10)
-        counts = model.observation_model.sample_generator(
-            key_array, p, scale=model.observation_model.scale
-        )
-        r = 1.0 / model.observation_model.scale
-        gamma_sample = jax.random.gamma(gkey, r, shape=p.shape) * (p / r)
-        expected_counts = jax.random.poisson(pkey, gamma_sample)
-        if not jnp.allclose(counts, expected_counts):
-            raise ValueError(
-                "The emission probability doesn't match expected NB sampling."
-            )
-
-    @pytest.mark.parametrize(
-        "score_type, expectation",
-        [
-            ("pseudo-r2-McFadden", does_not_raise()),
-            (
-                "not-implemented",
-                pytest.raises(
-                    NotImplementedError, match="Score not-implemented not implemented"
-                ),
-            ),
-        ],
-    )
-    def test_not_implemented_score(
-        self, score_type, expectation, negativeBinomialGLM_model_instantiation
-    ):
-        _, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        with expectation:
-            model.observation_model.pseudo_r2(y, firing_rate, score_type)
-
-    @pytest.mark.parametrize(
-        "scale, expectation",
-        [
-            (0.1, does_not_raise()),
-            (
-                "invalid",
-                pytest.raises(
-                    ValueError, match="The `scale` parameter must be of numeric type"
-                ),
-            ),
-        ],
-    )
-    def test_scale_setter(
-        self, scale, expectation, negativeBinomialGLM_model_instantiation
-    ):
-        _, _, model, _, _ = negativeBinomialGLM_model_instantiation
-        with expectation:
-            model.observation_model.scale = scale
-
-    def test_scale_getter(self, negativeBinomialGLM_model_instantiation):
-        _, _, model, _, _ = negativeBinomialGLM_model_instantiation
-        assert model.observation_model.scale == 1
-
-    def test_non_differentiable_inverse_link(
-        self, negativeBinomialGLM_model_instantiation
-    ):
-        _, _, model, _, _ = negativeBinomialGLM_model_instantiation
-
-        from numba import njit
-
-        non_diff = lambda y: jnp.asarray(njit(lambda x: x)(np.atleast_1d(y)))
-
-        with pytest.raises(
-            TypeError,
-            match="The `inverse_link_function` function cannot be differentiated",
-        ):
-            model.observation_model.inverse_link_function = non_diff
-
-    def test_pseudo_r2_vs_statsmodels(self, negativeBinomialGLM_model_instantiation):
-        X, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        mdl = sm.GLM(
-            y,
-            sm.add_constant(X),
-            family=sm.families.NegativeBinomial(alpha=model.observation_model.scale),
-        ).fit()
-        pr2_sms = mdl.pseudo_rsquared("mcf")
-        pr2_model = model.observation_model.pseudo_r2(
-            y,
-            mdl.mu,
-            scale=model.observation_model.scale,
-            score_type="pseudo-r2-McFadden",
-        )
-        if not np.allclose(pr2_model, pr2_sms, atol=1e-5):
-            raise ValueError("Pseudo-r2 doesn't match statsmodels!")
-
-    def test_aggregation_score_neg_ll(self, negativeBinomialGLM_model_instantiation):
-        X, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        sm = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.sum)
-        mn = model.observation_model._negative_log_likelihood(y, firing_rate, jnp.mean)
-        assert np.allclose(sm, mn * y.shape[0])
-
-    def test_aggregation_score_ll(self, negativeBinomialGLM_model_instantiation):
-        X, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        sm = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.log_likelihood(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn * y.shape[0])
-
-    @pytest.mark.parametrize("score_type", ["pseudo-r2-McFadden", "pseudo-r2-Cohen"])
-    def test_aggregation_score_pr2(
-        self, score_type, negativeBinomialGLM_model_instantiation
-    ):
-        X, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        sm = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model.pseudo_r2(
-            y, firing_rate, score_type=score_type, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_mcfadden(self, negativeBinomialGLM_model_instantiation):
-        X, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_mcfadden(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    def test_aggregation_score_choen(self, negativeBinomialGLM_model_instantiation):
-        X, y, model, _, firing_rate = negativeBinomialGLM_model_instantiation
-        sm = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.sum
-        )
-        mn = model.observation_model._pseudo_r2_cohen(
-            y, firing_rate, aggregate_sample_scores=jnp.mean
-        )
-        assert np.allclose(sm, mn)
-
-    @pytest.mark.parametrize(
-        "link_func, link_func_name",
-        [
-            (jax.nn.softplus, "softplus"),
-            (jax.numpy.exp, "exp"),
-        ],
-    )
-    def test_repr_out(self, link_func, link_func_name):
-        obs = nmo.observation_models.NegativeBinomialObservations(
-            inverse_link_function=link_func
-        )
-        assert (
-            repr(obs)
-            == f"NegativeBinomialObservations(inverse_link_function={link_func_name}, scale=1.0)"
-        )
+        """Check that the observation model initializes when a callable is passed."""
+        obs, _, _ = observation_model_rate_and_samples
+        raise_exception = not callable(link_function)
+        if raise_exception:
+            with pytest.raises(
+                TypeError,
+                match="The `inverse_link_function` function must be a Callable",
+            ):
+                obs.__class__(link_function)
+        else:
+            obs.__class__(link_function)

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -719,3 +719,19 @@ class TestCommonObservationModels:
                 obs.__class__(link_function)
         else:
             obs.__class__(link_function)
+
+    @pytest.mark.parametrize("link_function", [jnp.exp, jax.nn.softplus, 1])
+    def test_initialization_link_is_callable_set_params(
+        self, link_function, observation_model_rate_and_samples
+    ):
+        """Check that the observation model initializes when a callable is passed."""
+        obs, _, _ = observation_model_rate_and_samples
+        raise_exception = not callable(link_function)
+        if raise_exception:
+            with pytest.raises(
+                TypeError,
+                match="The `inverse_link_function` function must be a Callable",
+            ):
+                obs.set_params(inverse_link_function=link_function)
+        else:
+            obs.set_params(inverse_link_function=link_function)

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -321,7 +321,7 @@ class TestBernoulliObservations:
         if not np.allclose(ll_model, ll_scipy):
             raise ValueError("Log-likelihood doesn't match scipy!")
 
-    def test_emission_probability(selfself, bernoulliGLM_model_instantiation):
+    def test_emission_probability(self, bernoulliGLM_model_instantiation):
         """
         Test the poisson emission probability.
 


### PR DESCRIPTION
Add a log-likelihood compute function. This method is implemented in the base `Observations` class, simply as `exp(log-likelihood)`, however, it can be re-implemented wherever there is a smarter way to compute the likelihood, as in the `BernoulliObservations` case.

In the process of adding the test of the method I refactored the observation model tests.