### PR TITLE
Optimistix 0.1.0 compatibility

### DIFF
--- a/src/nemos/solvers/_fista.py
+++ b/src/nemos/solvers/_fista.py
@@ -11,7 +11,7 @@ from optimistix._custom_types import Aux, Y
 
 from ..proximal_operator import prox_none
 from ..tree_utils import tree_add_scalar_mul, tree_sub
-from ._optimistix_adapter import OptimistixAdapter
+from ._optimistix_adapter import _OPTX_V_010, OptimistixAdapter
 
 
 def tree_nan_like(x: PyTree):
@@ -215,9 +215,17 @@ class FISTA(optx.AbstractMinimiser[Y, Aux, ProxGradState]):
         f_at_point, lin_fn, _ = jax.linearize(
             lambda _y: fn(_y, args), update_point, has_aux=True
         )
-        grad_at_point = optx._misc.lin_to_grad(
-            lin_fn, update_point, autodiff_mode=autodiff_mode
-        )
+        if _OPTX_V_010:
+            grad_at_point = optx._misc.lin_to_grad(
+                lin_fn,
+                update_point,
+                autodiff_mode=autodiff_mode,
+                dtype=f_at_point.dtype,
+            )
+        else:
+            grad_at_point = optx._misc.lin_to_grad(
+                lin_fn, update_point, autodiff_mode=autodiff_mode
+            )
 
         if self.stepsize is None or self.stepsize <= 0.0:
             # do linesearch to find the new stepsize

--- a/src/nemos/solvers/_optimistix_adapter.py
+++ b/src/nemos/solvers/_optimistix_adapter.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, ClassVar, Type, TypeAlias
 
 import equinox as eqx
 import optimistix as optx
+from packaging.version import Version
 
 from ..regularizer import Regularizer
 from ..typing import Aux, Params
@@ -15,6 +16,8 @@ from ._aux_helpers import (
     wrap_aux,
 )
 from ._solver_adapter import SolverAdapter
+
+_OPTX_V_010 = Version(optx.__version__) >= Version("0.1.0")
 
 DEFAULT_ATOL = 1e-4
 DEFAULT_RTOL = 0.0

--- a/src/nemos/solvers/_optimistix_solvers.py
+++ b/src/nemos/solvers/_optimistix_solvers.py
@@ -4,7 +4,7 @@ import lineax as lx
 import optimistix as optx
 from jaxtyping import Array, PyTree, Scalar
 
-from ._optimistix_adapter import OptimistixAdapter
+from ._optimistix_adapter import _OPTX_V_010, OptimistixAdapter
 
 
 def _make_rate_scaler(
@@ -39,7 +39,7 @@ class BFGS(optx.BFGS):
         atol: float,
         norm: Callable[[PyTree], Scalar] = optx.max_norm,
         use_inverse: bool = True,
-        verbose: frozenset[str] = frozenset(),
+        verbose: frozenset[str] | bool | Callable[..., None] | None = None,
         stepsize: float | None = None,
         linesearch_kwargs: dict[str, Any] | None = None,
     ):
@@ -49,6 +49,17 @@ class BFGS(optx.BFGS):
         self.use_inverse = use_inverse
         self.descent = optx.NewtonDescent(linear_solver=lx.Cholesky())
         self.search = _make_rate_scaler(stepsize, linesearch_kwargs)
+
+        if _OPTX_V_010:
+            # >=0.1.0 accepts bool or callable
+            if verbose is None:
+                verbose = False
+            verbose = optx._misc.default_verbose(verbose)
+        else:
+            # < 0.1.0 accepts frozendict
+            if verbose is None:
+                verbose = frozenset()
+
         self.verbose = verbose
 
 


### PR DESCRIPTION
Optimistix v0.1.0 introduced some breaking changes: https://github.com/patrick-kidger/optimistix/releases/tag/v0.1.0

- `_misc.lin_to_grad` requires `dtype`
- `verbose` passed to solvers used to be `frozenset`, now it's `bool` or `Callable`

The appropriate arguments are passed based on the installed Optimistix version.