### PR TITLE
force python version for deploy, due to numba cap

### DIFF
--- a/.github/workflows/deploy-pure-python.yml
+++ b/.github/workflows/deploy-pure-python.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Build package
         run: |
           pip install build


### PR DESCRIPTION
use 3.12 in deploy