### PR TITLE
Allow any pytree

### DIFF
--- a/src/nemos/base_validator.py
+++ b/src/nemos/base_validator.py
@@ -329,8 +329,16 @@ class RegressorValidator(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParams
                 "Time axis mismatch. X and y pynapple objects have mismatching time axis."
             )
 
+        # initialize for static checker
+        n_samples_x: set[int] = set()
         check_vals = []
         if X is not None:
+            flat_x = jax.tree_util.tree_leaves(X)
+            n_samples_x = {x.shape[0] for x in flat_x}
+            if len(n_samples_x) > 1:
+                raise ValueError(
+                    f"X pytree contains arrays with different number of samples: {n_samples_x}."
+                )
             if is_pynapple_tsd(X):
                 X = X.values
             check_tree_leaves_dimensionality(
@@ -351,10 +359,11 @@ class RegressorValidator(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParams
             check_vals.append(y)
 
         if X is not None and y is not None:
-            if y.shape[0] != X.shape[0]:
+            if not n_samples_x == {y.shape[0]}:
+                n_samples_x = n_samples_x.pop()
                 raise ValueError(
                     "X and y must have the same number of samples (same length along axis 0). "
-                    f"X has {X.shape[0]} samples, "
+                    f"X has {n_samples_x} samples, "
                     f"y has {y.shape[0]} samples instead!"
                 )
         # error if all samples are invalid

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -763,7 +763,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
     >>> model.regularizer
     Ridge()
 
-    **Use a Pytree of Arrays as Input**
+    **Use a Pytree of arrays as Input**
 
     Features can be passed as any JAX pytree of 2-D arrays; the fitted
     ``coef_`` will share the same pytree structure:
@@ -1038,7 +1038,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
     >>> model.regularizer
     Ridge()
 
-    **Use a Pytree of Arrays as Input**
+    **Use a Pytree of arrays as Input**
 
     Features can be passed as any JAX pytree of 2-D arrays; the fitted
     ``coef_`` will share the same pytree structure:

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -266,7 +266,7 @@ class ClassifierMixin:
         ----------
         X :
             The input samples. Can be an array of shape ``(n_samples, n_features)``
-            or a ``FeaturePytree`` with arrays as leaves.
+            or a pytree of arrays of the same shape.
 
         Returns
         -------
@@ -306,7 +306,7 @@ class ClassifierMixin:
         ----------
         X :
             The input samples. Can be an array of shape ``(n_samples, n_features)``
-            or a ``FeaturePytree`` with arrays as leaves.
+            or a pytree of arrays of the same shape.
         return_type :
             The format of the returned probabilities. If ``"log-proba"``, returns
             log-probabilities. If ``"proba"``, returns probabilities. Defaults to
@@ -432,8 +432,8 @@ class ClassifierMixin:
             A JAX random key used to generate the simulated responses.
         feedforward_input :
             The input samples used to generate the responses. Can be an array of
-            shape ``(n_samples, n_features)`` or a ``FeaturePytree`` with arrays
-            as leaves.
+            shape ``(n_samples, n_features)`` or a pytree of arrays of the same
+            shape.
 
         Returns
         -------
@@ -578,7 +578,7 @@ class ClassifierMixin:
             optimization algorithm to continue from the current state.
         X :
             The predictors used in the model fitting process. Shape ``(n_time_bins, n_features)``
-            or a ``FeaturePytree``.
+            or a pytree of arrays of the same shape.
         y :
             Class labels, array of shape ``(n_time_bins,)`` for single neuron
             models or ``(n_time_bins, n_neurons)`` for population models. Labels must
@@ -803,7 +803,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
         Parameters
         ----------
         X
-            Training input samples of shape ``(n_samples, n_features)`` or FeaturePytree.
+            Training input samples of shape ``(n_samples, n_features)`` or a pytree of arrays of the same shape.
         y
             Target class labels of shape ``(n_samples,)``. Values should be in
             ``[0, n_classes - 1]``. Float arrays with integer values are
@@ -848,7 +848,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
         Parameters
         ----------
         X
-            Test input samples of shape ``(n_samples, n_features)`` or FeaturePytree.
+            Test input samples of shape ``(n_samples, n_features)`` or a pytree of arrays of the same shape.
         y
             True class labels of shape ``(n_samples,)``. Values should be in
             ``[0, n_classes - 1]``. Float arrays with integer values are
@@ -1103,7 +1103,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
         Parameters
         ----------
         X
-            Training input samples of shape ``(n_samples, n_features)`` or FeaturePytree.
+            Training input samples of shape ``(n_samples, n_features)`` or a pytree of arrays of the same shape.
         y
             Target class labels of shape ``(n_samples, n_neurons)``. Values should be in
             ``[0, n_classes - 1]``. Float arrays with integer values are
@@ -1148,7 +1148,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
         Parameters
         ----------
         X
-            Test input samples of shape ``(n_samples, n_features)`` or FeaturePytree.
+            Test input samples of shape ``(n_samples, n_features)`` or a pytree of arrays of the same shape.
         y
             True class labels of shape ``(n_samples, n_neurons)``. Values should be in
             ``[0, n_classes - 1]``. Float arrays with integer values are

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -762,6 +762,17 @@ class ClassifierGLM(ClassifierMixin, GLM):
     ... )
     >>> model.regularizer
     Ridge()
+
+    **Use a Pytree of Arrays as Input**
+
+    Features can be passed as any JAX pytree of 2-D arrays; the fitted
+    ``coef_`` will share the same pytree structure:
+
+    >>> X_dict = {"feature_1": X[:, :1], "feature_2": X[:, 1:]}
+    >>> model = nmo.glm.ClassifierGLM(n_classes=3).fit(X_dict, y)
+    >>> # The coefficient structure matches the input
+    >>> type(model.coef_)
+    <class 'dict'>
     """
 
     _validator_class = ClassifierGLMValidator
@@ -1026,6 +1037,16 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
     ... )
     >>> model.regularizer
     Ridge()
+
+    **Use a Pytree of Arrays as Input**
+
+    Features can be passed as any JAX pytree of 2-D arrays; the fitted
+    ``coef_`` will share the same pytree structure:
+
+    >>> X_dict = {"feature_1": X[:, :1], "feature_2": X[:, 1:]}
+    >>> model = nmo.glm.ClassifierPopulationGLM(n_classes=3).fit(X_dict, y)
+    >>> type(model.coef_)
+    <class 'dict'>
     """
 
     _validator_class = PopulationClassifierGLMValidator

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -619,7 +619,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
 
         This method initializes the coefficients (spike basis coefficients) and intercepts (bias terms)
         required for the GLM. The coefficients are initialized to zeros with dimensions based on the input X.
-        If X is a :class:`nemos.pytrees.FeaturePytree`, the coefficients retain the pytree structure with
+        If X is a pytree of arrays, the coefficients retain the pytree structure with
         arrays of zeros shaped according to the features in X.
         If X is a simple ndarray, the coefficients are initialized as a 2D array. The intercepts are initialized
         based on the log mean of the target data y across the first axis, corresponding to the average log activity
@@ -628,7 +628,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         Parameters
         ----------
         X :
-            The input data which can be a :class:`nemos.pytrees.FeaturePytree` with n_features arrays of shape
+            The input data, either a pytree of arrays with leaves of shape
             ``(n_timebins, n_features)``, or a simple ndarray of shape ``(n_timebins, n_features)``.
         y :
             The target data array of shape ``(n_timebins, )``, representing
@@ -636,10 +636,10 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
 
         Returns
         -------
-        Tuple[Union[FeaturePytree, jnp.ndarray], jnp.ndarray]
+        Tuple[Union[pytree of arrays, jnp.ndarray], jnp.ndarray]
             A tuple containing the initialized parameters:
             - The first element is the initialized coefficients
-            (either as a FeaturePytree or ndarray, matching the structure of X) with shapes (n_features,).
+            (either as a pytree of arrays or ndarray, matching the structure of X) with shapes (n_features,).
             - The second element is the initialized intercept (bias terms) as an ndarray of shape (1,).
         """
         if isinstance(X, FeaturePytree):
@@ -1178,7 +1178,7 @@ class PopulationGLM(GLM):
     combination of exogenous inputs (like convolved currents or light intensities) and a choice of observation model.
     It is suitable for scenarios where the relationship between predictors and the response
     variable might be non-linear, and the residuals  don't follow a normal distribution. The predictors must be
-    stored in tabular format, shape (n_timebins, num_features) or as :class:`nemos.pytrees.FeaturePytree`.
+    stored in tabular format, shape (n_timebins, num_features) or as a pytree of arrays of the same shape.
     Below is a table listing the default and available solvers for each regularizer.
 
     +---------------+------------------+-------------------------------------------------------------+

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -230,7 +230,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
     >>> model.solver_name
     'LBFGS[...]'
 
-    **Use a Pytree of Arrays as Input**
+    **Use a Pytree of arrays as Input**
 
     Features can be passed as any JAX pytree of 2-D arrays; the fitted
     ``coef_`` will share the same pytree structure:
@@ -395,8 +395,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         Parameters
         ----------
         X :
-            Predictors, array of shape ``(n_time_bins, n_features)`` or pytree of the same
-            shape.
+            Predictors, array of shape ``(n_time_bins, n_features)`` or a pytree
+            of arrays of the same shape.
 
         Returns
         -------
@@ -514,8 +514,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         Parameters
         ----------
         X :
-            Predictors, array of shape ``(n_time_bins, n_features)`` or pytree of the same
-            shape.
+            Predictors, array of shape ``(n_time_bins, n_features)`` or a pytree
+            of arrays of the same shape.
         y :
             Neural activity. Shape ``(n_time_bins, )``.
         score_type :

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -384,7 +384,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         Parameters
         ----------
         X :
-            Predictors, array of shape ``(n_time_bins, n_features)`` or pytree of same.
+            Predictors, array of shape ``(n_time_bins, n_features)`` or pytree of the same
+            shape.
 
         Returns
         -------
@@ -502,7 +503,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         Parameters
         ----------
         X :
-            The exogenous variables. Shape ``(n_time_bins, n_features)``.
+            Predictors, array of shape ``(n_time_bins, n_features)`` or pytree of the same
+            shape.
         y :
             Neural activity. Shape ``(n_time_bins, )``.
         score_type :
@@ -805,9 +807,9 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         random_key :
             jax.random.key for seeding the simulation.
         feedforward_input :
-            External input matrix to the model, representing factors like convolved currents,
+            External input predictors to the model, representing factors like convolved currents,
             light intensities, etc. When not provided, the simulation is done with coupling-only.
-            Array of shape (n_time_bins, n_basis_input) or pytree of same.
+            Array of shape (n_time_bins, n_basis_input) or pytree with leaves of the same shape.
 
         Returns
         -------
@@ -1002,7 +1004,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
             step sizes, and other optimizer-specific metrics.
         X
             The predictors used in the model fitting process, which may include feature matrices
-            or :class:`nemos.pytrees.FeaturePytree` objects. Shape ``(n_time_bins, n_features)``.
+            or a pytree of arrays. Shape ``(n_time_bins, n_features)``.
         y
             The response variable or output data corresponding to the predictors. Shape ``(n_time_bins,)``.
         *args

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -229,6 +229,17 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
     >>> model = nmo.glm.GLM(solver_name="LBFGS").fit(X, y)
     >>> model.solver_name
     'LBFGS[...]'
+
+    **Use a Pytree of Arrays as Input**
+
+    Features can be passed as any JAX pytree of 2-D arrays; the fitted
+    ``coef_`` will share the same pytree structure:
+
+    >>> X_dict = {"input_1": X[:, :2], "input_2": X[:, 2:]}
+    >>> model = nmo.glm.GLM().fit(X_dict, y)
+    >>> # The coefficient structure will match the input.
+    >>> type(model.coef_)
+    <class 'dict'>
     """
 
     _invalid_observation_types = (obs.CategoricalObservations,)
@@ -1300,29 +1311,28 @@ class PopulationGLM(GLM):
     >>> model.coef_
     Array(...)
 
-    **Mask Coefficients with a FeaturePytree**
+    **Use a Dict of Arrays as Input**
 
-    When using a FeaturePytree as input, the mask should also be a FeaturePytree
-    with arrays of shape ``(num_neurons,)``:
+    Features can be passed as a dict (or any JAX pytree). The feature mask
+    should mirror the same structure, with one 1-D entry per leaf:
 
-    >>> from nemos.pytrees import FeaturePytree
     >>> feature_1 = np.random.normal(size=(num_samples, 2))
     >>> feature_2 = np.random.normal(size=(num_samples, 1))
-    >>> X = FeaturePytree(feature_1=feature_1, feature_2=feature_2)
+    >>> X_dict = {"feature_1": feature_1, "feature_2": feature_2}
     >>> weights = dict(
     ...     feature_1=jnp.array([[0.0, 0.5], [0.0, -0.5]]),
     ...     feature_2=jnp.array([[1.0, 0.0]])
     ... )
     >>> rate = np.exp(
-    ...     X["feature_1"].dot(weights["feature_1"]) +
-    ...     X["feature_2"].dot(weights["feature_2"])
+    ...     X_dict["feature_1"].dot(weights["feature_1"]) +
+    ...     X_dict["feature_2"].dot(weights["feature_2"])
     ... )
     >>> y = np.random.poisson(rate)
-    >>> feature_mask = FeaturePytree(
-    ...     feature_1=jnp.array([0, 1], dtype=jnp.int32),
-    ...     feature_2=jnp.array([1, 0], dtype=jnp.int32)
-    ... )
-    >>> model = nmo.glm.PopulationGLM(feature_mask=feature_mask).fit(X, y)
+    >>> feature_mask = {
+    ...     "feature_1": jnp.array([0, 1], dtype=jnp.int32),
+    ...     "feature_2": jnp.array([1, 0], dtype=jnp.int32)
+    ... }
+    >>> model = nmo.glm.PopulationGLM(feature_mask=feature_mask).fit(X_dict, y)
     >>> model.coef_
     {...}
 

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -661,6 +661,10 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
             empty_params,
             (initial_coef, initial_intercept),
         )
