### PR TITLE
Correct CI schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 0 1 * 0     # monthly
+    - cron: 0 0 1 * *     # monthly
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The comment said it runs monthly, but the expression meant [monthly + every Sunday](https://crontab.guru/#0_0_1_*_0).
Changed to [just monthly](https://crontab.guru/#0_0_1_*_*).