### PR TITLE
Add method to transformer

### DIFF
--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -335,7 +335,7 @@ class TransformerBasis:
         if name in self._wrapped_methods:
             return self._wrapped_methods[name]
 
-        if not hasattr(self._basis, name) or name == "to_transformer":
+        if not hasattr(self._basis, name):
             raise AttributeError(f"'TransformerBasis' object has no attribute '{name}'")
 
         # Get the original attribute from the basis
@@ -463,7 +463,6 @@ class TransformerBasis:
         """Extend the list of properties of methods with the ones from the underlying Basis."""
         unique_attrs = set(list(super().__dir__()) + list(self.basis.__dir__()))
         # discard without raising errors if not present
-        unique_attrs.discard("to_transformer")
         return list(unique_attrs)
 
     def __add__(self, other: TransformerBasis | Basis) -> TransformerBasis:


### PR DESCRIPTION
Make sure that TransformerBasis has a `to_transformer` method. it may happen that, while scripting, one forgot if a basis is already a transformer and call `to_transformer` multiple times. This prevents exception to be raised and de-facto, does a deep copy of the transformer.