### PR TITLE
Fourier nd

### DIFF
--- a/src/nemos/basis/__init__.py
+++ b/src/nemos/basis/__init__.py
@@ -9,6 +9,7 @@ from .basis import (
     BSplineEval,
     CyclicBSplineConv,
     CyclicBSplineEval,
+    FourierEval,
     HistoryConv,
     IdentityEval,
     MSplineConv,

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -319,8 +319,7 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Parameters
         ----------
         n_samples :
-           The number of points in the uniformly spaced grid. A higher number of
-            samples will result in a more detailed visualization of the basis functions.
+           The number of samples.
 
         Returns
         -------

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -98,7 +98,8 @@ def min_max_rescale_samples(
 
 
 def get_equi_spaced_samples(
-    *n_samples, bounds: Optional[tuple[float, float]] = None
+    *n_samples,
+    bounds: Optional[tuple[float, float] | tuple[tuple[float, float]]] = None,
 ) -> Generator[NDArray]:
     """Get equi-spaced samples for all the input dimensions.
 
@@ -121,9 +122,11 @@ def get_equi_spaced_samples(
     # (i.e. when we cannot use max and min of samples)
     if bounds is None:
         mn, mx = 0, 1
+    elif all(isinstance(b, tuple) and len(b) == 2 for b in bounds):
+        return (np.linspace(*b, samp) for b, samp in zip(bounds, n_samples))
     else:
         mn, mx = bounds
-    return (np.linspace(mn, mx, n_samples[k]) for k in range(len(n_samples)))
+    return (np.linspace(mn, mx, samp) for samp in n_samples)
 
 
 class Basis(Base, abc.ABC, BasisTransformerMixin):

--- a/src/nemos/basis/_basis.py
+++ b/src/nemos/basis/_basis.py
@@ -319,7 +319,8 @@ class Basis(Base, abc.ABC, BasisTransformerMixin):
         Parameters
         ----------
         n_samples :
-           The number of samples.
+           The number of points in the uniformly spaced grid. A higher number of
+            samples will result in a more detailed visualization of the basis functions.
 
         Returns
         -------

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -540,7 +540,7 @@ class EvalBasisMixin:
 
         if not hasattr(values, "__len__"):
             raise TypeError(
-                "Invalid ``bounds`` provided. ``bounds`` must be a tuple of floats."
+                "Invalid bounds provided. ``bounds`` must be a tuple of floats."
                 f"``bounds`` {values} of type {type(values)} provided instead."
             )
 

--- a/src/nemos/basis/_basis_mixin.py
+++ b/src/nemos/basis/_basis_mixin.py
@@ -560,7 +560,10 @@ class EvalBasisMixin:
         try:
             values = values if values is None else tuple(map(float, values))
         except (ValueError, TypeError):
-            err = TypeError("Could not convert `bounds` to float.")
+            err = TypeError(
+                "Could not convert `bounds` to float. "
+                f"The provided bounds values are '{values}'."
+            )
 
         if err is not None:
             return None, err

--- a/src/nemos/basis/_check_basis.py
+++ b/src/nemos/basis/_check_basis.py
@@ -40,8 +40,7 @@ def _check_input_dimensionality(bas: "BasisMixin | Basis", xi: Tuple) -> None:
     n_input_dim = infer_input_dimensionality(bas)
     if len(xi) != n_input_dim:
         raise TypeError(
-            f"Input dimensionality mismatch. This basis evaluation requires {n_input_dim} inputs, "
-            f"{len(xi)} inputs provided instead."
+            f"This basis requires {n_input_dim} input(s) for evaluation, but {len(xi)} were provided."
         )
 
 

--- a/src/nemos/basis/_composition_utils.py
+++ b/src/nemos/basis/_composition_utils.py
@@ -28,6 +28,7 @@ __PUBLIC_BASES__ = [
     "BSplineConv",
     "CyclicBSplineEval",
     "CyclicBSplineConv",
+    "FourierEval",
     "RaisedCosineLinearEval",
     "RaisedCosineLinearConv",
     "RaisedCosineLogEval",

--- a/src/nemos/basis/_custom_basis.py
+++ b/src/nemos/basis/_custom_basis.py
@@ -156,6 +156,13 @@ class CustomBasis(BasisMixin, BasisTransformerMixin, Base):
         Enable pynapple support if True.
     label:
         The label of the basis function.
+    is_complex : bool, optional
+        Whether the basis should be treated as complex. This flag ensures that
+        multiplication with other bases behaves correctly: two real bases, or a real
+        and a complex basis, can be multiplied, but two complex bases cannot. This
+        restriction exists because after multiplication, ``basis.compute_features``
+        does not distinguish between real and imaginary components, which would lead
+        to incorrect outputs.
 
     Examples
     --------
@@ -194,6 +201,7 @@ class CustomBasis(BasisMixin, BasisTransformerMixin, Base):
         basis_kwargs: Optional[dict] = None,
         pynapple_support: bool = True,
         label: Optional[str] = None,
+        is_complex: bool = False,
     ):
         self._pynapple_support = bool(pynapple_support)
         self.funcs = funcs
@@ -210,7 +218,14 @@ class CustomBasis(BasisMixin, BasisTransformerMixin, Base):
         self._n_basis_funcs = len(self.funcs)
 
         self.basis_kwargs = basis_kwargs
+        self._is_complex = bool(is_complex)
         super().__init__(label=label)
+
+    @property
+    def is_complex(self):
+        # custom classes could be complex or real, so the attribute
+        # is an instance attribute not a class attribute
+        return self._is_complex
 
     @property
     def pynapple_support(self) -> bool:

--- a/src/nemos/basis/_fourier_basis.py
+++ b/src/nemos/basis/_fourier_basis.py
@@ -37,6 +37,46 @@ class FourierBasis(AtomicBasisMixin, Basis):
         frequency_mask: jnp.ndarray | None = None,
         label: Optional[str] = None,
     ) -> None:
+        """
+        N-dimensional Fourier basis for feature expansion.
+
+        This class generates a set of sine and cosine basis functions defined over
+        an ``n``-dimensional input space. The basis functions are constructed from
+        a Cartesian product of frequencies specified for each input dimension.
+        Each selected frequency combination contributes two basis functions
+        (cosine and sine), except for the all-zero frequency (DC component),
+        which contributes only a cosine term.
+
+        The class supports flexible frequency specification (integers, ranges, or
+        lists per dimension) and optional masking to include or exclude specific
+        frequency combinations.
+
+        Parameters
+        ----------
+        frequencies : int | tuple[int, int] | list[int] | list[tuple[int, int]]
+            Frequencies to use along each input dimension.
+
+            - ``int``: creates a range ``[0, 1, ..., n-1]`` for **all dimensions**.
+            - ``tuple[int, int]``: creates a range ``[start, ..., stop-1]`` for **all dimensions**.
+            - ``list[int]``: list of integers giving the number of frequencies per dimension.
+            - ``list[tuple[int, int]]``: list of (start, stop) tuples specifying ranges per dimension.
+
+        frequency_mask : array-like of {0, 1}, optional
+            Boolean mask specifying which frequency combinations to include.
+            If ``None``, all possible frequency combinations are used. The mask
+            must have shape ``(len(frequencies[0]), len(frequencies[1]), ...)``.
+
+        label : str, optional
+            Descriptive label for the basis (e.g., to use in plots or summaries).
+
+        Notes
+        -----
+        - If ``frequency_mask`` is provided, only the selected frequency
+          combinations are used to build the basis.
+        - The output of ``compute_features`` contains both cosine and sine components for
+          each active frequency combination, except that the all-zero frequency
+          includes only a cosine term.
+        """
         self.frequencies = frequencies
         self.frequency_mask = frequency_mask
 

--- a/src/nemos/basis/_fourier_basis.py
+++ b/src/nemos/basis/_fourier_basis.py
@@ -1,0 +1,251 @@
+"""Module for ND fourier basis class."""
+
+from typing import List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from numpy._typing import NDArray
+from numpy.typing import ArrayLike
+from pynapple import Tsd, TsdFrame, TsdTensor
+
+from ..type_casting import support_pynapple
+from ..typing import FeatureMatrix
+from ._basis import Basis, check_transform_input, min_max_rescale_samples
+from ._basis_mixin import AtomicBasisMixin
+
+
+def rowwise_outer_sum_flatten(N, M):
+    """
+    N: array of shape (T, n)
+    M: array of shape (T, m)
+    Returns: array of shape (T, n * m)
+    """
+    T, n = N.shape
+    _, m = M.shape
+
+    # Expand N and M to enable broadcasting
+    # N: (T, n, 1)
+    # M: (T, 1, m)
+    N_exp = N[:, :, jnp.newaxis]  # (T, n, 1)
+    M_exp = M[:, jnp.newaxis, :]  # (T, 1, m)
+
+    # Compute pairwise sums for each row: (T, n, m)
+    pairwise_sum = N_exp + M_exp
+
+    # Flatten the last two axes: (T, n * m)
+    result = pairwise_sum.reshape(T, n * m)
+
+    return result
+
+
+def make_arange(arg):
+    if isinstance(arg, int):
+        if arg <= 0:
+            raise ValueError("Integer frequencies must be > 0.")
+        return jnp.arange(arg, dtype=float)
+    elif isinstance(arg, tuple) and len(arg) == 2:
+        start, stop = arg
+        if not (isinstance(start, int) and isinstance(stop, int)):
+            raise TypeError("Tuple frequencies must be integers.")
+        if start < 0 or stop <= start:
+            raise ValueError("Tuple frequencies must satisfy 0 <= start < stop.")
+        return jnp.arange(start, stop, dtype=float)
+    else:
+        raise TypeError("Each frequency must be an int or a 2-element tuple of ints.")
+
+
+class FourierBasis(AtomicBasisMixin, Basis):
+
+    def __init__(
+        self,
+        frequencies: int | Tuple[int, int] | List[int] | List[Tuple[int, int]],
+        frequency_mask: jnp.ndarray | None = None,
+        label: Optional[str] = None,
+    ) -> None:
+        self.frequencies = frequencies
+        self.frequency_mask = frequency_mask
+
+        AtomicBasisMixin.__init__(
+            self,
+            n_basis_funcs=self.n_basis_funcs,
+            label=label,
+        )
+
+    @property
+    def frequency_mask(self) -> jnp.ndarray | None:
+        return self._frequency_mask
+
+    @frequency_mask.setter
+    def frequency_mask(self, values: ArrayLike | jnp.ndarray | None) -> None:
+        if values is None:
+            self._frequency_mask = None
+
+            # cache all frequencies
+            grids = jnp.meshgrid(
+                *[jnp.arange(len(freqs)) for freqs in self._frequencies], indexing="ij"
+            )
+            idxs = jnp.stack([g.reshape(-1) for g in grids], axis=1)
+            self._eval_freq = jnp.stack(
+                [freqs[idxs[:, d]] for d, freqs in enumerate(self._frequencies)], axis=0
+            )
+            return
+        try:
+            values = jnp.asarray(values)
+        except Exception:
+            raise ValueError(
+                "``frequency_mask`` cannot be converted to a jax array of boolean."
+            )
+
+        if not jnp.all((values == 0) | (values == 1)):
+            raise ValueError("Frequency mask must be an array-like of 0s and 1s.")
+
+        values = values.astype(bool)
+
+        if not values.ndim == self._n_input_dimensionality:
+            ndim = self._n_input_dimensionality
+            raise ValueError(
+                f"The frequency mask for an  {ndim}-dimensional Fourier basis "
+                f"must be an {ndim}-dimensional array of 0s and 1s. "
+                f"The provided mask is an {ndim}-dimensional array instead."
+            )
+
+        if tuple(len(freqs) for freqs in self._frequencies) != values.shape:
+            expected_shape = tuple(len(freqs) for freqs in self._frequencies)
+            raise ValueError(
+                "Invalid shape for ``frequency_mask``. "
+                f"Expected shape {expected_shape}, "
+                f"but got {values.shape} instead. The mask must have one entry (0 or 1) for each "
+                "frequency along every dimension of the Fourier basis."
+            )
+
+        self._frequency_mask = values
+        self._n_basis_funcs = 2 * int(jnp.sum(self._frequency_mask)) - int(
+            self._frequency_mask[(0,) * values.ndim]
+        )
+
+        idxs = jnp.stack(jnp.where(self._frequency_mask), axis=0)
+        self._eval_freq = jnp.stack(
+            [freqs[idxs[d]] for d, freqs in enumerate(self._frequencies)]
+        )
+
+    @property
+    def frequencies(self) -> Tuple[jnp.ndarray, ...]:
+        return self._frequencies
+
+    @frequencies.setter
+    def frequencies(
+        self, frequencies: int | tuple[int, int] | list[int] | list[tuple[int, int]]
+    ) -> None:
+
+        if isinstance(frequencies, int):
+            self._frequencies = tuple(
+                make_arange(frequencies) for _ in range(self._n_input_dimensionality)
+            )
+
+        elif isinstance(frequencies, tuple):
+            self._frequencies = tuple(
+                make_arange(frequencies) for _ in range(self._n_input_dimensionality)
+            )
+
+        elif isinstance(frequencies, list):
+            if len(frequencies) != self._n_input_dimensionality:
+                raise ValueError(
+                    "Length of frequencies list must match input dimensionality."
+                )
+            self._frequencies = tuple(make_arange(f) for f in frequencies)
+
+        else:
+            raise TypeError(
+                "Frequencies must be one of:\n"
+                "  - int\n"
+                "  - tuple[int, int]\n"
+                "  - list[int]\n"
+                "  - list[tuple[int, int]]\n"
+                f"If a list is provided, the list should be of length ``{self.ndim}``, "
+                f"one entry for each dimension of the Fourier basis."
+            )
+
+    @property
+    def ndim(self):
+        return self._n_input_dimensionality
+
+    @ndim.setter
+    def ndim(self, ndim: int) -> None:
+        # TODO: Add an exception handling
+        self._n_input_dimensionality = ndim
+
+    @property
+    def n_basis_funcs(self) -> int | None:
+        if self._frequency_mask is None:
+            return 2 * len(self._frequencies) - 1 * (0 in self._frequencies)
+        else:
+            return 2 * int(jnp.sum(self._frequency_mask)) - int(
+                self._frequency_mask[(0,) * self._frequency_mask.ndim]
+            )
+
+    @support_pynapple(conv_type="numpy")
+    @check_transform_input
+    def evaluate(  # call these _evaluate
+        self,
+        *sample_pts: ArrayLike | Tsd | TsdFrame | TsdTensor,
+    ) -> FeatureMatrix:
+        """Evaluate the Fourier basis at the sample points.
+
+        Parameters
+        ----------
+        sample_pts :
+            Spacing for basis functions, holding elements on interval [0, 1].
+            `sample_pts` is a n-dimensional (n >= 1) array with first axis being the samples, i.e.
+            `sample_pts.shape[0] == n_samples`.
+
+        Raises
+        ------
+        ValueError
+            If the sample provided do not lie in [0,1].
+
+        """
+        shape = sample_pts[0].shape
+
+        bounds = getattr(self, "bounds", None)
+        if bounds is None:
+            bounds = (None,) * self._n_input_dimensionality
+
+        # min/max rescale to [0,1]:
+        # The function does so over the time axis (each extra dim is
+        # normalized independently)
+        def _flat_samples_to_angles(xs):
+            scaled_samples = jax.tree_util.tree_map(
+                lambda x, b: 2
+                * jnp.pi
+                * self._shift_angles(min_max_rescale_samples(x, b)[0].reshape(-1)),
+                xs,
+                bounds,
+            )
+            return jnp.stack(scaled_samples, axis=-1)
+
+        sample_pts = _flat_samples_to_angles(sample_pts)
+        angles = sample_pts @ self._eval_freq
+        out = jnp.concatenate([jnp.cos(angles), jnp.sin(angles)], axis=1)
+        return out.reshape(*shape, out.shape[-1])
+
+    def _shift_angles(self, sample_pts: ArrayLike) -> ArrayLike:
+        """
+        Shift angles.
+
+        Reimplemented for ``FourierConv``, shifting the angles to
+        match the Fourier coefficients when the basis is used for convolutions.
+        This shift must not be applied for ``FourierEval`` basis, therefore the
+        super-class implements an identity function.
+
+        Parameters
+        ----------
+        sample_pts :
+            The samples.
+
+        Returns
+        -------
+        sample_pts :
+            The samples as provided, identity function.
+        """
+        return sample_pts

--- a/src/nemos/basis/_fourier_basis.py
+++ b/src/nemos/basis/_fourier_basis.py
@@ -48,10 +48,55 @@ class FourierBasis(AtomicBasisMixin, Basis):
 
     @property
     def frequency_mask(self) -> jnp.ndarray | None:
+        """Get or set the frequency mask for the Fourier basis.
+
+        The frequency mask is a boolean array (or array-like of 0s and 1s)
+        that specifies which frequencies to include when evaluating the basis.
+        Its shape must match the number of frequencies along each input dimension.
+
+        - If ``None``, all possible frequency combinations are included.
+        - If provided, entries set to 1 (``True``) enable the corresponding frequency
+          combination, while 0 (``False``) disables it.
+
+        Returns
+        -------
+        :
+            A boolean JAX array indicating the selected frequencies, or ``None``
+            if no mask is applied.
+        """
         return self._frequency_mask
 
     @frequency_mask.setter
     def frequency_mask(self, values: ArrayLike | jnp.ndarray | None) -> None:
+        """Set the frequency mask for the Fourier basis.
+
+        Parameters
+        ----------
+        values :
+            A boolean array (or array-like of 0s and 1s) specifying which
+            frequency combinations to include. Must have shape
+            ``(len(frequencies[0]), len(frequencies[1]), ...)``.
+
+            - If ``None``, all frequency combinations are included.
+            - If provided, each entry set to 1 includes the corresponding
+              frequency combination; entries set to 0 exclude it.
+
+        Raises
+        ------
+        ValueError
+            If the array contains values other than 0 or 1, or if the shape
+            does not match the expected number of frequencies.
+        TypeError
+            If ``values`` cannot be converted to a JAX array.
+
+        Notes
+        -----
+        Setting this property also updates:
+
+        - ``self._frequency_mask``: stores the boolean mask.
+        - ``self._n_basis_funcs``: number of active basis functions.
+        - ``self._eval_freq``: array of selected frequencies for evaluation.
+        """
         if values is None:
             self._frequency_mask = None
 

--- a/src/nemos/basis/_fourier_basis.py
+++ b/src/nemos/basis/_fourier_basis.py
@@ -277,6 +277,7 @@ class FourierBasis(AtomicBasisMixin, Basis):
         frequencies: (
             int | Tuple[int, int] | List[int] | List[Tuple[int, int]] | ArrayLike
         ),
+        ndim: int,
         frequency_mask: jnp.ndarray | None = None,
         label: Optional[str] = None,
     ) -> None:
@@ -303,6 +304,8 @@ class FourierBasis(AtomicBasisMixin, Basis):
             - ``tuple[int, int]``: creates a range ``[start, ..., stop-1]`` for **all dimensions**.
             - ``list[int]``: list of integers giving the number of frequencies per dimension.
             - ``list[tuple[int, int]]``: list of (start, stop) tuples specifying ranges per dimension.
+        ndim :
+            Dimensionality of the basis. Default is 1.
 
         frequency_mask : array-like of {0, 1}, optional
             Boolean mask specifying which frequency combinations to include.
@@ -320,6 +323,7 @@ class FourierBasis(AtomicBasisMixin, Basis):
           each active frequency combination, except that the all-zero frequency
           includes only a cosine term.
         """
+        self.ndim = ndim
         self.frequencies = frequencies
         self.frequency_mask = frequency_mask
 
@@ -514,8 +518,16 @@ class FourierBasis(AtomicBasisMixin, Basis):
 
     @ndim.setter
     def ndim(self, ndim: int) -> None:
-        # TODO: Add an exception handling
-        self._n_input_dimensionality = ndim
+        try:
+            is_int = int(ndim) == ndim
+        except Exception as e:
+            raise TypeError(f"Cannot convert ndim {ndim!r} to type int.") from e
+        is_positive = ndim > 0
+        if not is_int or not is_positive:
+            raise ValueError(
+                f"ndim must be a positive integer. {ndim!r} provided instead."
+            )
+        self._n_input_dimensionality = int(ndim)
 
     @property
     def n_basis_funcs(self) -> int | None:

--- a/src/nemos/basis/_fourier_basis.py
+++ b/src/nemos/basis/_fourier_basis.py
@@ -390,7 +390,7 @@ class FourierBasis(AtomicBasisMixin, Basis):
             self._frequency_mask = None
             self._eval_freq = _get_all_frequency_pairs(self._frequencies)
 
-        elif isinstance(values, Callable):
+        elif callable(values):
             self._eval_freq = _get_frequency_pairs_from_callable(
                 values, self._frequencies
             )

--- a/src/nemos/basis/_fourier_basis.py
+++ b/src/nemos/basis/_fourier_basis.py
@@ -460,7 +460,7 @@ class FourierBasis(AtomicBasisMixin, Basis):
         ndim = self._n_input_dimensionality
 
         if isinstance(frequencies, Number) and (frequencies == int(frequencies)):
-            frequencies = (arange_constructor(frequencies),)
+            frequencies = (arange_constructor(frequencies),) * ndim
 
         elif isinstance(frequencies, tuple):
             frequencies = _process_tuple_frequencies(
@@ -531,7 +531,7 @@ class FourierBasis(AtomicBasisMixin, Basis):
 
     @property
     def n_basis_funcs(self) -> int | None:
-        return 2 * self._eval_freq.size - self._has_zero_phase
+        return 2 * self._eval_freq.shape[-1] - self._has_zero_phase
 
     @support_pynapple(conv_type="numpy")
     @check_transform_input

--- a/src/nemos/basis/_fourier_basis.py
+++ b/src/nemos/basis/_fourier_basis.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+from numpy._typing import NDArray
 from numpy.typing import ArrayLike
 from pynapple import Tsd, TsdFrame, TsdTensor
 
@@ -285,6 +286,25 @@ class FourierBasis(AtomicBasisMixin, Basis):
             [jnp.cos(angles), jnp.sin(angles[..., self._has_zero_phase :])], axis=1
         )
         return out.reshape(*shape, out.shape[-1])
+
+    def evaluate_on_grid(self, *n_samples: int) -> Tuple[Tuple[NDArray], NDArray]:
+        """Evaluate the basis set on a grid of equi-spaced sample points.
+
+        Parameters
+        ----------
+        n_samples :
+            The number of points in the uniformly spaced grid. A higher number of
+            samples will result in a more detailed visualization of the basis functions.
+
+        Returns
+        -------
+        X :
+            Array of shape (n_samples,) containing the equi-spaced sample
+            points where we've evaluated the basis.
+        basis_funcs :
+            Fourier basis functions, shape (n_samples, n_basis_funcs)
+        """
+        return super().evaluate_on_grid(*n_samples)
 
     def _shift_angles(self, sample_pts: ArrayLike) -> ArrayLike:
         """

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -2449,7 +2449,6 @@ class FourierEval(EvalBasisMixin, FourierBasis):
         frequency_mask: NDArray[bool] | None = None,
         label: Optional[str] = "FourierEval",
     ):
-        EvalBasisMixin.__init__(self, bounds=bounds)
         FourierBasis.__init__(
             self,
             frequencies=frequencies,
@@ -2457,6 +2456,7 @@ class FourierEval(EvalBasisMixin, FourierBasis):
             frequency_mask=frequency_mask,
             ndim=ndim,
         )
+        EvalBasisMixin.__init__(self, bounds=bounds)
 
     @add_docstring("evaluate_on_grid", FourierBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
@@ -2578,7 +2578,9 @@ class FourierEval(EvalBasisMixin, FourierBasis):
             return
 
         def _is_leaf(x):
-            return isinstance(x, Sequence) and all(isinstance(xi, Number) for xi in x)
+            return isinstance(x, Sequence) and all(
+                isinstance(xi, Number) or xi is None for xi in x
+            )
 
         values = jax.tree_util.tree_leaves(values, is_leaf=_is_leaf)
 

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -2587,10 +2587,11 @@ class FourierEval(EvalBasisMixin, FourierBasis):
             values = (values,) * self.ndim
 
         elif len(values) != self.ndim:
-            raise ValueError(
-                "If multiple bounds are provided, one must provide a bounds tuple per each dimension. "
-                f"The dimension of the basis is ``{self.ndim}``, but {len(values)} bounds are provided "
-                f"instead.\nList of provided bounds: {values}"
+            raise TypeError(
+                f"Invalid bounds ``{values}`` provided. "
+                "When provided, the bounds should be one or multiple tuples containing pair of floats.\n"
+                "If multiple tuples are provided, one must provide a tuple per each dimension"
+                "of the basis. "
             )
         else:
             out = jax.tree_util.tree_map(self._format_bounds, values, is_leaf=_is_leaf)

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -10,7 +10,6 @@ import jax
 from numpy.typing import ArrayLike, NDArray
 
 from ..typing import FeatureMatrix
-from ._basis import Basis
 from ._basis_mixin import AtomicBasisMixin, BasisMixin, ConvBasisMixin, EvalBasisMixin
 from ._composition_utils import add_docstring
 from ._decaying_exponential import OrthExponentialBasis
@@ -2457,7 +2456,7 @@ class FourierEval(EvalBasisMixin, FourierBasis):
             frequency_mask=frequency_mask,
         )
 
-    @add_docstring("evaluate_on_grid", Basis)
+    @add_docstring("evaluate_on_grid", FourierBasis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -10,6 +10,7 @@ import jax
 from numpy.typing import ArrayLike, NDArray
 
 from ..typing import FeatureMatrix
+from ._basis import Basis
 from ._basis_mixin import AtomicBasisMixin, BasisMixin, ConvBasisMixin, EvalBasisMixin
 from ._composition_utils import add_docstring
 from ._decaying_exponential import OrthExponentialBasis
@@ -2456,14 +2457,14 @@ class FourierEval(EvalBasisMixin, FourierBasis):
             frequency_mask=frequency_mask,
         )
 
-    @add_docstring("evaluate_on_grid", FourierBasis)
+    @add_docstring("evaluate_on_grid", Basis)
     def evaluate_on_grid(self, n_samples: int) -> Tuple[NDArray, NDArray]:
         """
         Examples
         --------
         .. plot::
             :include-source: True
-            :caption: FourierEval Basis
+            :caption: FourierEval
 
             >>> import numpy as np
             >>> import matplotlib.pyplot as plt

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -2418,6 +2418,8 @@ class FourierEval(EvalBasisMixin, FourierBasis):
     ----------
     frequencies :
         Fourier frequencies.
+    ndim :
+        Dimensionality of the basis. Default is 1.
     bounds :
         The bounds for the basis domain. The default ``bounds[0]`` and ``bounds[1]`` are the
         minimum and the maximum of the samples provided when evaluating the basis.
@@ -2447,13 +2449,13 @@ class FourierEval(EvalBasisMixin, FourierBasis):
         frequency_mask: NDArray[bool] | None = None,
         label: Optional[str] = "FourierEval",
     ):
-        self._n_input_dimensionality = ndim
         EvalBasisMixin.__init__(self, bounds=bounds)
         FourierBasis.__init__(
             self,
             frequencies=frequencies,
             label=label,
             frequency_mask=frequency_mask,
+            ndim=ndim,
         )
 
     @add_docstring("evaluate_on_grid", FourierBasis)

--- a/src/nemos/basis/basis.py
+++ b/src/nemos/basis/basis.py
@@ -10,7 +10,7 @@ import jax
 from numpy.typing import ArrayLike, NDArray
 
 from ..typing import FeatureMatrix
-from ._basis_mixin import AtomicBasisMixin, ConvBasisMixin, EvalBasisMixin
+from ._basis_mixin import AtomicBasisMixin, BasisMixin, ConvBasisMixin, EvalBasisMixin
 from ._composition_utils import add_docstring
 from ._decaying_exponential import OrthExponentialBasis
 from ._fourier_basis import FourierBasis
@@ -2478,7 +2478,7 @@ class FourierEval(EvalBasisMixin, FourierBasis):
         return super().evaluate_on_grid(n_samples)
 
     @add_docstring("_compute_features", EvalBasisMixin)
-    def compute_features(self, xi: ArrayLike) -> FeatureMatrix:
+    def compute_features(self, *xi: ArrayLike) -> FeatureMatrix:
         """
         Examples
         --------
@@ -2494,7 +2494,7 @@ class FourierEval(EvalBasisMixin, FourierBasis):
         (1000, 20)
 
         """
-        return super().compute_features(xi)
+        return super().compute_features(*xi)
 
     @add_docstring("split_by_feature", FourierBasis)
     def split_by_feature(
@@ -2519,7 +2519,7 @@ class FourierEval(EvalBasisMixin, FourierBasis):
         return super().split_by_feature(x, axis=axis)
 
     @add_docstring("set_input_shape", AtomicBasisMixin)
-    def set_input_shape(self, xi: int | tuple[int, ...] | NDArray):
+    def set_input_shape(self, *xi: int | tuple[int, ...] | NDArray):
         """
         Examples
         --------
@@ -2541,7 +2541,7 @@ class FourierEval(EvalBasisMixin, FourierBasis):
         200
 
         """
-        return AtomicBasisMixin.set_input_shape(self, xi)
+        return BasisMixin.set_input_shape(self, *xi)
 
     @add_docstring("evaluate", FourierBasis)
     def evaluate(self, *sample_pts: NDArray) -> NDArray:
@@ -2560,6 +2560,11 @@ class FourierEval(EvalBasisMixin, FourierBasis):
 
     @property
     def bounds(self) -> Tuple[Tuple[float, float]] | None:
+        """Bounds.
+
+        Tuple of bounds, one per dimension or None if no bounds are
+        provided.
+        """
         return self._bounds
 
     @bounds.setter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,9 @@ import pytest
 import nemos as nmo
 import nemos._inspect_utils as inspect_utils
 import nemos.basis.basis as basis
-from docs.scripts.basis_figs import KWARGS
 from nemos.basis import AdditiveBasis, CustomBasis, MultiplicativeBasis
 from nemos.basis._basis import Basis
+from nemos.basis._basis_mixin import BasisMixin
 from nemos.basis._transformer_basis import TransformerBasis
 
 DEFAULT_KWARGS = {
@@ -164,7 +164,7 @@ class CombinedBasis(BasisFuncsTesting):
 
 
 # automatic define user accessible basis and check the methods
-def list_all_basis_classes(filter_basis="all") -> list[type]:
+def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
     """
     Return all the classes in nemos.basis which are a subclass of Basis,
     which should be all concrete classes except TransformerBasis.
@@ -184,7 +184,12 @@ def list_all_basis_classes(filter_basis="all") -> list[type]:
     )
     if filter_basis != "all":
         all_basis = [a for a in all_basis if filter_basis in a.__name__]
-    return all_basis
+    return [nmo.basis.FourierEval]  # all_basis
+
+
+def list_all_real_basis_classes(filter_basis="all"):
+    list_all_basis = list_all_basis_classes(filter_basis)
+    return [cls for cls in list_all_basis if not getattr(cls, "is_complex", False)]
 
 
 # Sample subclass to test instantiation and methods

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,9 @@ class CombinedBasis(BasisFuncsTesting):
             "n_basis_funcs": n_basis,
             "window_size": window_size,
             "decay_rates": np.arange(1, 1 + n_basis),
+            "frequencies": np.arange(
+                (n_basis + 1) % 2, 1 + (n_basis - n_basis % 2) // 2
+            ),
         }
         default_kwargs = DEFAULT_KWARGS.copy()
         default_kwargs.update(new_kwargs)
@@ -189,7 +192,7 @@ def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
 
 def list_all_real_basis_classes(filter_basis="all"):
     list_all_basis = list_all_basis_classes(filter_basis)
-    return [cls for cls in list_all_basis if not getattr(cls, "is_complex", False)]
+    return [cls for cls in list_all_basis if not getattr(cls, "_is_complex", False)]
 
 
 # Sample subclass to test instantiation and methods

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,17 @@ import pytest
 import nemos as nmo
 import nemos._inspect_utils as inspect_utils
 import nemos.basis.basis as basis
+from docs.scripts.basis_figs import KWARGS
 from nemos.basis import AdditiveBasis, CustomBasis, MultiplicativeBasis
 from nemos.basis._basis import Basis
 from nemos.basis._transformer_basis import TransformerBasis
+
+DEFAULT_KWARGS = {
+    "n_basis_funcs": 5,
+    "frequencies": 4,
+    "window_size": 11,
+    "decay_rates": np.arange(1, 1 + 5),
+}
 
 # shut-off conversion warnings
 nap.nap_config.suppress_conversion_warnings = True
@@ -107,12 +115,14 @@ class CombinedBasis(BasisFuncsTesting):
         """Instantiate and return two basis of the type specified."""
 
         # Set non-optional args
-        default_kwargs = {
+        new_kwargs = {
             "n_basis_funcs": n_basis,
             "window_size": window_size,
             "decay_rates": np.arange(1, 1 + n_basis),
         }
-        repeated_keys = set(default_kwargs.keys()).intersection(kwargs.keys())
+        default_kwargs = DEFAULT_KWARGS.copy()
+        default_kwargs.update(new_kwargs)
+        repeated_keys = set(new_kwargs.keys()).intersection(kwargs.keys())
         if repeated_keys:
             raise ValueError(
                 "Cannot set `n_basis_funcs, window_size, decay_rates` with kwargs"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,7 @@ def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
     )
     if filter_basis != "all":
         all_basis = [a for a in all_basis if filter_basis in a.__name__]
-    return [nmo.basis.FourierEval]  # all_basis
+    return all_basis
 
 
 def list_all_real_basis_classes(filter_basis="all"):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -3304,6 +3304,7 @@ class TestFourierBasis(BasisFuncsTesting):
         bas = self.cls[mode](frequencies=5)
         with expectation:
             bas.ndim = ndim
+            assert bas.ndim == ndim
 
     def test_n_basis_function_compute(self):
         pass

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -3248,14 +3248,14 @@ class TestFourierBasis(BasisFuncsTesting):
                 5,
                 6,
                 np.array([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]], dtype=np.float32),
-                pytest.warns(UserWarning, match="Resetting 'frequency_mask' to None"),
+                pytest.warns(UserWarning, match="Resetting ``frequency_mask`` to None"),
             ),
             (
                 lambda x: x < 3,
                 5,
                 6,
                 np.array([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]], dtype=np.float32),
-                pytest.warns(UserWarning, match="Resetting 'frequency_mask' to None"),
+                pytest.warns(UserWarning, match="Resetting ``frequency_mask`` to None"),
             ),
         ],
     )

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -230,6 +230,7 @@ def test_example_docstrings_add(
         ("RaisedCosineLogConv", "RaisedCosineBasisLog"),
         ("OrthExponentialEval", "OrthExponentialBasis"),
         ("OrthExponentialConv", "OrthExponentialBasis"),
+        ("FourierEval", "FourierBasis"),
     ],
 )
 @pytest.mark.parametrize("method", ["evaluate", "split_by_feature", "evaluate_on_grid"])

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -3306,8 +3306,19 @@ class TestFourierBasis(BasisFuncsTesting):
             bas.ndim = ndim
             assert bas.ndim == ndim
 
-    def test_n_basis_function_compute(self):
-        pass
+    @pytest.mark.parametrize("mode", ["eval"])
+    @pytest.mark.parametrize(
+        "frequency_mask, ndim, expected_output_shape",
+        [
+            (None, 1, (10, 9)), # 5 * 2 -1
+            (None, 2, (10, 49)) # 5 * 5 * 2 -1
+        ]
+    )
+    def test_n_basis_function_compute(self, frequency_mask, ndim, expected_output_shape, mode):
+        bas = self.cls[mode](frequencies=5, ndim=ndim)
+        out = bas.compute_features(*np.ones((ndim, 10)))
+        assert out.shape == expected_output_shape
+        assert bas.n_basis_funcs == expected_output_shape[-1]
 
     def test_bounds_setter(self):
         pass

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -2927,6 +2927,21 @@ class TestFourierBasis(BasisFuncsTesting):
         with expectation:
             bas.frequencies = frequencies
 
+    def test_frequency_mask_setter(self):
+        pass
+
+    def test_joint_frequency_and_frequency_mask_set_params(self):
+        pass
+
+    def test_ndim_getter_and_setter(self):
+        pass
+
+    def test_n_basis_function_compute(self):
+        pass
+
+    def test_bounds_setter(self):
+        pass
+
 
 class TestAdditiveBasis(CombinedBasis):
     cls = {"eval": AdditiveBasis, "conv": AdditiveBasis}

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -5417,15 +5417,15 @@ class TestMultiplicativeBasis(CombinedBasis):
         ):
             return
         # test attributes are not related
-        basis_a.n_basis_funcs = 10
-        basis_b.n_basis_funcs = 10
-        assert mul.basis1.n_basis_funcs == n_basis_a
-        assert mul.basis2.n_basis_funcs == n_basis_b
+        set_basis_attr(basis_a, 10)
+        assert get_basis_attr(mul.basis1) != 10
+        set_basis_attr(mul.basis1, 6)
+        assert basis_a.n_basis_funcs != 6
 
-        mul.basis1.n_basis_funcs = 6
-        mul.basis2.n_basis_funcs = 6
-        assert basis_a.n_basis_funcs == 10
-        assert basis_b.n_basis_funcs == 10
+        set_basis_attr(basis_b, 10)
+        assert get_basis_attr(mul.basis2) != 10
+        set_basis_attr(mul.basis2, 6)
+        assert basis_b.n_basis_funcs != 6
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
@@ -5459,11 +5459,10 @@ class TestMultiplicativeBasis(CombinedBasis):
 
         mul = basis_a * basis_b
         if not isinstance(mul.basis1, (HistoryConv, IdentityEval, CustomBasis)):
-            mul.basis1.n_basis_funcs = 10
+            set_basis_attr(mul.basis1, 10)
             assert mul.n_basis_funcs == 10 * n_basis_b
         if not isinstance(mul.basis2, (HistoryConv, IdentityEval, CustomBasis)):
-            mul.basis2.n_basis_funcs = 10
-            mul.basis2.n_basis_funcs = 10
+            set_basis_attr(mul.basis2, 10)
             assert mul.n_basis_funcs == 10 * mul.basis1.n_basis_funcs
 
     @pytest.mark.parametrize(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -2780,7 +2780,11 @@ class TestFourierBasis(BasisFuncsTesting):
             (1, [10], does_not_raise()),
             (1, [(1, 10)], does_not_raise()),
             (1, [np.arange(1, 10)], does_not_raise()),
-            (1, (np.arange(1, 10),), does_not_raise()),
+            (
+                1,
+                (np.arange(1, 10),),
+                pytest.raises(ValueError, match="Invalid frequencies specification"),
+            ),
             (2, 10, does_not_raise()),
             (2, (1, 10), does_not_raise()),
             (2, [1, 10], does_not_raise()),
@@ -2796,7 +2800,7 @@ class TestFourierBasis(BasisFuncsTesting):
                 [np.arange(1, 10)],
                 pytest.raises(
                     ValueError,
-                    match=r"Invalid frequencies[\s\S]*The length of provided tuple",
+                    match=r"Length of frequencies list",
                 ),
             ),
             (
@@ -2804,13 +2808,17 @@ class TestFourierBasis(BasisFuncsTesting):
                 (np.arange(1, 10),),
                 pytest.raises(
                     ValueError,
-                    match=r"Invalid frequencies[\s\S]*The length of provided tuple",
+                    match=r"Invalid frequencies specification",
                 ),
             ),
             (2, [10, 10], does_not_raise()),
             (2, [(1, 10), (1, 10)], does_not_raise()),
             (2, [np.arange(1, 10), np.arange(1, 10)], does_not_raise()),
-            (2, (np.arange(1, 10), np.arange(1, 10)), does_not_raise()),
+            (
+                2,
+                (np.arange(1, 10), np.arange(1, 10)),
+                pytest.raises(ValueError, match="Invalid frequencies specification"),
+            ),
             (1, [(0, 1)], does_not_raise()),
             (
                 1,
@@ -2822,11 +2830,15 @@ class TestFourierBasis(BasisFuncsTesting):
                 [(1, 10), (10, 1)],
                 pytest.raises(ValueError, match="Tuple frequencies must satisfy"),
             ),
-            (1, -1, pytest.raises(ValueError, match="Integer frequencies must be > 0")),
+            (
+                1,
+                -1,
+                pytest.raises(ValueError, match="Integer frequencies must be >= 0"),
+            ),
             (
                 2,
-                [1, 0],
-                pytest.raises(ValueError, match="Integer frequencies must be > 0"),
+                [1, -1],
+                pytest.raises(ValueError, match="Integer frequencies must be >= 0"),
             ),
             (
                 1,
@@ -2863,6 +2875,24 @@ class TestFourierBasis(BasisFuncsTesting):
                 [np.array([1, 2, 3]), np.array([0.5, 2, 3])],
                 pytest.raises(ValueError, match="frequency values are not integers"),
             ),
+            (
+                2,
+                [np.arange(-1, 3), (1, 3)],
+                pytest.raises(
+                    ValueError,
+                ),
+            ),
+            (
+                2,
+                [np.arange(1, 3), -1],
+                pytest.raises(ValueError, match="Integer frequencies must be >= 0"),
+            ),
+            (
+                2,
+                [np.arange(1, 3), (-1, 2)],
+                pytest.raises(ValueError, match="Tuple frequencies must satisfy 0"),
+            ),
+            (3, [np.arange(1, 3), (1, 3), 10], does_not_raise()),
         ],
     )
     def test_frequencies_setter(self, frequencies, expectation, mode, ndim):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -2927,8 +2927,35 @@ class TestFourierBasis(BasisFuncsTesting):
         with expectation:
             bas.frequencies = frequencies
 
-    def test_frequency_mask_setter(self):
-        pass
+    @pytest.mark.parametrize(
+        "frequency_mask, expectation, output_pairs",
+        [
+            (None, does_not_raise(), np.arange(1, 4).reshape(1, -1)),
+            (np.array([1, 0, 1]), does_not_raise(), np.array([[1, 3]])),
+            (np.array([False, False, True]), does_not_raise(), np.array([[3]])),
+            (lambda x: x == 1, does_not_raise(), np.array([[1.0]])),
+        ],
+    )
+    @pytest.mark.parametrize("mode", ["eval"])
+    def test_frequency_mask_setter_1d(
+        self, mode, frequency_mask, expectation, output_pairs
+    ):
+        with expectation:
+            bas = instantiate_atomic_basis(
+                self.cls[mode],
+                **extra_kwargs(self.cls[mode], 6),
+                ndim=1,
+                frequency_mask=frequency_mask,
+            )
+        np.testing.assert_array_equal(bas._eval_freq, output_pairs)
+
+        # check that mask is reset
+        bas.frequency_mask = None
+        np.testing.assert_array_equal(bas._eval_freq, np.arange(1, 4).reshape(1, -1))
+
+        # check setter directly
+        bas.frequency_mask = frequency_mask
+        np.testing.assert_array_equal(bas._eval_freq, output_pairs)
 
     def test_joint_frequency_and_frequency_mask_set_params(self):
         pass

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -3351,8 +3351,63 @@ class TestFourierBasis(BasisFuncsTesting):
         assert out.shape == expected_output_shape
         assert bas.n_basis_funcs == expected_output_shape[-1]
 
-    def test_bounds_setter(self):
-        pass
+    @pytest.mark.parametrize(
+        "bounds, ndim, expectation",
+        [
+            (None, 1, does_not_raise()),
+            (
+                (None, np.pi),
+                1,
+                pytest.raises(TypeError, match="Could not convert `bounds` to float"),
+            ),
+            (
+                (np.pi, None),
+                1,
+                pytest.raises(TypeError, match="Could not convert `bounds` to float"),
+            ),
+            ((np.pi / 2, np.pi), 1, does_not_raise()),
+            (
+                (np.pi, np.pi),
+                1,
+                pytest.raises(
+                    ValueError, match=" Lower bound is greater or equal than the"
+                ),
+            ),
+            ([(np.pi / 2, np.pi)], 1, does_not_raise()),
+            (None, 2, does_not_raise()),
+            (
+                [None, None],
+                2,
+                pytest.raises(TypeError, match="Could not convert `bounds` to float"),
+            ),
+            (
+                [(np.pi / 2, np.pi)] * 2,
+                1,
+                pytest.raises(
+                    TypeError, match="When provided, the bounds should be one"
+                ),
+            ),
+            ([(np.pi / 2, np.pi)] * 2, 2, does_not_raise()),
+            (
+                [(np.pi / 2, np.pi), (np.pi, np.pi)],
+                2,
+                pytest.raises(
+                    ValueError, match=" Lower bound is greater or equal than the"
+                ),
+            ),
+            (
+                [(np.pi / 2, np.pi), ("a", np.pi)],
+                2,
+                pytest.raises(
+                    TypeError,
+                    match="the bounds should be one or multiple tuples containing pair of floats",
+                ),
+            ),
+        ],
+    )
+    def test_bounds_setter(self, bounds, ndim, expectation):
+        with expectation:
+            self.cls["eval"](frequencies=5, bounds=bounds, ndim=ndim)
 
 
 class TestAdditiveBasis(CombinedBasis):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -3051,12 +3051,12 @@ class TestAdditiveBasis(CombinedBasis):
         assert add_a_twice.basis2.label == f"{cls_b_name}"
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_input_shape_product_init(
         self, basis_a, basis_b, basis_class_specific_params
@@ -3096,12 +3096,12 @@ class TestAdditiveBasis(CombinedBasis):
         assert sum((1 for _ in out._iterate_over_components())) == 10
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_provide_label_at_init(self, basis_a, basis_b, basis_class_specific_params):
         basis_a_obj = self.instantiate_basis(
@@ -3971,12 +3971,12 @@ class TestAdditiveBasis(CombinedBasis):
             )
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     @pytest.mark.parametrize("shape_a", [1, (), np.ones(3)])
     @pytest.mark.parametrize("shape_b", [1, (), np.ones(3)])
@@ -4009,12 +4009,12 @@ class TestAdditiveBasis(CombinedBasis):
         )
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     @pytest.mark.parametrize("shape_a", [2, (2,), np.ones((3, 2))])
     @pytest.mark.parametrize("shape_b", [3, (3,), np.ones((3, 3))])
@@ -4047,12 +4047,12 @@ class TestAdditiveBasis(CombinedBasis):
         )
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     @pytest.mark.parametrize("shape_a", [(2, 2), np.ones((3, 2, 2))])
     @pytest.mark.parametrize("shape_b", [(3, 1), np.ones((3, 3, 1))])
@@ -4103,12 +4103,12 @@ class TestAdditiveBasis(CombinedBasis):
         ],
     )
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_set_input_value_types(
         self, inp_shape, expectation, basis_a, basis_b, basis_class_specific_params
@@ -4124,12 +4124,12 @@ class TestAdditiveBasis(CombinedBasis):
             add.set_input_shape(*inp_shape)
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_deep_copy_basis(self, basis_a, basis_b, basis_class_specific_params):
 
@@ -4176,12 +4176,12 @@ class TestAdditiveBasis(CombinedBasis):
         assert basis_b.n_basis_funcs != 6
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_compute_n_basis_runtime(
         self, basis_a, basis_b, basis_class_specific_params
@@ -5224,16 +5224,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         assert bas_prod._input_shape_product == (n_basis_input1, n_basis_input2)
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     @pytest.mark.parametrize("shape_a", [1, (), np.ones(3)])
     @pytest.mark.parametrize("shape_b", [1, (), np.ones(3)])
@@ -5266,16 +5262,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     @pytest.mark.parametrize("shape_a", [2, (2,), np.ones((3, 2))])
     @pytest.mark.parametrize("shape_b", [3, (3,), np.ones((3, 3))])
@@ -5308,16 +5300,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         )
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     @pytest.mark.parametrize("shape_a", [(2, 2), np.ones((3, 2, 2))])
     @pytest.mark.parametrize("shape_b", [(3, 1), np.ones((3, 3, 1))])
@@ -5368,16 +5356,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         ],
     )
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_set_input_value_types(
         self, inp_shape, expectation, basis_a, basis_b, basis_class_specific_params
@@ -5393,16 +5377,12 @@ class TestMultiplicativeBasis(CombinedBasis):
             mul.set_input_shape(*inp_shape)
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_deep_copy_basis(self, basis_a, basis_b, basis_class_specific_params):
 
@@ -5448,16 +5428,12 @@ class TestMultiplicativeBasis(CombinedBasis):
         assert basis_b.n_basis_funcs == 10
 
     @pytest.mark.parametrize(
-        "basis_a",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
-    )
-    @pytest.mark.parametrize(
-        "basis_b",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        "basis_a, basis_b",
+        create_atomic_basis_pairs(
+            list_all_basis_classes("Eval")
+            + list_all_basis_classes("Conv")
+            + [CustomBasis]
+        ),
     )
     def test_compute_n_basis_runtime(
         self, basis_a, basis_b, basis_class_specific_params

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -1,15 +1,15 @@
 import copy
 import warnings
+from contextlib import nullcontext as does_not_raise
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 import statsmodels.api as sm
+from scipy.optimize import minimize
 from sklearn.linear_model import GammaRegressor, PoissonRegressor
 from statsmodels.tools.sm_exceptions import DomainWarning
-from scipy.optimize import minimize
-from contextlib import nullcontext as does_not_raise
 
 import nemos as nmo
 


### PR DESCRIPTION
This PR adds a class for N-dimensional `FourierEval` bases. This basis is composed by pairs of cosine and sine at different frequencies. The output of `compute_features` is  a real valued design matrix, but columns corresponding to cosine and sine pairs represent real and imaginary part of a complex number. 

For this reason, naive multiplication with other real bases (i.e. BSpline, Raised Cosines etc) is disabled, as it would treat all columns as real. 

The `FourierEval` basis can be instantiated as multidimensional, by providing an `ndim` parameter. 

Frequency pairs can be selected by specifying an optional `frequency_mask` which can be: 

- A boolean array of shape `(n_1, n_2, ..., n_m)` where `m` is the dimensionality of the basis (`ndim`) and `n_k` is the number of frequencies for the k-th dimension of the Fourier basis.
- A  callable: `def mask_func(f_1: float, ..., f_m: float): -> bool`, which takes as input `m` frequency values and returns a boolean.