+
+        self._validator.feature_mask_consistency(
+            getattr(self, "_feature_mask", None), init_params
+        )
         return init_params
 
     @cast_to_jax

--- a/src/nemos/glm/validation.py
+++ b/src/nemos/glm/validation.py
@@ -59,7 +59,7 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
             "check_array_dimensions",
             dict(
                 err_message_format="Invalid parameter dimensionality. coef must be an array "
-                "or nemos.pytree.FeaturePytree with array leafs of shape "
+                "or pytree with array leaves of shape "
                 "(n_features, ). intercept must be of shape (1,)."
                 "\nThe provided coef and intercept have shape ``{}`` and ``{}`` "
                 "instead."
@@ -187,8 +187,8 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
             else:
                 data = X
                 msg += (
-                    f" X was provided as an array, and coef should be an array too. "
-                    f"The provided coef is of type ``{type(params.coef)}`` instead."
+                    f" X has pytree structure ``{jax.tree_util.tree_structure(X)}``, "
+                    f"but coef has structure ``{jax.tree_util.tree_structure(params.coef)}``."
                 )
 
             validation.check_tree_structure(
@@ -338,8 +338,8 @@ class PopulationGLMValidator(GLMValidator):
             "check_array_dimensions",
             dict(
                 err_message_format="Invalid parameter dimensionality. "
-                "coef must be an array or nemos.pytree.FeaturePytree "
-                "with array leafs of shape (n_features, n_neurons). "
+                "coef must be an array or pytree "
+                "with array leaves of shape (n_features, n_neurons). "
                 "intercept must be of shape (n_neurons,)."
                 "\nThe provided coef and intercept have shape ``{}`` and ``{}`` instead."
             ),
@@ -406,8 +406,8 @@ class ClassifierGLMValidator(GLMValidator):
             "check_array_dimensions",
             dict(
                 err_message_format="Invalid parameter dimensionality. "
-                "coef must be an array or nemos.pytree.FeaturePytree "
-                "with array leafs of shape (n_features, n_classes). "
+                "coef must be an array or pytree "
+                "with array leaves of shape (n_features, n_classes). "
                 "intercept must be of shape (n_classes,)."
                 "\nThe provided coef and intercept have shape ``{}`` and ``{}`` instead."
             ),
@@ -489,8 +489,8 @@ class ClassifierGLMValidator(GLMValidator):
             else:
                 data = X
                 msg += (
-                    f" X was provided as an array, and coef should be an array too. "
-                    f"The coef are of type ``{type(params.coef)}`` instead."
+                    f" X has pytree structure ``{jax.tree_util.tree_structure(X)}``, "
+                    f"but coef has structure ``{jax.tree_util.tree_structure(params.coef)}``."
                 )
 
             validation.check_tree_structure(
@@ -597,8 +597,8 @@ class PopulationClassifierGLMValidator(ClassifierGLMValidator):
             "check_array_dimensions",
             dict(
                 err_message_format="Invalid parameter dimensionality. "
-                "coef must be an array or nemos.pytree.FeaturePytree "
-                "with array leafs of shape (n_features, n_neurons, n_classes). "
+                "coef must be an array or pytree "
+                "with array leaves of shape (n_features, n_neurons, n_classes). "
                 "intercept must be of shape (n_neurons, n_classes)."
                 "\nThe provided coef and intercept have shape ``{}`` and ``{}`` instead."
             ),

--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -247,6 +247,9 @@ class Regularizer(Base, abc.ABC):
         """
         filter_kwargs = self._get_filter_kwargs(strength=strength, params=params)
 
+        # hyperparams is unused: strength is captured in filter_kwargs at construction time.
+        # The argument is required to match the jaxopt prox interface:
+        # prox(params, hyperparams_prox, scaling=1.0).
         def prox_op(params, hyperparams, scaling=1.0, *args):
             return apply_operator(
                 self._proximal_operator,

--- a/src/nemos/typing.py
+++ b/src/nemos/typing.py
@@ -24,7 +24,7 @@ Params: TypeAlias = Pytree
 Aux = TypeVar("Aux")
 SolverState = TypeVar("SolverState")
 StepResult: TypeAlias = Tuple[Params, SolverState, Aux]
-DESIGN_INPUT_TYPE = "Union[jnp.ndarray, FeaturePytree, nap.TsdFrame]"
+DESIGN_INPUT_TYPE = "Union[jnp.ndarray, Pytree, nap.TsdFrame]"
 
 # copying jax.random's annotation
 KeyArrayLike = ArrayLike

--- a/src/nemos/validation.py
+++ b/src/nemos/validation.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import difflib
 import warnings
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional
 
 import jax
 import jax.numpy as jnp
 from numpy.typing import DTypeLike, NDArray
 
 from . import utils
-from .pytrees import FeaturePytree
 from .tree_utils import get_valid_multitree, pytree_map_and_reduce
 
 
@@ -210,8 +209,8 @@ def check_array_shape_match_tree(
 
 
 def array_axis_consistency(
-    array_1: Union[FeaturePytree, jnp.ndarray, NDArray],
-    array_2: Union[FeaturePytree, jnp.ndarray, NDArray],
+    array_1: Any,
+    array_2: Any,
     axis_1: int,
     axis_2: int,
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1410,7 +1410,6 @@ def instantiate_population_glm_func(
     model.intercept_ = np.random.randn(n_neurons)
     model.scale_ = 1.0
     if simulate:
-        model._feature_mask = initialize_feature_mask_for_population_glm(X, n_neurons)
         counts, rates = model.simulate(jax.random.PRNGKey(1234), X)
     else:
         counts, rates = None, None
@@ -1479,9 +1478,6 @@ def instantiate_population_classifier_glm_func(
     model.coef_ = np.random.randn(n_features, n_neurons, n_classes)
     model.intercept_ = np.random.randn(n_neurons, n_classes)
     if simulate:
-        model._feature_mask = initialize_feature_mask_for_population_glm(
-            X, n_neurons, n_classes=n_classes
-        )
         counts, rates = model.simulate(jax.random.PRNGKey(123), X)
     else:
         counts, rates = None, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1359,7 +1359,7 @@ def instantiate_glm_func(
     )
     model.coef_ = np.random.randn(n_features)
     model.intercept_ = np.random.randn(1)
-    model.scale_ = 1.
+    model.scale_ = 1.0
     if simulate:
         counts, rates = model.simulate(jax.random.PRNGKey(1234), X)
     else:
@@ -1401,7 +1401,7 @@ def instantiate_population_glm_func(
     )
     model.coef_ = np.random.randn(n_features, n_neurons)
     model.intercept_ = np.random.randn(n_neurons)
-    model.scale_ = 1.
+    model.scale_ = 1.0
     if simulate:
         model._feature_mask = initialize_feature_mask_for_population_glm(X, n_neurons)
         counts, rates = model.simulate(jax.random.PRNGKey(1234), X)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ from nemos.pytrees import FeaturePytree
 from nemos.tree_utils import tree_full_like
 
 
-def initialize_feature_mask_for_population_glm(X, n_neurons: int, coef=None):
+def initialize_feature_mask_for_population_glm(X, n_neurons: int, n_classes: int=0, coef=None):
     """
     Create a feature mask of ones for PopulationGLM testing.
 
@@ -63,6 +63,8 @@ def initialize_feature_mask_for_population_glm(X, n_neurons: int, coef=None):
     coef :
         Optional coefficient array/pytree. If provided, the mask shape will match
         coef shape exactly (required for ClassifierPopulationGLM).
+    n_classes:
+        Number of classes (determines the second dimension of the mask).
 
     Returns
     -------
@@ -72,14 +74,15 @@ def initialize_feature_mask_for_population_glm(X, n_neurons: int, coef=None):
         of shape (n_neurons,) for each key.
         If X is an array, returns an array of shape (n_features, n_neurons).
     """
+    extra_shape = (n_classes,) if n_classes else ()
     if coef is not None:
         return jax.tree_util.tree_map(lambda c: jnp.ones(c.shape), coef)
     if isinstance(X, FeaturePytree):
-        return jax.tree_util.tree_map(lambda x: jnp.ones((n_neurons,)), X.data)
+        return jax.tree_util.tree_map(lambda x: jnp.ones((n_neurons, *extra_shape)), X.data)
     elif isinstance(X, dict):
-        return jax.tree_util.tree_map(lambda x: jnp.ones((n_neurons,)), X)
+        return jax.tree_util.tree_map(lambda x: jnp.ones((n_neurons, *extra_shape)), X)
     else:
-        return jnp.ones((X.shape[1], n_neurons))
+        return jnp.ones((X.shape[1], n_neurons, *extra_shape))
 
 
 DEFAULT_KWARGS = {
@@ -1472,7 +1475,7 @@ def instantiate_population_classifier_glm_func(
     model.coef_ = np.random.randn(n_features, n_neurons, n_classes)
     model.intercept_ = np.random.randn(n_neurons, n_classes)
     if simulate:
-        model._feature_mask = initialize_feature_mask_for_population_glm(X, n_neurons)
+        model._feature_mask = initialize_feature_mask_for_population_glm(X, n_neurons, n_classes=n_classes)
         counts, rates = model.simulate(jax.random.PRNGKey(123), X)
     else:
         counts, rates = None, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1347,13 +1347,19 @@ def instantiate_glm_func(
     X = np.ones((500, n_features))
     X[:250, 0] = 0
     X[np.arange(500) % 2 == 1, 1] = 0
+    if obs_model == "Gamma":
+        inv_link = jax.nn.softplus
+    else:
+        inv_link = None
     model = nmo.glm.GLM(
         observation_model=obs_model,
         regularizer=regularizer,
         solver_name=solver_name,
+        inverse_link_function=inv_link,
     )
     model.coef_ = np.random.randn(n_features)
     model.intercept_ = np.random.randn(1)
+    model.scale_ = 1.
     if simulate:
         counts, rates = model.simulate(jax.random.PRNGKey(1234), X)
     else:
@@ -1383,13 +1389,19 @@ def instantiate_population_glm_func(
     X = np.ones((500, n_features))
     X[:250, 0] = 0
     X[np.arange(500) % 2 == 1, 1] = 0
+    if obs_model == "Gamma":
+        inv_link = jax.nn.softplus
+    else:
+        inv_link = None
     model = nmo.glm.PopulationGLM(
         observation_model=obs_model,
         regularizer=regularizer,
         solver_name=solver_name,
+        inverse_link_function=inv_link,
     )
     model.coef_ = np.random.randn(n_features, n_neurons)
     model.intercept_ = np.random.randn(n_neurons)
+    model.scale_ = 1.
     if simulate:
         model._feature_mask = initialize_feature_mask_for_population_glm(X, n_neurons)
         counts, rates = model.simulate(jax.random.PRNGKey(1234), X)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,9 @@ from nemos.pytrees import FeaturePytree
 from nemos.tree_utils import tree_full_like
 
 
-def initialize_feature_mask_for_population_glm(X, n_neurons: int, n_classes: int=0, coef=None):
+def initialize_feature_mask_for_population_glm(
+    X, n_neurons: int, n_classes: int = 0, coef=None
+):
     """
     Create a feature mask of ones for PopulationGLM testing.
 
@@ -78,7 +80,9 @@ def initialize_feature_mask_for_population_glm(X, n_neurons: int, n_classes: int
     if coef is not None:
         return jax.tree_util.tree_map(lambda c: jnp.ones(c.shape), coef)
     if isinstance(X, FeaturePytree):
-        return jax.tree_util.tree_map(lambda x: jnp.ones((n_neurons, *extra_shape)), X.data)
+        return jax.tree_util.tree_map(
+            lambda x: jnp.ones((n_neurons, *extra_shape)), X.data
+        )
     elif isinstance(X, dict):
         return jax.tree_util.tree_map(lambda x: jnp.ones((n_neurons, *extra_shape)), X)
     else:
@@ -1475,7 +1479,9 @@ def instantiate_population_classifier_glm_func(
     model.coef_ = np.random.randn(n_features, n_neurons, n_classes)
     model.intercept_ = np.random.randn(n_neurons, n_classes)
     if simulate:
-        model._feature_mask = initialize_feature_mask_for_population_glm(X, n_neurons, n_classes=n_classes)
+        model._feature_mask = initialize_feature_mask_for_population_glm(
+            X, n_neurons, n_classes=n_classes
+        )
         counts, rates = model.simulate(jax.random.PRNGKey(123), X)
     else:
         counts, rates = None, None

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -254,7 +254,9 @@ class TestModelVsPytree:
     ):
         """initialize_params runs without error when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
-        fixture.model.initialize_params(pytree_x, fixture.y)
+        model = fixture.model
+        model._feature_mask = None
+        model.initialize_params(pytree_x, fixture.y)
 
     @pytest.mark.parametrize(
         "instantiate_base_regressor_subclass, pytree_x",
@@ -296,7 +298,9 @@ class TestModelVsPytree:
     def test_fit_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
         """fit runs without error when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
-        fixture.model.fit(pytree_x, fixture.y)
+        model = fixture.model
+        model._feature_mask = None
+        model.fit(pytree_x, fixture.y)
 
     @pytest.mark.parametrize(
         "instantiate_base_regressor_subclass, pytree_x",
@@ -307,8 +311,10 @@ class TestModelVsPytree:
     def test_predict_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
         """predict output shape matches y after fitting with pytree X."""
         fixture = instantiate_base_regressor_subclass
-        fixture.model.fit(pytree_x, fixture.y)
-        assert fixture.model.predict(pytree_x).shape == fixture.y.shape
+        model = fixture.model
+        model._feature_mask = None
+        model.fit(pytree_x, fixture.y)
+        assert model.predict(pytree_x).shape == fixture.y.shape
 
     @pytest.mark.parametrize(
         "instantiate_base_regressor_subclass, pytree_x",
@@ -319,8 +325,10 @@ class TestModelVsPytree:
     def test_score_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
         """score returns a scalar after fitting with pytree X."""
         fixture = instantiate_base_regressor_subclass
-        fixture.model.fit(pytree_x, fixture.y)
-        assert fixture.model.score(pytree_x, fixture.y).ndim == 0
+        model = fixture.model
+        model._feature_mask = None
+        model.fit(pytree_x, fixture.y)
+        assert model.score(pytree_x, fixture.y).ndim == 0
 
 
 def test_all_defaults_assigned():

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -330,6 +330,22 @@ class TestModelVsPytree:
         model.fit(pytree_x, fixture.y)
         assert model.score(pytree_x, fixture.y).ndim == 0
 
+    @pytest.mark.parametrize(
+        "instantiate_base_regressor_subclass, pytree_x",
+        _MODEL_PYTREE_X_CASES,
+        indirect=["instantiate_base_regressor_subclass"],
+    )
+    @pytest.mark.solver_related
+    def test_simulate_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
+        """simulate runs without error and returns outputs with the correct n_samples when X is an arbitrary pytree."""
+        fixture = instantiate_base_regressor_subclass
+        model = fixture.model
+        model._feature_mask = None
+        model.fit(pytree_x, fixture.y)
+        n_samples = jax.tree_util.tree_leaves(pytree_x)[0].shape[0]
+        counts, rates = model.simulate(jax.random.key(123), pytree_x)
+        assert counts.shape[0] == n_samples
+
 
 def test_all_defaults_assigned():
     PARS_WITHOUT_DEFAULTS = {}

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -3,6 +3,7 @@ import itertools
 import warnings
 from contextlib import nullcontext as does_not_raise
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -26,7 +27,6 @@ from nemos.glm.validation import (
     PopulationGLMValidator,
 )
 from nemos.inverse_link_function_utils import LINK_NAME_TO_FUNC
-import equinox as eqx
 
 MODEL_REGISTRY = {
     "GLM": nmo.glm.GLM,
@@ -154,73 +154,173 @@ def _zero_init_params(X, y):
         jnp.zeros(jnp.nanmean(y, axis=0).shape),
     )
 
+
 class _TwoLeafModule(eqx.Module):
     a: jnp.ndarray
     b: jnp.ndarray
 
-def _make_predictor(param):
-    model_name: str = param["model"]
-    if model_name in ["GLM", "PopulationGLM", "ClassifierGLM", "ClassifierPopulationGLM"]:
-        n_samples = DEFAULT_OBS_SHAPE[model_name][0]
-        a, b = jnp.ones((n_samples, 2)), jnp.zeros((n_samples, 1))
-        pytree_classes = [
-            pytest.param(lambda: {"a": a, "b": b}, id="dict"),
-            pytest.param(
-                lambda: _TwoLeafModule(a=a, b=b), id="eqx_module"
-            ),
-            pytest.param(lambda: {"w": [a], "b": tuple([b])}, id="dict_list"),
-        ]
-        return pytree_classes
-    else:
-        raise NotImplementedError(f"_make_predictor function not implemented for model ``{model_name}``.")
 
-
-def pytest_generate_tests(metafunc):
-    if (
-        "instantiate_base_regressor_subclass" in metafunc.fixturenames
-        and "predictor_pytree" in metafunc.fixturenames
-    ):
-        params = []
-
-        for base_param in INSTANTIATE_MODEL_AND_SIMULATE:
-            pytree_factories = _make_predictor(base_param)
-
-            for pytree_param in pytree_factories:
-                params.append(
-                    pytest.param(
-                        base_param,
-                        pytree_param.values[0],
-                        id=f"{base_param['model']}-{pytree_param.id}",
-                    )
-                )
-
-        metafunc.parametrize(
-            "instantiate_base_regressor_subclass,predictor_pytree",
-            params,
-            indirect=["instantiate_base_regressor_subclass"],
-        )
+# n_samples must match what the instantiate_base_regressor_subclass fixture produces.
+# Each entry is (model_config, make_pytree_x): fully co-specified so that the pytree
+# is meaningful for the paired model. Add new entries when new model types are introduced.
+_N_SAMPLES = 500
+_MODEL_PYTREE_X_CASES = [
+    # GLM
+    pytest.param(
+        {
+            "model": "GLM",
+            "obs_model": OBSERVATION_PER_MODEL["GLM"][0],
+            "simulate": True,
+        },
+        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
+        id="GLM-dict",
+    ),
+    pytest.param(
+        {
+            "model": "GLM",
+            "obs_model": OBSERVATION_PER_MODEL["GLM"][0],
+            "simulate": True,
+        },
+        _TwoLeafModule(a=jnp.ones((_N_SAMPLES, 1)), b=jnp.ones((_N_SAMPLES, 1))),
+        id="GLM-eqx_module",
+    ),
+    pytest.param(
+        {
+            "model": "GLM",
+            "obs_model": OBSERVATION_PER_MODEL["GLM"][0],
+            "simulate": True,
+        },
+        {"a": [jnp.ones((_N_SAMPLES, 1))], "b": jnp.ones((_N_SAMPLES, 1))},
+        id="GLM-dict_list",
+    ),
+    # PopulationGLM
+    pytest.param(
+        {
+            "model": "PopulationGLM",
+            "obs_model": OBSERVATION_PER_MODEL["PopulationGLM"][0],
+            "simulate": True,
+        },
+        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
+        id="PopulationGLM-dict",
+    ),
+    pytest.param(
+        {
+            "model": "PopulationGLM",
+            "obs_model": OBSERVATION_PER_MODEL["PopulationGLM"][0],
+            "simulate": True,
+        },
+        _TwoLeafModule(a=jnp.ones((_N_SAMPLES, 1)), b=jnp.ones((_N_SAMPLES, 1))),
+        id="PopulationGLM-eqx_module",
+    ),
+    pytest.param(
+        {
+            "model": "PopulationGLM",
+            "obs_model": OBSERVATION_PER_MODEL["PopulationGLM"][0],
+            "simulate": True,
+        },
+        {"a": [jnp.ones((_N_SAMPLES, 1))], "b": jnp.ones((_N_SAMPLES, 1))},
+        id="PopulationGLM-dict_list",
+    ),
+    # ClassifierGLM
+    pytest.param(
+        {"model": "ClassifierGLM", "obs_model": "Categorical", "simulate": True},
+        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
+        id="ClassifierGLM-dict",
+    ),
+    # ClassifierPopulationGLM
+    pytest.param(
+        {
+            "model": "ClassifierPopulationGLM",
+            "obs_model": "Categorical",
+            "simulate": True,
+        },
+        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
+        id="ClassifierPopulationGLM-dict",
+    ),
+]
 
 
 class TestModelVsPytree:
-    """
-    Model ↔ pytree equivalence tests.
+    """Test that public model API accepts arbitrary pytree X inputs."""
 
-    Uses the existing instantiate_base_regressor_subclass fixture
-    without modifying it.
-    """
-
-    def test_init_params_coef_structure(
-        self,
-        instantiate_base_regressor_subclass,
-        predictor_pytree,
+    @pytest.mark.parametrize(
+        "instantiate_base_regressor_subclass, pytree_x",
+        _MODEL_PYTREE_X_CASES,
+        indirect=["instantiate_base_regressor_subclass"],
+    )
+    @pytest.mark.solver_related
+    def test_initialize_params_pytree_x(
+        self, instantiate_base_regressor_subclass, pytree_x
     ):
+        """initialize_params runs without error when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
-        pytree = predictor_pytree()
+        fixture.model.initialize_params(pytree_x, fixture.y)
 
+    @pytest.mark.parametrize(
+        "instantiate_base_regressor_subclass, pytree_x",
+        _MODEL_PYTREE_X_CASES,
+        indirect=["instantiate_base_regressor_subclass"],
+    )
+    @pytest.mark.solver_related
+    def test_initialize_solver_and_state_pytree_x(
+        self, instantiate_base_regressor_subclass, pytree_x
+    ):
+        """initialize_solver_and_state runs without error when X is an arbitrary pytree."""
+        fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        y = fixture.y
-        params = model.initialize_params(pytree, y)
-        assert jax.tree_util.tree_structure(pytree) == jax.tree_util.tree_structure(params[0])
+        model._feature_mask = None
+        params = model.initialize_params(pytree_x, fixture.y)
+        model.initialize_solver_and_state(pytree_x, fixture.y, params)
+
+    @pytest.mark.parametrize(
+        "instantiate_base_regressor_subclass, pytree_x",
+        _MODEL_PYTREE_X_CASES,
+        indirect=["instantiate_base_regressor_subclass"],
+    )
+    @pytest.mark.solver_related
+    def test_update_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
+        """update runs without error when X is an arbitrary pytree."""
+        fixture = instantiate_base_regressor_subclass
+        model = fixture.model
+        model._feature_mask = None
+        params = model.initialize_params(pytree_x, fixture.y)
+        opt_state = model.initialize_solver_and_state(pytree_x, fixture.y, params)
+        model.update(params, opt_state, pytree_x, fixture.y)
+
+    @pytest.mark.parametrize(
+        "instantiate_base_regressor_subclass, pytree_x",
+        _MODEL_PYTREE_X_CASES,
+        indirect=["instantiate_base_regressor_subclass"],
+    )
+    @pytest.mark.solver_related
+    def test_fit_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
+        """fit runs without error when X is an arbitrary pytree."""
+        fixture = instantiate_base_regressor_subclass
+        fixture.model.fit(pytree_x, fixture.y)
+
+    @pytest.mark.parametrize(
+        "instantiate_base_regressor_subclass, pytree_x",
+        _MODEL_PYTREE_X_CASES,
+        indirect=["instantiate_base_regressor_subclass"],
+    )
+    @pytest.mark.solver_related
+    def test_predict_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
+        """predict output shape matches y after fitting with pytree X."""
+        fixture = instantiate_base_regressor_subclass
+        fixture.model.fit(pytree_x, fixture.y)
+        assert fixture.model.predict(pytree_x).shape == fixture.y.shape
+
+    @pytest.mark.parametrize(
+        "instantiate_base_regressor_subclass, pytree_x",
+        _MODEL_PYTREE_X_CASES,
+        indirect=["instantiate_base_regressor_subclass"],
+    )
+    @pytest.mark.solver_related
+    def test_score_pytree_x(self, instantiate_base_regressor_subclass, pytree_x):
+        """score returns a scalar after fitting with pytree X."""
+        fixture = instantiate_base_regressor_subclass
+        fixture.model.fit(pytree_x, fixture.y)
+        assert fixture.model.score(pytree_x, fixture.y).ndim == 0
 
 
 def test_all_defaults_assigned():

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -255,7 +255,6 @@ class TestModelVsPytree:
         """initialize_params runs without error when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        model._feature_mask = None
         model.initialize_params(pytree_x, fixture.y)
 
     @pytest.mark.parametrize(
@@ -270,7 +269,6 @@ class TestModelVsPytree:
         """initialize_solver_and_state runs without error when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        model._feature_mask = None
         params = model.initialize_params(pytree_x, fixture.y)
         model.initialize_solver_and_state(pytree_x, fixture.y, params)
 
@@ -284,7 +282,6 @@ class TestModelVsPytree:
         """update runs without error when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        model._feature_mask = None
         params = model.initialize_params(pytree_x, fixture.y)
         opt_state = model.initialize_solver_and_state(pytree_x, fixture.y, params)
         model.update(params, opt_state, pytree_x, fixture.y)
@@ -299,7 +296,6 @@ class TestModelVsPytree:
         """fit runs without error when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        model._feature_mask = None
         model.fit(pytree_x, fixture.y)
 
     @pytest.mark.parametrize(
@@ -312,7 +308,6 @@ class TestModelVsPytree:
         """predict output shape matches y after fitting with pytree X."""
         fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        model._feature_mask = None
         model.fit(pytree_x, fixture.y)
         assert model.predict(pytree_x).shape == fixture.y.shape
 
@@ -326,7 +321,6 @@ class TestModelVsPytree:
         """score returns a scalar after fitting with pytree X."""
         fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        model._feature_mask = None
         model.fit(pytree_x, fixture.y)
         assert model.score(pytree_x, fixture.y).ndim == 0
 
@@ -340,7 +334,6 @@ class TestModelVsPytree:
         """simulate runs without error and returns outputs with the correct n_samples when X is an arbitrary pytree."""
         fixture = instantiate_base_regressor_subclass
         model = fixture.model
-        model._feature_mask = None
         model.fit(pytree_x, fixture.y)
         n_samples = jax.tree_util.tree_leaves(pytree_x)[0].shape[0]
         counts, rates = model.simulate(jax.random.key(123), pytree_x)

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -26,6 +26,7 @@ from nemos.glm.validation import (
     PopulationGLMValidator,
 )
 from nemos.inverse_link_function_utils import LINK_NAME_TO_FUNC
+import equinox as eqx
 
 MODEL_REGISTRY = {
     "GLM": nmo.glm.GLM,
@@ -99,7 +100,6 @@ OBSERVATION_PER_MODEL = {
     "PopulationGLM": [o for o in AVAILABLE_OBSERVATION_MODELS if o != "Categorical"],
 }
 
-
 # as of now, all models are glm type... in the future this may change.
 MODEL_WITH_LINK_FUNCTION_REGISTRY = {
     "GLM": nmo.glm.GLM,
@@ -153,6 +153,74 @@ def _zero_init_params(X, y):
         jax.tree_util.tree_map(lambda x: jnp.zeros((*x[0].shape, *y.shape[1:])), X),
         jnp.zeros(jnp.nanmean(y, axis=0).shape),
     )
+
+class _TwoLeafModule(eqx.Module):
+    a: jnp.ndarray
+    b: jnp.ndarray
+
+def _make_predictor(param):
+    model_name: str = param["model"]
+    if model_name in ["GLM", "PopulationGLM", "ClassifierGLM", "ClassifierPopulationGLM"]:
+        n_samples = DEFAULT_OBS_SHAPE[model_name][0]
+        a, b = jnp.ones((n_samples, 2)), jnp.zeros((n_samples, 1))
+        pytree_classes = [
+            pytest.param(lambda: {"a": a, "b": b}, id="dict"),
+            pytest.param(
+                lambda: _TwoLeafModule(a=a, b=b), id="eqx_module"
+            ),
+            pytest.param(lambda: {"w": [a], "b": tuple([b])}, id="dict_list"),
+        ]
+        return pytree_classes
+    else:
+        raise NotImplementedError(f"_make_predictor function not implemented for model ``{model_name}``.")
+
+
+def pytest_generate_tests(metafunc):
+    if (
+        "instantiate_base_regressor_subclass" in metafunc.fixturenames
+        and "predictor_pytree" in metafunc.fixturenames
+    ):
+        params = []
+
+        for base_param in INSTANTIATE_MODEL_AND_SIMULATE:
+            pytree_factories = _make_predictor(base_param)
+
+            for pytree_param in pytree_factories:
+                params.append(
+                    pytest.param(
+                        base_param,
+                        pytree_param.values[0],
+                        id=f"{base_param['model']}-{pytree_param.id}",
+                    )
+                )
+
+        metafunc.parametrize(
+            "instantiate_base_regressor_subclass,predictor_pytree",
+            params,
+            indirect=["instantiate_base_regressor_subclass"],
+        )
+
+
+class TestModelVsPytree:
+    """
+    Model ↔ pytree equivalence tests.
+
+    Uses the existing instantiate_base_regressor_subclass fixture
+    without modifying it.
+    """
+
+    def test_init_params_coef_structure(
+        self,
+        instantiate_base_regressor_subclass,
+        predictor_pytree,
+    ):
+        fixture = instantiate_base_regressor_subclass
+        pytree = predictor_pytree()
+
+        model = fixture.model
+        y = fixture.y
+        params = model.initialize_params(pytree, y)
+        assert jax.tree_util.tree_structure(pytree) == jax.tree_util.tree_structure(params[0])
 
 
 def test_all_defaults_assigned():

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -158,83 +158,29 @@ class _TwoLeafModule(eqx.Module):
     b: jnp.ndarray
 
 
-# n_samples must match what the instantiate_base_regressor_subclass fixture produces.
-# Each entry is (model_config, make_pytree_x): fully co-specified so that the pytree
-# is meaningful for the paired model. Add new entries when new model types are introduced.
-_N_SAMPLES = 500
+# Pytree factories keyed by id; each takes n_samples and returns a pytree of arrays.
+_PYTREE_X_FACTORIES = {
+    "dict": lambda n: {"a": jnp.ones((n, 1)), "b": jnp.ones((n, 1))},
+    "eqx_module": lambda n: _TwoLeafModule(a=jnp.ones((n, 1)), b=jnp.ones((n, 1))),
+    "dict_list": lambda n: {"a": [jnp.ones((n, 1))], "b": jnp.ones((n, 1))},
+}
+
+# One entry per (model, obs_model) pair; all pytree types are tested for each.
+_MODEL_CONFIGS = [
+    ("GLM", "Poisson"),
+    ("PopulationGLM", "Poisson"),
+    ("ClassifierGLM", "Categorical"),
+    ("ClassifierPopulationGLM", "Categorical"),
+]
+
 _MODEL_PYTREE_X_CASES = [
-    # GLM
     pytest.param(
-        {
-            "model": "GLM",
-            "obs_model": OBSERVATION_PER_MODEL["GLM"][0],
-            "simulate": True,
-        },
-        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
-        id="GLM-dict",
-    ),
-    pytest.param(
-        {
-            "model": "GLM",
-            "obs_model": OBSERVATION_PER_MODEL["GLM"][0],
-            "simulate": True,
-        },
-        _TwoLeafModule(a=jnp.ones((_N_SAMPLES, 1)), b=jnp.ones((_N_SAMPLES, 1))),
-        id="GLM-eqx_module",
-    ),
-    pytest.param(
-        {
-            "model": "GLM",
-            "obs_model": OBSERVATION_PER_MODEL["GLM"][0],
-            "simulate": True,
-        },
-        {"a": [jnp.ones((_N_SAMPLES, 1))], "b": jnp.ones((_N_SAMPLES, 1))},
-        id="GLM-dict_list",
-    ),
-    # PopulationGLM
-    pytest.param(
-        {
-            "model": "PopulationGLM",
-            "obs_model": OBSERVATION_PER_MODEL["PopulationGLM"][0],
-            "simulate": True,
-        },
-        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
-        id="PopulationGLM-dict",
-    ),
-    pytest.param(
-        {
-            "model": "PopulationGLM",
-            "obs_model": OBSERVATION_PER_MODEL["PopulationGLM"][0],
-            "simulate": True,
-        },
-        _TwoLeafModule(a=jnp.ones((_N_SAMPLES, 1)), b=jnp.ones((_N_SAMPLES, 1))),
-        id="PopulationGLM-eqx_module",
-    ),
-    pytest.param(
-        {
-            "model": "PopulationGLM",
-            "obs_model": OBSERVATION_PER_MODEL["PopulationGLM"][0],
-            "simulate": True,
-        },
-        {"a": [jnp.ones((_N_SAMPLES, 1))], "b": jnp.ones((_N_SAMPLES, 1))},
-        id="PopulationGLM-dict_list",
-    ),
-    # ClassifierGLM
-    pytest.param(
-        {"model": "ClassifierGLM", "obs_model": "Categorical", "simulate": True},
-        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
-        id="ClassifierGLM-dict",
-    ),
-    # ClassifierPopulationGLM
-    pytest.param(
-        {
-            "model": "ClassifierPopulationGLM",
-            "obs_model": "Categorical",
-            "simulate": True,
-        },
-        {"a": jnp.ones((_N_SAMPLES, 1)), "b": jnp.ones((_N_SAMPLES, 1))},
-        id="ClassifierPopulationGLM-dict",
-    ),
+        {"model": model, "obs_model": obs_model, "simulate": True},
+        factory(DEFAULT_OBS_SHAPE[model][0]),
+        id=f"{model}-{pytree_id}",
+    )
+    for model, obs_model in _MODEL_CONFIGS
+    for pytree_id, factory in _PYTREE_X_FACTORIES.items()
 ]
 
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -954,7 +954,7 @@ class TestGLM:
             model.intercept_ = true_params.intercept
             if is_population_model(model):
                 model._feature_mask = initialize_feature_mask_for_population_glm(
-                    X, y.shape[1], model._validator.get_empty_params(X, y).coef
+                    X, y.shape[1], coef=model._validator.get_empty_params(X, y).coef
                 )
         with expectation:
             model.simulate(
@@ -3856,7 +3856,7 @@ class TestClassifierGLM:
             (
                 "invalid",
                 pytest.raises(
-                    AttributeError, match="'str' object has no attribute 'ndim'"
+                    AttributeError, match="'str' object has no attribute 'shape'"
                 ),
             ),
             # wrong number of features

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2905,6 +2905,18 @@ class TestPopulationGLM:
         assert np.all(y._metadata == rate._metadata)
         assert np.all(y.columns == rate.columns)
 
+    def test_initialize_params_stale_feature_mask_raises(
+        self, request, model_instantiation
+    ):
+        """initialize_params raises when a stale array feature_mask is incompatible with the new X structure."""
+        X, y, model, true_params, firing_rate = request.getfixturevalue(
+            model_instantiation
+        )
+        model._feature_mask = jnp.ones_like(true_params.coef)
+        X_pytree = {"a": X[:, : X.shape[1] // 2], "b": X[:, X.shape[1] // 2 :]}
+        with pytest.raises(TypeError, match="feature_mask"):
+            model.initialize_params(X_pytree, y)
+
 
 @pytest.mark.parametrize(
     "model_instantiation",
@@ -4124,6 +4136,18 @@ class TestClassifierGLM:
         # Roundtrip: encode -> decode should give original labels
         y_label_roundtrip = model._decode_labels(model._encode_labels(y_label))
         assert np.array_equal(y_label, y_label_roundtrip)
+
+    def test_initialize_params_stale_feature_mask_raises(
+        self, inv_link, glm_type, model_instantiation, request
+    ):
+        """initialize_params raises when a stale array feature_mask is incompatible with the new X structure."""
+        X, y, model, true_params, firing_rate = request.getfixturevalue(
+            glm_type + model_instantiation
+        )
+        model._feature_mask = jnp.ones_like(true_params.coef)
+        X_pytree = {"a": X[:, : X.shape[1] // 2], "b": X[:, X.shape[1] // 2 :]}
+        with pytest.raises(TypeError, match="feature_mask"):
+            model.initialize_params(X_pytree, y)
 
 
 def test_glm_public_api_matches_subclasses():

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2468,9 +2468,9 @@ class TestGLMObservationModel:
         X = pytree_x_factory(y.shape[0])
         model.solver_kwargs = {"maxiter": 1}
         model.fit(X, y)
-        assert jax.tree_util.tree_structure(model.coef_) == jax.tree_util.tree_structure(
-            X
-        )
+        assert jax.tree_util.tree_structure(
+            model.coef_
+        ) == jax.tree_util.tree_structure(X)
 
     #####################
     # Test residual DOF #

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1603,6 +1603,29 @@ class TestGLM:
             nmo.load_model(save_path, mapping_dict=invalid_mapping)
 
 
+class _TwoLeafModule(eqx.Module):
+    a: jnp.ndarray
+    b: jnp.ndarray
+
+
+# Factories that build a two-leaf pytree X given n_samples. Used to parametrize
+# coef-structure tests over different pytree types.
+_PYTREE_X_FACTORIES = [
+    pytest.param(
+        lambda n: {"a": jnp.ones((n, 1)), "b": jnp.ones((n, 1))},
+        id="dict",
+    ),
+    pytest.param(
+        lambda n: _TwoLeafModule(a=jnp.ones((n, 1)), b=jnp.ones((n, 1))),
+        id="eqx_module",
+    ),
+    pytest.param(
+        lambda n: {"a": [jnp.ones((n, 1))], "b": jnp.ones((n, 1))},
+        id="dict_list",
+    ),
+]
+
+
 @pytest.mark.parametrize("glm_type", ["", "population_"])
 @pytest.mark.parametrize(
     "model_instantiation",
@@ -2424,6 +2447,30 @@ class TestGLMObservationModel:
             raise ValueError("Shape mismatch coefficients")
         if intercept.shape != intercept_shape:
             raise ValueError("Shape mismatch intercepts")
+
+    @pytest.mark.parametrize("pytree_x_factory", _PYTREE_X_FACTORIES)
+    def test_coef_tree_structure_after_initialize_params_pytree_x(
+        self, pytree_x_factory, request, glm_type, model_instantiation
+    ):
+        """coef tree structure matches X structure after initialize_params with pytree X."""
+        _, y, model, _, _ = request.getfixturevalue(glm_type + model_instantiation)
+        X = pytree_x_factory(y.shape[0])
+        coef, _ = model.initialize_params(X, y)
+        assert jax.tree_util.tree_structure(coef) == jax.tree_util.tree_structure(X)
+
+    @pytest.mark.parametrize("pytree_x_factory", _PYTREE_X_FACTORIES)
+    @pytest.mark.solver_related
+    def test_coef_tree_structure_after_fit_pytree_x(
+        self, pytree_x_factory, request, glm_type, model_instantiation
+    ):
+        """model.coef_ tree structure matches X structure after fit with pytree X."""
+        _, y, model, _, _ = request.getfixturevalue(glm_type + model_instantiation)
+        X = pytree_x_factory(y.shape[0])
+        model.solver_kwargs = {"maxiter": 1}
+        model.fit(X, y)
+        assert jax.tree_util.tree_structure(model.coef_) == jax.tree_util.tree_structure(
+            X
+        )
 
     #####################
     # Test residual DOF #

--- a/tests/test_proximal_operator.py
+++ b/tests/test_proximal_operator.py
@@ -12,7 +12,6 @@ from nemos.proximal_operator import (
     prox_none,
     prox_ridge,
 )
-from nemos.pytrees import FeaturePytree
 from nemos.tree_utils import tree_full_like
 
 
@@ -56,6 +55,23 @@ _PYTREE_DATA_CASES = [
     pytest.param(_make_eqx_module_data, id="eqx_module"),
     pytest.param(_make_dict_list_data, id="dict_list"),
 ]
+
+def _flat_and_unflat_coef(coef_tree):
+    """Utility function to flatten and unflatten coefficients."""
+    flat_coef, struct = jax.tree_util.tree_flatten(coef_tree)
+    shapes = jax.tree_util.tree_map(lambda x: x.shape, coef_tree)
+    splits = [0] + [x.size for x in flat_coef]
+    splits = jnp.cumsum(jnp.array(splits, dtype=jnp.int32))
+    def _flat(x):
+        x_flat = jax.tree_util.tree_leaves(x)
+        x_flat = jnp.hstack([x.ravel() for x in x_flat])
+        return x_flat
+    def _unflat(x):
+        flat_x = [x[start:stop] for start, stop in zip(splits[:-1], splits[1:])]
+        tree_x = jax.tree_util.tree_unflatten(struct, flat_x)
+        return jax.tree_util.tree_map(lambda x,s: jnp.reshape(x, s), tree_x, shapes)
+    return _flat, _unflat
+
 
 
 @pytest.mark.parametrize(
@@ -655,12 +671,12 @@ def test_prox_group_lasso_pytree_strength_broadcast_and_shape():
     assert out_strong["w"].shape == params["w"].shape
 
 
-# === Tests: proximal operators work with dict, FeaturePytree, and eqx.Module ===
+# === Tests: proximal operators work with arbitrary pytree param structures ===
 
 
 @pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
 def test_prox_none_pytree_types(make_data):
-    """prox_none returns input unchanged for dict, FeaturePytree, and eqx.Module."""
+    """prox_none returns input unchanged for dict, eqx.Module, and dict_list pytrees."""
     params, strength, _ = make_data()
     out = prox_none(params, strength=strength, scaling=1.0)
     assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
@@ -668,7 +684,7 @@ def test_prox_none_pytree_types(make_data):
 
 @pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
 def test_prox_ridge_pytree_types(make_data):
-    """prox_ridge preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    """prox_ridge preserves structure and shape for dict, eqx.Module, and dict_list pytrees."""
     params, strength, _ = make_data()
     out = prox_ridge(params, strength=strength, scaling=1.0)
     assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
@@ -680,7 +696,7 @@ def test_prox_ridge_pytree_types(make_data):
 
 @pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
 def test_prox_lasso_pytree_types(make_data):
-    """prox_lasso preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    """prox_lasso preserves structure and shape for dict, eqx.Module, and dict_list pytrees."""
     params, strength, _ = make_data()
     out = prox_lasso(params, strength=strength, scaling=1.0)
     assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
@@ -692,7 +708,7 @@ def test_prox_lasso_pytree_types(make_data):
 
 @pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
 def test_prox_elastic_net_pytree_types(make_data):
-    """prox_elastic_net preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    """prox_elastic_net preserves structure and shape for dict, eqx.Module, and dict_list pytrees."""
     params, _, _ = make_data()
     # elastic net expects per-leaf (strength, ratio) tuples
     strength = tree_full_like(params, (0.5, 0.5))
@@ -706,7 +722,7 @@ def test_prox_elastic_net_pytree_types(make_data):
 
 @pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
 def test_prox_group_lasso_pytree_types(make_data):
-    """prox_group_lasso preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    """prox_group_lasso preserves structure and shape for dict, eqx.Module, and dict_list pytrees."""
     params, strength, mask = make_data()
     out = prox_group_lasso(params, strength=strength, mask=mask, scaling=1.0)
     assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
@@ -714,3 +730,66 @@ def test_prox_group_lasso_pytree_types(make_data):
         jax.tree_util.tree_leaves(out), jax.tree_util.tree_leaves(params)
     ):
         assert out_leaf.shape == in_leaf.shape
+
+
+# === Array vs pytree equivalence: element-wise operators ===
+# prox_none, prox_ridge, prox_lasso, and prox_elastic_net are element-wise
+# with uniform strength, so applying them to a pytree must give the same
+# numerical result as applying them to the equivalent flat 1-D array (then
+# re-shaped back).
+#
+# For each operator the (tree_strength, flat_strength) pair is:
+#   prox_none         -> (0.5, 0.5)          strength is ignored
+#   prox_ridge        -> (0.5, 0.5)          scalar broadcasts element-wise
+#   prox_lasso        -> (0.5, 0.5)          scalar broadcasts element-wise
+#   prox_elastic_net  -> ((0.5, 0.5), (0.5, 0.5))  per-leaf (s, r) tuple
+
+_ELEMENTWISE_PROX_CASES = [
+    pytest.param(
+        prox_none,
+        lambda params: tree_full_like(params, 0.5),
+        0.5,
+        id="prox_none",
+    ),
+    pytest.param(
+        prox_ridge,
+        lambda params: tree_full_like(params, 0.5),
+        0.5,
+        id="prox_ridge",
+    ),
+    pytest.param(
+        prox_lasso,
+        lambda params: tree_full_like(params, 0.5),
+        0.5,
+        id="prox_lasso",
+    ),
+    pytest.param(
+        prox_elastic_net,
+        lambda params: tree_full_like(params, (0.5, 0.5)),
+        (0.5, 0.5),
+        id="prox_elastic_net",
+    ),
+]
+
+
+@pytest.mark.parametrize("prox_op, tree_strength_fn, flat_strength", _ELEMENTWISE_PROX_CASES)
+@pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
+def test_prox_operator_tree_vs_array_equivalence(make_data, prox_op, tree_strength_fn, flat_strength):
+    """Proximal operator on a pytree matches element-wise application to its flat array."""
+    params, _, _ = make_data()
+    _flat, _unflat = _flat_and_unflat_coef(params)
+
+    scaling = 1.0
+
+    # Apply to pytree with uniform per-leaf strength
+    out_tree = prox_op(params, strength=tree_strength_fn(params), scaling=scaling)
+
+    # Apply to the equivalent flat 1-D array
+    flat_params = jnp.array(_flat(params))
+    out_flat_unflat = _unflat(prox_op(flat_params, strength=flat_strength, scaling=scaling))
+
+    for tree_leaf, flat_leaf in zip(
+        jax.tree_util.tree_leaves(out_tree),
+        jax.tree_util.tree_leaves(out_flat_unflat),
+    ):
+        assert jnp.allclose(jnp.asarray(tree_leaf), jnp.asarray(flat_leaf))

--- a/tests/test_proximal_operator.py
+++ b/tests/test_proximal_operator.py
@@ -756,9 +756,13 @@ _ELEMENTWISE_PROX_CASES = [
 ]
 
 
-@pytest.mark.parametrize("prox_op, tree_strength_fn, flat_strength", _ELEMENTWISE_PROX_CASES)
+@pytest.mark.parametrize(
+    "prox_op, tree_strength_fn, flat_strength", _ELEMENTWISE_PROX_CASES
+)
 @pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
-def test_prox_operator_tree_vs_array_equivalence(make_data, prox_op, tree_strength_fn, flat_strength):
+def test_prox_operator_tree_vs_array_equivalence(
+    make_data, prox_op, tree_strength_fn, flat_strength
+):
     """Proximal operator on a pytree matches element-wise application to its flat array."""
     params, _, _ = make_data()
     _flat, _unflat = get_flattener_unflattener(params)
@@ -770,7 +774,9 @@ def test_prox_operator_tree_vs_array_equivalence(make_data, prox_op, tree_streng
 
     # Apply to the equivalent flat 1-D array
     flat_params = jnp.array(_flat(params))
-    out_flat_unflat = _unflat(prox_op(flat_params, strength=flat_strength, scaling=scaling))
+    out_flat_unflat = _unflat(
+        prox_op(flat_params, strength=flat_strength, scaling=scaling)
+    )
 
     for tree_leaf, flat_leaf in zip(
         jax.tree_util.tree_leaves(out_tree),

--- a/tests/test_proximal_operator.py
+++ b/tests/test_proximal_operator.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
@@ -11,7 +12,50 @@ from nemos.proximal_operator import (
     prox_none,
     prox_ridge,
 )
+from nemos.pytrees import FeaturePytree
 from nemos.tree_utils import tree_full_like
+
+
+class _TwoLeafModule(eqx.Module):
+    w: jnp.ndarray
+    b: jnp.ndarray
+
+
+def _make_dict_data():
+    params = {"w": jnp.array([1.0, -2.0, 3.0]), "b": jnp.array([0.5])}
+    strength = tree_full_like(params, 0.5)
+    mask = {
+        "w": jnp.array([[1, 1, 0], [0, 0, 1]], dtype=float),
+        "b": jnp.zeros((2, 1), dtype=float),
+    }
+    return params, strength, mask
+
+
+def _make_eqx_module_data():
+    params = _TwoLeafModule(w=jnp.array([1.0, -2.0, 3.0]), b=jnp.array([0.5]))
+    strength = tree_full_like(params, 0.5)
+    mask = _TwoLeafModule(
+        w=jnp.array([[1, 1, 0], [0, 0, 1]], dtype=float),
+        b=jnp.zeros((2, 1), dtype=float),
+    )
+    return params, strength, mask
+
+
+def _make_dict_list_data():
+    params = dict(w=[jnp.array([1.0, -2.0, 3.0])], b=jnp.array([0.5]))
+    strength = tree_full_like(params, 0.5)
+    mask = dict(
+        w=[jnp.array([[1, 1, 0], [0, 0, 1]], dtype=float)],
+        b=jnp.zeros((2, 1), dtype=float),
+    )
+    return params, strength, mask
+
+
+_PYTREE_DATA_CASES = [
+    pytest.param(_make_dict_data, id="dict"),
+    pytest.param(_make_eqx_module_data, id="eqx_module"),
+    pytest.param(_make_dict_list_data, id="dict_list"),
+]
 
 
 @pytest.mark.parametrize(
@@ -609,3 +653,64 @@ def test_prox_group_lasso_pytree_strength_broadcast_and_shape():
     # Structure preserved
     assert out_weak["w"].shape == params["w"].shape
     assert out_strong["w"].shape == params["w"].shape
+
+
+# === Tests: proximal operators work with dict, FeaturePytree, and eqx.Module ===
+
+
+@pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
+def test_prox_none_pytree_types(make_data):
+    """prox_none returns input unchanged for dict, FeaturePytree, and eqx.Module."""
+    params, strength, _ = make_data()
+    out = prox_none(params, strength=strength, scaling=1.0)
+    assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+
+
+@pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
+def test_prox_ridge_pytree_types(make_data):
+    """prox_ridge preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    params, strength, _ = make_data()
+    out = prox_ridge(params, strength=strength, scaling=1.0)
+    assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+    for out_leaf, in_leaf in zip(
+        jax.tree_util.tree_leaves(out), jax.tree_util.tree_leaves(params)
+    ):
+        assert out_leaf.shape == in_leaf.shape
+
+
+@pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
+def test_prox_lasso_pytree_types(make_data):
+    """prox_lasso preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    params, strength, _ = make_data()
+    out = prox_lasso(params, strength=strength, scaling=1.0)
+    assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+    for out_leaf, in_leaf in zip(
+        jax.tree_util.tree_leaves(out), jax.tree_util.tree_leaves(params)
+    ):
+        assert out_leaf.shape == in_leaf.shape
+
+
+@pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
+def test_prox_elastic_net_pytree_types(make_data):
+    """prox_elastic_net preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    params, _, _ = make_data()
+    # elastic net expects per-leaf (strength, ratio) tuples
+    strength = tree_full_like(params, (0.5, 0.5))
+    out = prox_elastic_net(params, strength=strength, scaling=1.0)
+    assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+    for out_leaf, in_leaf in zip(
+        jax.tree_util.tree_leaves(out), jax.tree_util.tree_leaves(params)
+    ):
+        assert out_leaf.shape == in_leaf.shape
+
+
+@pytest.mark.parametrize("make_data", _PYTREE_DATA_CASES)
+def test_prox_group_lasso_pytree_types(make_data):
+    """prox_group_lasso preserves structure and shape for dict, FeaturePytree, and eqx.Module."""
+    params, strength, mask = make_data()
+    out = prox_group_lasso(params, strength=strength, mask=mask, scaling=1.0)
+    assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+    for out_leaf, in_leaf in zip(
+        jax.tree_util.tree_leaves(out), jax.tree_util.tree_leaves(params)
+    ):
+        assert out_leaf.shape == in_leaf.shape

--- a/tests/test_proximal_operator.py
+++ b/tests/test_proximal_operator.py
@@ -13,6 +13,7 @@ from nemos.proximal_operator import (
     prox_ridge,
 )
 from nemos.tree_utils import tree_full_like
+from nemos.utils import get_flattener_unflattener
 
 
 class _TwoLeafModule(eqx.Module):
@@ -55,23 +56,6 @@ _PYTREE_DATA_CASES = [
     pytest.param(_make_eqx_module_data, id="eqx_module"),
     pytest.param(_make_dict_list_data, id="dict_list"),
 ]
-
-def _flat_and_unflat_coef(coef_tree):
-    """Utility function to flatten and unflatten coefficients."""
-    flat_coef, struct = jax.tree_util.tree_flatten(coef_tree)
-    shapes = jax.tree_util.tree_map(lambda x: x.shape, coef_tree)
-    splits = [0] + [x.size for x in flat_coef]
-    splits = jnp.cumsum(jnp.array(splits, dtype=jnp.int32))
-    def _flat(x):
-        x_flat = jax.tree_util.tree_leaves(x)
-        x_flat = jnp.hstack([x.ravel() for x in x_flat])
-        return x_flat
-    def _unflat(x):
-        flat_x = [x[start:stop] for start, stop in zip(splits[:-1], splits[1:])]
-        tree_x = jax.tree_util.tree_unflatten(struct, flat_x)
-        return jax.tree_util.tree_map(lambda x,s: jnp.reshape(x, s), tree_x, shapes)
-    return _flat, _unflat
-
 
 
 @pytest.mark.parametrize(
@@ -777,7 +761,7 @@ _ELEMENTWISE_PROX_CASES = [
 def test_prox_operator_tree_vs_array_equivalence(make_data, prox_op, tree_strength_fn, flat_strength):
     """Proximal operator on a pytree matches element-wise application to its flat array."""
     params, _, _ = make_data()
-    _flat, _unflat = _flat_and_unflat_coef(params)
+    _flat, _unflat = get_flattener_unflattener(params)
 
     scaling = 1.0
 

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -19,6 +19,20 @@ from nemos.glm.params import GLMParams
 pytestmark = pytest.mark.solver_related
 
 
+class _TwoLeafModule(eqx.Module):
+    w: jnp.ndarray
+    b: jnp.ndarray
+
+
+_SIMPLE_PYTREE_CASES = [
+    pytest.param(lambda: {"w": jnp.ones(3), "b": jnp.zeros(1)}, id="dict"),
+    pytest.param(
+        lambda: _TwoLeafModule(w=jnp.ones(3), b=jnp.zeros(1)), id="eqx_module"
+    ),
+    pytest.param(lambda: {"w": [jnp.ones(3)], "b": jnp.zeros(1)}, id="dict_list"),
+]
+
+
 @pytest.fixture(scope="module", autouse=True)
 def register_deregister_agradientdescent():
     """Fixture for registering and deregistering AGradientDescent."""
@@ -1114,6 +1128,29 @@ class TestUnRegularized:
         model.solver_name = solver_name
         model.fit(X, y)
 
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_get_proximal_operator_pytree(self, make_params):
+        """get_proximal_operator output preserves pytree structure for any pytree params."""
+        params = make_params()
+        regularizer = self.cls()
+        prox_op = regularizer.get_proximal_operator(params, strength=None)
+        out = prox_op(params, None)
+        assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_penalized_loss_pytree(self, make_params):
+        """penalized_loss can be called with any pytree params and returns a scalar."""
+        params = make_params()
+        regularizer = self.cls()
+
+        def dummy_loss(p, X, y):
+            return sum(jnp.sum(leaf) for leaf in jax.tree_util.tree_leaves(p))
+
+        penalized = regularizer.penalized_loss(dummy_loss, params=params, strength=None)
+        result = penalized(params, jnp.ones((10, 3)), jnp.ones(10))
+        assert isinstance(result, jnp.ndarray)
+        assert result.ndim == 0
+
 
 class TestRidge:
     cls = nmo.regularizer.Ridge
@@ -1377,6 +1414,29 @@ class TestRidge:
         model.solver_name = solver_name
         model.fit(X, y)
 
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_get_proximal_operator_pytree(self, make_params):
+        """get_proximal_operator output preserves pytree structure for any pytree params."""
+        params = make_params()
+        regularizer = self.cls()
+        prox_op = regularizer.get_proximal_operator(params, strength=1.0)
+        out = prox_op(params, None)
+        assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_penalized_loss_pytree(self, make_params):
+        """penalized_loss can be called with any pytree params and returns a scalar."""
+        params = make_params()
+        regularizer = self.cls()
+
+        def dummy_loss(p, X, y):
+            return sum(jnp.sum(leaf) for leaf in jax.tree_util.tree_leaves(p))
+
+        penalized = regularizer.penalized_loss(dummy_loss, params=params, strength=1.0)
+        result = penalized(params, jnp.ones((10, 3)), jnp.ones(10))
+        assert isinstance(result, jnp.ndarray)
+        assert result.ndim == 0
+
 
 class TestLasso:
     cls = nmo.regularizer.Lasso
@@ -1611,6 +1671,29 @@ class TestLasso:
         model.set_params(regularizer=self.cls(), regularizer_strength=1.0)
         model.solver_name = solver_name
         model.fit(X, y)
+
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_get_proximal_operator_pytree(self, make_params):
+        """get_proximal_operator output preserves pytree structure for any pytree params."""
+        params = make_params()
+        regularizer = self.cls()
+        prox_op = regularizer.get_proximal_operator(params, strength=1.0)
+        out = prox_op(params, None)
+        assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_penalized_loss_pytree(self, make_params):
+        """penalized_loss can be called with any pytree params and returns a scalar."""
+        params = make_params()
+        regularizer = self.cls()
+
+        def dummy_loss(p, X, y):
+            return sum(jnp.sum(leaf) for leaf in jax.tree_util.tree_leaves(p))
+
+        penalized = regularizer.penalized_loss(dummy_loss, params=params, strength=1.0)
+        result = penalized(params, jnp.ones((10, 3)), jnp.ones(10))
+        assert isinstance(result, jnp.ndarray)
+        assert result.ndim == 0
 
 
 class TestElasticNet:
@@ -2521,6 +2604,31 @@ class TestElasticNet:
         model.solver_name = solver_name
         model.fit(X, y)
 
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_get_proximal_operator_pytree(self, make_params):
+        """get_proximal_operator output preserves pytree structure for any pytree params."""
+        params = make_params()
+        regularizer = self.cls()
+        prox_op = regularizer.get_proximal_operator(params, strength=(1.0, 0.5))
+        out = prox_op(params, None)
+        assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_penalized_loss_pytree(self, make_params):
+        """penalized_loss can be called with any pytree params and returns a scalar."""
+        params = make_params()
+        regularizer = self.cls()
+
+        def dummy_loss(p, X, y):
+            return sum(jnp.sum(leaf) for leaf in jax.tree_util.tree_leaves(p))
+
+        penalized = regularizer.penalized_loss(
+            dummy_loss, params=params, strength=(1.0, 0.5)
+        )
+        result = penalized(params, jnp.ones((10, 3)), jnp.ones(10))
+        assert isinstance(result, jnp.ndarray)
+        assert result.ndim == 0
+
 
 class TestGroupLasso:
     cls = nmo.regularizer.GroupLasso
@@ -3321,6 +3429,52 @@ class TestGroupLasso:
         assert isinstance(penalty, jnp.ndarray)
         assert penalty.ndim == 0
         assert penalty >= 0
+
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_get_proximal_operator_pytree(self, make_params):
+        """get_proximal_operator output preserves pytree structure for any pytree params."""
+        params = make_params()
+        # mask=None: auto-initialized from params structure
+        regularizer = self.cls(mask=None)
+        prox_op = regularizer.get_proximal_operator(params, strength=1.0)
+        out = prox_op(params, None)
+        assert jax.tree_util.tree_structure(out) == jax.tree_util.tree_structure(params)
+
+    @pytest.mark.parametrize("make_params", _SIMPLE_PYTREE_CASES)
+    def test_penalized_loss_pytree(self, make_params):
+        """penalized_loss can be called with any pytree params and returns a scalar."""
+        params = make_params()
+        regularizer = self.cls(mask=None)
+
+        def dummy_loss(p, X, y):
+            return sum(jnp.sum(leaf) for leaf in jax.tree_util.tree_leaves(p))
+
+        penalized = regularizer.penalized_loss(dummy_loss, params=params, strength=1.0)
+        result = penalized(params, jnp.ones((10, 3)), jnp.ones(10))
+        assert isinstance(result, jnp.ndarray)
+        assert result.ndim == 0
+
+    @pytest.mark.parametrize("solver_name", ["ProximalGradient", "ProxSVRG"])
+    def test_run_solver_tree(self, solver_name, poissonGLM_model_instantiation_pytree):
+        """Test that the GroupLasso solver runs with pytree X (mask auto-initialized)."""
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation_pytree
+
+        # mask=None: auto-initialized from params structure during _instantiate_solver
+        model.set_params(regularizer=self.cls(mask=None), regularizer_strength=1.0)
+        model.solver_name = solver_name
+        params = GLMParams(
+            jax.tree_util.tree_map(jnp.zeros_like, true_params.coef),
+            true_params.intercept,
+        )
+        runner = model._instantiate_solver(model._compute_loss, params).solver_run
+        runner(params, X.data, y)
+
+    def test_grouplasso_pytree(self, poissonGLM_model_instantiation_pytree):
+        """Check that GroupLasso fits with a FeaturePytree X (mask auto-initialized)."""
+        X, y, model, true_params, firing_rate = poissonGLM_model_instantiation_pytree
+        model.set_params(regularizer=self.cls(mask=None), regularizer_strength=0.1)
+        model.solver_name = "ProximalGradient"
+        model.fit(X, y)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# PR: Arbitrary Pytree Support for X Input

## Summary

Extend the test suite and documentation to formally cover arbitrary JAX pytrees as the `X`
argument to all GLM models, and fix two source-level issues discovered during testing.

## Motivation

`FeaturePytree` was the only officially documented and tested path for grouped feature input.
JAX's own pytree mechanism is more general (dicts, `equinox.Module`, nested containers, etc.)
and avoids bespoke wrapper types. This PR validates that the implementation already supports
arbitrary pytrees, removes `FeaturePytree` from every X-parameter description, and adds
regression coverage so future refactors cannot silently break pytree inputs.

## Description of the Changes and Rationale

### Source fixes

**`base_validator.py` — `validate_inputs`**: replaced `X.shape[0]` with a loop over 
`jax.tree_util.tree_leaves(X)` to obtain n_samples from an arbitrary pytree. Also added
a consistency check that all leaves share the same number of samples.

**`validation.py`**: updated structure-mismatch error messages to report
`jax.tree_util.tree_structure(X)` vs `jax.tree_util.tree_structure(coef)` instead of
assuming X is an array; 

**`glm.py` — `initialize_params`**: added a `feature_mask_consistency` call so that a
stale array `_feature_mask` set by a previous `fit(array_X, y)` raises a clear `TypeError`
instead of silently producing wrong shapes when the model is re-initialized with a pytree X. Added a test for this new behavior, see below. This was not necessary for the pytree support but that I caught this as I was writing new tests.

### Tests

| Layer | File | What is tested |
|---|---|---|
| 1 | `test_proximal_operator.py` | Each of the 5 prox operators accepts a pytree of params; array-vs-tree equivalence |
| 2 | `test_regularizer.py` | `_SIMPLE_PYTREE_CASES` uses plain dict / eqx module / dict-list instead of FeaturePytree |
| 3 | `test_base_regressor_subclasses.py` | `TestModelVsPytree` — all public API methods involving X × models × pytree-type |
| 4 | `test_glm.py` | Coef tree structure matches X after `initialize_params` and `fit`; stale mask regression |

`test_initialize_params_stale_feature_mask_raises` guards the source fix above: before this
PR the mask/pytree mismatch would surface at the first loss evaluation, producing a cryptic
shape error far from the site of the mistake.

### Documentation

- Removed every X-parameter reference to `FeaturePytree` in method docstrings across
  `GLM`, `PopulationGLM`, `ClassifierGLM`, and `ClassifierPopulationGLM`; replaced with
  "pytree of arrays of the same shape".
- Updated `PopulationGLM` class docstring: replaced the "Mask Coefficients with a
  FeaturePytree" example with a plain-dict equivalent.
- Added a "Use a Pytree of Arrays as Input" example to the class docstrings of `GLM`,
  `ClassifierGLM`, and `ClassifierPopulationGLM`.

## Open Questions for the Reviewers

- **FeaturePytree backward compatibility**. I would want to drop the FeaturePytree implementation entirely at this point. In a subsequent PR I would like to add a deprecation warning. For how many versions should we be backward compatible?
- What should I do with the showcasing the FeaturePytree? (Probably nothing in this one but in the next PR deprecating the feature pytree)
  - **plot_03_population_glm.md**: This shows that the `feature_mask` is automatically generated based on the tree structure, one group per leaf. I think this should stay and be replaced with a regular dictionary.
  - **plot_07_glm_pytree.md**: This one literally shows the FeaturePytree on its own. Should we show the pytree compatibility with different tree types instead or should we just delete it?
  - **finegrained_regularization.md**: This shows how to regularize with structured regularization strength, as long as the strength structure matches that of the parameters. I could just show how to do it with dict and list of coefficients.
  - **variable_selection_group_lasso.md**: This had a note on how to structure the regularization by grouping variables (using FeaturePytree for now). What should I do here? If I keep `plot_07_glm_pytree` using other tree types, I can keep the link to it. 