### PR TITLE
Glm hmm e step

### DIFF
--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -60,6 +60,7 @@ VALID_PAIRS = [
     {"state", "states"},
     {"state", "start"},
     {"states", "start"},
+    {"n_states", "states"},
     {"feature_mask", "features"},
     {"observation", "observations"},
     # doc utils
@@ -68,6 +69,10 @@ VALID_PAIRS = [
     {"predicted_firing_rate", "predicted_firing_rates"},
     {"tuning_curve", "tuning_curves"},
     {"hyperparams_prox", "hyperparams"},
+    {"condition", "conditionals"},
+    {"posterior", "posteriors"},
+    {"beta", "betas"},
+    {"alpha", "alphas"},
     {"hyperparams_prox", "hyperparams"},
     {"flat_dict", "flat_map_dict"},
     {"fit_params", "init_params"},

--- a/src/nemos/fetch/fetch_data.py
+++ b/src/nemos/fetch/fetch_data.py
@@ -41,6 +41,7 @@ REGISTRY_DATA = {
     "m691l1.nwb": "1990d8d95a70a29af95dade51e60ffae7a176f6207e80dbf9ccefaf418fe22b6",
     "A2929-200711.nwb": "f698d7319efa5dfeb18fb5fe718ec1a84fdf96b85a158177849a759cd5e396fe",
     "Achilles_10252013_EEG.nwb": "a97a69d231e7e91c07e24890225f8fe4636bac054de50345551f32fc46b9efdd",
+    "em_three_states.npz": "92e9fe7990e98f3d23536a40658e258acbc83c26d773f78336431abc12e01951",
 }
 DOWNLOADABLE_FILES = list(REGISTRY_DATA.keys())
 
@@ -56,6 +57,7 @@ REGISTRY_URLS_DATA = {
     "m691l1.nwb": OSF_TEMPLATE.format("xesdm"),
     "A2929-200711.nwb": OSF_TEMPLATE.format("y7zwd"),
     "Achilles_10252013_EEG.nwb": OSF_TEMPLATE.format("2dfvp"),
+    "em_three_states.npz": OSF_TEMPLATE.format("wdz7j"),
 }
 
 _NEMOS_ENV = "NEMOS_DATA_DIR"

--- a/src/nemos/glm_hmm/__init__.py
+++ b/src/nemos/glm_hmm/__init__.py
@@ -1,0 +1,3 @@
+"""GLM-HMM module."""
+
+from .expectation_maximization import backward_pass, forward_backward, forward_pass

--- a/src/nemos/glm_hmm/expectation_maximization.py
+++ b/src/nemos/glm_hmm/expectation_maximization.py
@@ -1,0 +1,408 @@
+"""Forward backward pass for a GLM-HMM."""
+
+from functools import partial
+from typing import Callable, Tuple
+
+import jax
+import jax.numpy as jnp
+from numpy.typing import NDArray
+
+Array = NDArray | jax.numpy.ndarray
+
+
+def compute_xi(
+    alphas, betas, conditionals, normalization, is_new_session, transition_prob
+):
+    """
+    Compute the expected joint posterior (xi) over consecutive latent states.
+
+    Parameters
+    ----------
+    alphas :
+        Forward messages, shape ``(n_time_bins, n_states)``
+    betas :
+        Backward messages, shape ``(n_time_bins, n_states)``.
+    conditionals :
+        Observation likelihoods p(y_t | z_t), shape ``(n_time_bins, n_states)``.
+    normalization :
+        Normalization constants from forward pass, shape ``(n_time_bins,)``.
+    is_new_session :
+        Boolean array, True at start of new sessions, shape ``(n_time_bins,)``.
+    transition_prob :
+        Transition probability matrix, shape ``(n_states, n_states)``.
+
+    Returns
+    -------
+    :
+        Expected joint posteriors between time steps, shape ``(n_states, n_states)``.
+    """
+    # shift alpha so that alpha[t-1] aligns with beta[t]
+    norm_alpha = alphas[:-1] / normalization[1:, jnp.newaxis]
+
+    # mask out steps where t is a new session
+    norm_alpha = jnp.where(is_new_session[1:, jnp.newaxis], 0.0, norm_alpha)
+
+    # Compute xi sum in one matmul
+    xi_sum = norm_alpha.T @ (conditionals[1:] * betas[1:])
+
+    return xi_sum * transition_prob
+
+
+def forward_pass(
+    initial_prob: Array,
+    transition_prob: Array,
+    conditional_prob: Array,
+    is_new_session: Array,
+) -> Tuple[Array, Array]:
+    """
+    Forward pass of an HMM.
+
+    This function performs the recursive forward pass over time using ``jax.lax.scan``,
+    computing the filtered probabilities (``alpha``) at each time step. At the start of
+    a new session, the recursion is reset using the initial state distribution.
+
+    Parameters
+    ----------
+    initial_prob :
+        Initial state probability distribution, array of shape ``(n_states,)``.
+
+    transition_prob :
+        Transition matrix of shape ``(n_states, n_states)``, where entry ``T[i, j]`` is the
+        probability of transitioning from state ``i`` to state ``j``.
+
+    conditional_prob :
+        Array of shape ``(n_time_bins, n_states)``, representing the observation likelihood
+        ``p(y_t | z_t)`` at each time step for each state.
+
+    is_new_session :
+        Boolean array of shape ``(n_time_bins,)`` indicating the start of new sessions. When
+        ``is_new_session[t]`` is True, the recursion at time ``t`` is reset using ``initial_prob``.
+
+    Returns
+    -------
+    alphas :
+        Array of shape ``(n_time_bins, n_states)``, containing the filtered probabilities
+        at each time step. ``alphas[t]`` corresponds to the forward message at time ``t``.
+
+    normalizers :
+        Array of shape ``(n_time_bins,)`` containing the normalization constants at each
+        time step. These values can be used to compute the log-likelihood of the sequence.
+
+    Notes
+    -----
+    Normalization is performed at each time step to avoid numerical underflow, guarding
+    against divide-by-zero errors.
+
+    Equivalent pseudocode in standard Python:
+
+    .. code-block:: python
+
+        alphas = np.full((n_states, n_time_bins), np.nan)
+        c = np.full(n_time_bins, np.nan)
+
+        for t in range(n_time_bins):
+            if new_sess[t]:
+                alphas[:, t] = initial_prob * py_z.T[:, t]
+            else:
+                alphas[:, t] = py_z.T[:, t] * (transition_prob.T @ alphas[:, t - 1])
+
+            c[t] = np.sum(alphas[:, t])
+            alphas[:, t] /= c[t]
+    """
+
+    def initial_compute(posterior, _):
+        # Equation 13.37. Reinitialize for new sessions
+        return posterior * initial_prob
+
+    def transition_compute(posterior, alpha_previous):
+        # Equation 13.36
+        exp_transition = jnp.matmul(transition_prob, alpha_previous)
+        return posterior * exp_transition
+
+    def body_fn(carry, xs):
+        alpha_previous = carry
+        posterior, is_new_session = xs
+        # if it is a new session, run initial_compute
+        # else, run transition_compute
+        # for both functions, the inputs are posterior and alpha_previous
+        alpha = jax.lax.cond(
+            is_new_session,
+            initial_compute,
+            transition_compute,
+            posterior,
+            alpha_previous,
+        )
+        const = jnp.sum(alpha)  # Store marginal likelihood
+
+        # Safe divide implementation so we don't divide over 0
+        const = jnp.where(const > 0, const, 1.0)
+
+        alpha = alpha / const  # Normalize - Equation 13.59
+        return alpha, (alpha, const)
+
+    init = jnp.zeros_like(conditional_prob[0])
+    transition_prob = transition_prob.T
+    _, (alphas, normalizers) = jax.lax.scan(
+        body_fn, init, (conditional_prob, is_new_session)
+    )
+    return alphas, normalizers
+
+
+def backward_pass(
+    transition_prob: Array,
+    conditional_prob: Array,
+    normalizers: Array,
+    is_new_session: Array,
+):
+    """
+    Run the backward pass of the HMM inference algorithm to compute beta messages.
+
+    This function performs the backward recursion step of the forward–backward algorithm,
+    using ``jax.lax.scan`` in reverse to compute beta messages at each time step. It handles
+    session boundaries by resetting the beta messages when a new session starts.
+
+    Parameters
+    ----------
+    transition_prob :
+        Transition matrix of shape ``(n_states, n_states)``, where entry ``T[i, j]`` is the
+        probability of transitioning from state ``i`` to state ``j``.
+
+    conditional_prob :
+        Array of shape ``(n_time_bins, n_states)``, representing the observation likelihoods
+        ``p(y_t | z_t)`` at each time step for each state.
+
+    normalizers :
+        Array of shape ``(n_time_bins,)`` containing the normalization constants from the forward
+        pass (e.g., sums of alpha messages). These are used to normalize the backward recursion.
+
+    is_new_session :
+        Boolean array of shape ``(n_time_bins,)`` indicating the start of new sessions. When
+        ``is_new_session[t]`` is True, the backward message at time ``t`` is reset to a vector of ones.
+
+    Returns
+    -------
+    betas :
+        Array of shape ``(n_time_bins, n_states)``, containing the beta messages at each time step.
+        The indexing is aligned with the forward pass, such that ``betas[t]`` corresponds to the
+        backward message at time ``t``.
+
+    Notes
+    -----
+    This implementation follows the standard HMM backward equations (Bishop, 2006, Eq. 13.38–13.39),
+    including reinitialization for segmented sequences.
+
+    Equivalent pseudocode in standard Python:
+
+    .. code-block:: python
+
+        betas = np.full((n_states, n_time_bins), np.nan)
+        betas[:, -1] = np.ones(n_states)
+
+        for t in range(n_time_bins - 2, -1, -1):
+            if new_sess[t + 1]:
+                betas[:, t] = np.ones(
+                    n_states
+                )
+            else:
+                betas[:, t] = transition_prob @ (
+                    betas[:, t + 1] * py_z.T[:, t + 1]
+                )
+                betas[:, t] /= c[t + 1]
+    """
+    init = jnp.ones_like(conditional_prob[0])
+
+    def initial_compute(posterior, *_):
+        # Initialize
+        return jnp.ones_like(posterior)
+
+    def backward_step(posterior, beta, normalization):
+        # Normalize (Equation 13.62)
+        return jnp.matmul(transition_prob, posterior * beta) / normalization
+
+    def body_fn(carry, xs):
+        posterior, norm, is_new_sess = xs
+        beta = jax.lax.cond(
+            is_new_sess,
+            initial_compute,
+            backward_step,
+            posterior,
+            carry,
+            norm,
+        )
+        return beta, carry
+
+    # Keeping the carrys because I am interested in
+    # all outputs, including the last one.
+    _, betas = jax.lax.scan(
+        body_fn, init, (conditional_prob, normalizers, is_new_session), reverse=True
+    )
+    return betas
+
+
+@partial(jax.jit, static_argnames=["inverse_link_function", "likelihood_func"])
+def forward_backward(
+    X: Array,
+    y: Array,
+    initial_prob: Array,
+    transition_prob: Array,
+    projection_weights: Array,
+    inverse_link_function: Callable,
+    likelihood_func: Callable[[Array, Array], Array],
+    is_new_session: Array | None = None,
+):
+    """
+    Run the forward-backward Baum-Welch algorithm.
+
+    Run the forward-backward Baum-Welch algorithm [1]_ that compute a posterior distribution over latent
+    states.
+
+    Parameters
+    ----------
+    X :
+        Design matrix, pytree with leaves of shape ``(n_time_bins, n_features)``.
+
+    y :
+        Observations, pytree with leaves of shape ``(n_time_bins,)``.
+
+    initial_prob :
+        Initial latent state probability, pytree with leaves of shape ``(``n_states, 1)``.
+
+    transition_prob :
+        Latent state transition matrix, pytree with leaves of shape ``(n_states, n_states)``.
+        ``transition_prob[i, j]`` is the probability of transitioning from state ``i`` to state ``j``.
+
+    projection_weights :
+        Latent state GLM weights, pytree with leaves of shape ``(n_features, n_states)``.
+
+    inverse_link_function :
+        Function mapping linear predictors to the mean of the observation distribution
+        (e.g., ``jnp.exp`` for Poisson, sigmoid for Bernoulli).
+
+    likelihood_func :
+        Function computing the elementwise likelihood of observations given predicted mean values.
+        Must return an array of shape ``(n_time_bins, n_states)``.
+
+    is_new_session :
+        Boolean array marking the start of a new session.
+        If unspecified or empty, treats the full set of trials as a single session.
+
+    Returns
+    -------
+    posteriors :
+        Marginal posterior distribution over latent states, shape ``(n_time_bins, n_states)``.
+
+    joint_posterior :
+        Joint posterior distribution between consecutive time steps summed
+        over samples, shape ``(n_states, n_states)``.
+
+    log_likelihood :
+        Total log-likelihood of the observation sequence under the model.
+
+    log_likelihood_norm :
+        A vmapped function that computes the elementwise log-likelihood between observed
+        and predicted values. Must return an array of shape ``(n_time_bins, n_states)``.
+        The vmapping over states must be performed by the caller, outside this function,
+        using `jax.vmap` or equivalent, so that the passed function is already fully
+        vectorized over the state dimension.
+
+    alphas :
+        Forward messages (alpha values), shape ``(n_time_bins, n_states)``.
+
+    betas :
+        Backward messages (beta values), shape ``(n_time_bins, n_states)``.
+
+    References
+    ----------
+    .. [1] Bishop, C. M. (2006). *Pattern recognition and machine learning*. Springer.
+    """
+    # Initialize variables
+    n_time_bins = X.shape[0]
+
+    # Revise if the data is one single session or multiple sessions.
+    # If new_sess is not provided, assume one session
+    if is_new_session is None:
+        # default: all False, but first time bin must be True
+        is_new_session = jax.lax.dynamic_update_index_in_dim(
+            jnp.zeros(y.shape[0], dtype=bool), True, 0, axis=0
+        )
+    else:
+        # use the user-provided tree, but force the first time bin to be True
+        is_new_session = jax.lax.dynamic_update_index_in_dim(
+            jnp.asarray(is_new_session, dtype=bool), True, 0, axis=0
+        )
+
+    # Predicted y
+    if projection_weights.ndim > 2:
+        predicted_rate_given_state = inverse_link_function(
+            jnp.einsum("ik, kjw->ijw", X, projection_weights)
+        )
+    else:
+        predicted_rate_given_state = inverse_link_function(X @ projection_weights)
+
+    # Compute likelihood given the fixed weights
+    # Data likelihood p(y|z) from emissions model
+    # NOTE:
+    # For N neurons and S samples, we want the total likelihood
+    # across neurons for each sample and latent state.
+
+    # Example helper:
+    # def combined_likelihood(log_likelihood_func, y, rate):
+    #     # log_likelihood_func takes (y, rate) and returns log-likelihood per neuron:
+    #     #   y:    shape (S, N)
+    #     #   rate: shape (S, N, K)  # K = number of latent states
+    #
+    #     assert y.ndim == 2      # (samples, neurons)
+    #     assert rate.ndim == 3   # (samples, neurons, states)
+    #
+    #     # vmap over the state axis: apply log_likelihood_func for each state
+    #     # Result: shape (S, N, K)
+    #     log_like = jax.vmap(log_likelihood_func, in_axes=(None, 2), out_axes=2)(y, rate)
+    #
+    #     # Combine neurons assuming conditional independence:
+    #     # sum log-likelihoods over neurons (axis=1), then exponentiate for stability
+    #     # Final shape: (S, K)
+    #     return jnp.exp(jnp.sum(log_like, axis=1))
+    #
+    # Here, log_likelihood_func is the ``log_likelihood`` method from
+    # nemos.observation_models.Observations with ``aggregate_sample_scores = lambda x:x``
+
+    conditionals = likelihood_func(y, predicted_rate_given_state)
+
+    # Compute forward pass
+    alphas, normalization = forward_pass(
+        initial_prob, transition_prob, conditionals, is_new_session
+    )  # these are equivalent to the forward pass with python loop
+
+    # Compute backward pass
+    betas = backward_pass(transition_prob, conditionals, normalization, is_new_session)
+
+    log_likelihood = jnp.sum(
+        jnp.log(normalization)
+    )  # Store log-likelihood, log of Equation 13.63
+
+    log_likelihood_norm = jnp.exp(log_likelihood / n_time_bins)  # Normalize
+
+    # Posteriors
+    # ----------
+    # Compute posterior distributions
+    # Gamma - Equations 13.32, 13.64 from [1]
+    posteriors = alphas * betas
+
+    # xis Equations 13.43 and 13.65 from [1]
+    # Posterior over consecutive states summed across time steps
+    joint_posterior = compute_xi(
+        alphas,
+        betas,
+        conditionals,
+        normalization,
+        is_new_session,
+        transition_prob,
+    )
+    return (
+        posteriors,
+        joint_posterior,
+        log_likelihood,
+        log_likelihood_norm,
+        alphas,
+        betas,
+    )

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -1030,7 +1030,7 @@ class BernoulliObservations(Observations):
         Returns
         -------
         :
-            The Bernoulli negative log-likehood. Shape (1,).
+            The Bernoulli negative log-likelihood. Shape (1,).
 
         Notes
         -----

--- a/tests/test_glm_hmm.py
+++ b/tests/test_glm_hmm.py
@@ -1,0 +1,75 @@
+from functools import partial
+
+import jax
+import numpy as np
+import pytest
+
+from nemos.fetch import fetch_data
+from nemos.glm_hmm.expectation_maximization import forward_backward
+from nemos.observation_models import BernoulliObservations
+
+
+# Below are tests for Bernoulli observation 3 states model glm hmm
+@pytest.mark.parametrize(
+    "decorator",
+    [
+        lambda x: x,
+        partial(jax.jit, static_argnames=["likelihood_func", "inverse_link_function"]),
+    ],
+)
+def test_forward_backward_regression(decorator):
+    jax.config.update("jax_enable_x64", True)
+
+    # Fetch the data
+    data_path = fetch_data("em_three_states.npz")
+    data = np.load(data_path)
+
+    X, y = data["X"], data["y"]
+    new_sess = data["new_sess"]
+
+    # E-step initial parameters
+    initial_prob = data["initial_prob"]
+    projection_weights = data["projection_weights"]
+    transition_prob = data["transition_prob"]
+
+    # E-step output
+    xis = data["xis"]
+    gammas = data["gammas"]
+    ll_orig, ll_norm_orig = data["log_likelihood"], data["ll_norm"]
+    alphas, betas = data["alphas"], data["betas"]
+
+    obs = BernoulliObservations()
+
+    likelihood = jax.vmap(
+        lambda x, z: obs.likelihood(x, z, aggregate_sample_scores=lambda w: w),
+        in_axes=(None, 1),
+        out_axes=1,
+    )
+
+    decorated_forward_backward = decorator(forward_backward)
+    gammas_nemos, xis_nemos, ll_nemos, ll_norm_nemos, alphas_nemos, betas_nemos = (
+        decorated_forward_backward(
+            X,
+            y,
+            initial_prob,
+            transition_prob,
+            projection_weights,
+            likelihood_func=likelihood,
+            inverse_link_function=obs.default_inverse_link_function,
+            is_new_session=new_sess.astype(bool),
+        )
+    )
+
+    # First testing alphas and betas because they are computed first
+    np.testing.assert_almost_equal(alphas_nemos, alphas, decimal=8)
+    np.testing.assert_almost_equal(betas_nemos, betas, decimal=8)
+
+    # testing log likelihood and normalized log likelihood
+    np.testing.assert_almost_equal(ll_nemos, ll_orig, decimal=8)
+    np.testing.assert_almost_equal(ll_norm_nemos, ll_norm_orig, decimal=8)
+
+    # Next testing xis and gammas because they depend on alphas and betas
+    # Testing Eq. 13.43 of Bishop
+    np.testing.assert_almost_equal(gammas_nemos, gammas, decimal=8)
+    # Testing Eq. 13.65 of Bishop
+    np.testing.assert_almost_equal(xis_nemos, xis, decimal=8)


### PR DESCRIPTION
# GLM-HMM E-step
Implement the forward-backward algorithm of the GLM-HMM with trial resetting.

## Included in the PR
- Main scan based algorithms for the forward and backward passes.
- Joint forward-backward step which outputs other auxiliary quantities needed for the M-step and the evaluation of the model likelihood.
- Regression test for the E-step parameters.

## Notes
The E-step can be parallelized, using `jax.lax.associative_scan` since it consists of a bunch of matmul that can be applied in whatever order given the associative property of the product; however the phase resetting will need a bit of thought because it breaks this symmetry, see issue #398 for additional details and thoughts.