### PR TITLE
Make HMM validator class

### DIFF
--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -1,6 +1,6 @@
 """Validation classes for GLMHMM and PopulationGLMHMM models."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable, Optional, Tuple, Union
 
 import jax
@@ -12,10 +12,10 @@ from .. import validation
 from ..base_validator import RegressorValidator
 from ..glm.params import GLMParams, GLMUserParams
 from ..glm.validation import GLMValidator
-from ..hmm.params import HMMParams
 from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE
 from .params import GLMHMMModelParams, GLMHMMParams, GLMHMMUserParams
+from ..hmm.validation import HMMValidatorMixin, to_hmm_params, from_hmm_params
 
 
 def has_nans_only_at_border(arr):
@@ -48,7 +48,7 @@ def to_glm_hmm_params(user_params: GLMHMMUserParams) -> GLMHMMParams:
     """
     return GLMHMMParams(
         model_params=GLMHMMModelParams(user_params[:3]),
-        hmm_params=HMMParams(*(jnp.log(p) for p in user_params[3:])),
+        hmm_params=to_hmm_params(user_params[3:]),
     )
 
 
@@ -58,11 +58,7 @@ def from_glm_hmm_params(params: GLMHMMParams) -> GLMHMMUserParams:
     Converts internal model parameters (log_scale and log probabilities)
     to user-facing parameters (scale and probabilities in regular space).
     """
-    # exponentiate and re-normalize
-    initial_prob = jnp.exp(params.hmm_params.log_initial_prob)
-    initial_prob /= initial_prob.sum()
-    transition_prob = jnp.exp(params.hmm_params.log_transition_prob)
-    transition_prob /= transition_prob.sum(axis=1, keepdims=True)
+    initial_prob, transition_prob = from_hmm_params(params.hmm_params)
     return (
         params.model_params.coef,
         params.model_params.intercept,
@@ -73,16 +69,14 @@ def from_glm_hmm_params(params: GLMHMMParams) -> GLMHMMUserParams:
 
 
 @dataclass(frozen=True, repr=False)
-class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams]):
+class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams], HMMValidatorMixin):
     """Validate GLM-HMM parameters and inputs."""
 
-    n_states: int = field(kw_only=True)  # keyword only and required.
     expected_param_dims: Tuple[int] = (
         2,
         1,
         1,
-        1,
-        2,
+        *HMMValidatorMixin.expected_param_dims,
     )  # (coef.ndim, intercept.ndim, scale.ndim, init_prob.ndim, transition_prob.ndim)
     to_model_params: Callable[[GLMHMMUserParams], GLMHMMParams] = to_glm_hmm_params
     from_model_params: Callable[[GLMHMMParams], GLMHMMUserParams] = from_glm_hmm_params
@@ -106,9 +100,8 @@ class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams]):
                 "instead."
             ),
         ),
-        ("check_init_and_transition_prob_shape", None),
-        ("check_init_and_transition_prob_sum_to_1", None),
         ("check_model_params_shape", None),
+        *HMMValidatorMixin.params_validation_sequence,
         *RegressorValidator.params_validation_sequence[3:],
     )
 
@@ -148,24 +141,6 @@ class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams]):
         err_msg = err_message_format.format(*shapes)
         return super().check_array_dimensions(params, err_msg=err_msg)
 
-    def check_init_and_transition_prob_shape(
-        self, params: GLMHMMUserParams
-    ) -> GLMHMMUserParams:
-        """Check initial and transition probabilities shape."""
-        wrapped = self.wrap_user_params(params)
-        initial_prob, transition_prob = wrapped[-2:]
-        if initial_prob.shape != (self.n_states,):
-            raise ValueError(
-                f"initial_prob must be a 1-dimensional array of shape ``({self.n_states},)``. "
-                f"Provided initial_prob is of shape ``{initial_prob.shape}`` instead."
-            )
-        if transition_prob.shape != (self.n_states, self.n_states):
-            raise ValueError(
-                f"transition_prob must be a 2-dimensional array of shape ``({self.n_states}, {self.n_states})``."
-                f"Provided transition_prob is of shape ``{transition_prob.shape}`` instead."
-            )
-        return params
-
     def check_model_params_shape(self, params: GLMHMMUserParams) -> GLMHMMUserParams:
         """Check the length of the glm parameters state axis."""
         wrapped = self.wrap_user_params(params)
@@ -184,25 +159,6 @@ class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams]):
             raise ValueError(
                 "GLM intercept must be of shape ``(n_states,)``. "
                 f"n_states is {self.n_states} but coef has shape ``{intercept.shape}``."
-            )
-        return params
-
-    def check_init_and_transition_prob_sum_to_1(
-        self, params: GLMHMMUserParams
-    ) -> GLMHMMUserParams:
-        """Check that initial and transition probability sum to 1."""
-        wrapped = self.wrap_user_params(params)
-        initial_prob, transition_prob = wrapped[-2:]
-        if not jnp.allclose(initial_prob.sum(), 1):
-            raise ValueError(
-                f"initial_prob must sum to 1, but got sum = {initial_prob.sum()}. "
-            )
-        if not jnp.allclose(jnp.sum(transition_prob, axis=1), 1):
-            row_sums = jnp.sum(transition_prob, axis=1)
-            raise ValueError(
-                f"transition_prob matrix rows must sum to 1 over columns, but got sum = {row_sums}. "
-                f"Each row i represents the probability distribution of transitioning from state i"
-                f"and must sum to 1. "
             )
         return params
 

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -76,7 +76,8 @@ class GLMHMMValidator(HMMValidator[GLMHMMUserParams, GLMHMMParams]):
         1,
         *HMMValidator.expected_param_dims,
     )  # (coef.ndim, intercept.ndim, scale.ndim, init_prob.ndim, transition_prob.ndim)
-    hmm_param_inds: Tuple[int] = (3, 4)  # (initial_prob, transition_prob)
+    initial_prob_ind: int = 3
+    transition_prob_ind: int = 4
     model_param_names: Tuple[str] = (
         "coef",
         "intercept",

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -12,10 +12,10 @@ from .. import validation
 from ..base_validator import RegressorValidator
 from ..glm.params import GLMParams, GLMUserParams
 from ..glm.validation import GLMValidator
+from ..hmm.validation import HMMValidatorMixin, from_hmm_params, to_hmm_params
 from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE
 from .params import GLMHMMModelParams, GLMHMMParams, GLMHMMUserParams
-from ..hmm.validation import HMMValidatorMixin, to_hmm_params, from_hmm_params
 
 
 def has_nans_only_at_border(arr):

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -12,7 +12,7 @@ from .. import validation
 from ..base_validator import RegressorValidator
 from ..glm.params import GLMParams, GLMUserParams
 from ..glm.validation import GLMValidator
-from ..hmm.validation import HMMValidatorMixin, from_hmm_params, to_hmm_params
+from ..hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
 from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE
 from .params import GLMHMMModelParams, GLMHMMParams, GLMHMMUserParams
@@ -69,15 +69,22 @@ def from_glm_hmm_params(params: GLMHMMParams) -> GLMHMMUserParams:
 
 
 @dataclass(frozen=True, repr=False)
-class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams], HMMValidatorMixin):
+class GLMHMMValidator(HMMValidator[GLMHMMUserParams, GLMHMMParams]):
     """Validate GLM-HMM parameters and inputs."""
 
     expected_param_dims: Tuple[int] = (
         2,
         1,
         1,
-        *HMMValidatorMixin.expected_param_dims,
+        *HMMValidator.expected_param_dims,
     )  # (coef.ndim, intercept.ndim, scale.ndim, init_prob.ndim, transition_prob.ndim)
+    hmm_param_inds: Tuple[int] = (3, 4)  # (initial_prob, transition_prob)
+    model_param_names: Tuple[str] = (
+        "coef",
+        "intercept",
+        "scale",
+        *HMMValidator.model_param_names,
+    )
     to_model_params: Callable[[GLMHMMUserParams], GLMHMMParams] = to_glm_hmm_params
     from_model_params: Callable[[GLMHMMParams], GLMHMMUserParams] = from_glm_hmm_params
     model_class: str = "GLMHMM"
@@ -101,45 +108,9 @@ class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams], HMMValidator
             ),
         ),
         ("check_model_params_shape", None),
-        *HMMValidatorMixin.params_validation_sequence,
+        *HMMValidator.params_validation_sequence,
         *RegressorValidator.params_validation_sequence[3:],
     )
-
-    def check_array_dimensions(
-        self,
-        params: GLMHMMUserParams,
-        err_msg: Optional[str] = None,
-        err_message_format: str = None,
-    ) -> GLMHMMUserParams:
-        """
-        Check array dimensions with custom error formatting for GLM parameters.
-
-        Overrides the base implementation to provide GLM-specific error messages
-        that include the actual shapes of the provided coefficient and intercept arrays.
-
-        Parameters
-        ----------
-        params : GLMUserParams
-            User-provided parameters as a tuple (coef, intercept).
-        err_msg : str, optional
-            Custom error message (unused, overridden by err_message_format).
-        err_message_format : str, optional
-            Format string for error message that takes two shape arguments.
-
-        Returns
-        -------
-        GLMUserParams
-            The validated parameters.
-
-        Raises
-        ------
-        ValueError
-            If arrays have incorrect dimensionality.
-        """
-        wrapped = self.wrap_user_params(params)
-        shapes = tuple(jax.tree_util.tree_map(lambda x: x.shape, p) for p in wrapped)
-        err_msg = err_message_format.format(*shapes)
-        return super().check_array_dimensions(params, err_msg=err_msg)
 
     def check_model_params_shape(self, params: GLMHMMUserParams) -> GLMHMMUserParams:
         """Check the length of the glm parameters state axis."""
@@ -159,42 +130,6 @@ class GLMHMMValidator(RegressorValidator[GLMUserParams, GLMParams], HMMValidator
             raise ValueError(
                 "GLM intercept must be of shape ``(n_states,)``. "
                 f"n_states is {self.n_states} but coef has shape ``{intercept.shape}``."
-            )
-        return params
-
-    def check_user_params_structure(
-        self, params: GLMUserParams, **kwargs
-    ) -> GLMUserParams:
-        """
-        Validate that user parameters are a two-element structure.
-
-        Parameters
-        ----------
-        params : GLMUserParams
-            User-provided parameters (should be a tuple/list of length 2).
-        **kwargs
-            Additional keyword arguments (unused).
-
-        Returns
-        -------
-        GLMUserParams
-            The validated parameters.
-
-        Raises
-        ------
-        ValueError
-            If parameters do not have length two.
-        """
-        validation.check_length(
-            params,
-            5,
-            "Params must have length 5: "
-            "(coef, intercept, scale, initial_prob, transition_prob).",
-        )
-        if not isinstance(params, (tuple, list)):
-            raise TypeError(
-                "GLMHMM params must be a tuple/list of length 5, "
-                "(coef, intercept, scale, initial_prob, transition_prob)."
             )
         return params
 

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -8,9 +8,7 @@ import jax.numpy as jnp
 from jax.typing import DTypeLike
 from pynapple import Tsd, TsdFrame
 
-from .. import validation
 from ..base_validator import RegressorValidator
-from ..glm.params import GLMParams, GLMUserParams
 from ..glm.validation import GLMValidator
 from ..hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
 from ..type_casting import is_pynapple_tsd

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -24,9 +24,7 @@ def to_hmm_params(user_params: HMMUserParams) -> HMMParams:
     Converts user-provided parameters (scale and probabilities in regular space)
     to internal model parameters (log_scale and log probabilities).
     """
-    return HMMParams(
-        hmm_params=HMMParams(*(jnp.log(p) for p in user_params)),
-    )
+    return HMMParams(*(jnp.log(p) for p in user_params))
 
 
 def from_hmm_params(params: HMMParams) -> HMMUserParams:

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -10,8 +10,6 @@ from .. import validation
 from ..base_validator import RegressorValidator
 from .params import HMMParams, HMMUserParams
 
-# from .typing import ModelParamsT, UserProvidedParamsT
-
 # HMM-type User provided init_params (e.g. for GLM-HMM Tuple[array, array, array, array, array]])
 HMMUserProvidedParamsT = TypeVar("HMMUserProvidedParamsT")
 # HMM-type Model internal representation (e.g. for GLM-s nemos.glm_hmm.glm_hmm.GLMHMMParams)

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -1,15 +1,14 @@
 """Validation mixin class for HMM-based models."""
 
 from dataclasses import dataclass, field
-from typing import Any, Tuple, Optional
+from typing import Any, Optional, Tuple, TypeVar
 
-import jax.numpy as jnp
 import jax
+import jax.numpy as jnp
 
 from .. import validation
-from .params import HMMParams, HMMUserParams
 from ..base_validator import RegressorValidator
-from typing import TypeVar
+from .params import HMMParams, HMMUserParams
 
 # from .typing import ModelParamsT, UserProvidedParamsT
 
@@ -131,12 +130,12 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
             params,
             len(self.expected_param_dims),
             f"Params must have length {len(self.expected_param_dims)}: "
-            f"({", ".join(self.model_param_names)}).",
+            f"({', '.join(self.model_param_names)}).",
         )
         if not isinstance(params, (tuple, list)):
             raise TypeError(
                 f"{self.model_class} params must be a tuple/list of length {len(self.expected_param_dims)}, "
-                f"({", ".join(self.model_param_names)})."
+                f"({', '.join(self.model_param_names)})."
             )
         return params
 

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -1,0 +1,87 @@
+"""Validation mixin class for HMM-based models."""
+
+from dataclasses import dataclass, field
+from typing import Any, Tuple
+
+import jax.numpy as jnp
+from .params import HMMParams, HMMUserParams
+
+
+def to_hmm_params(user_params: HMMUserParams) -> HMMParams:
+    """Map from HMMUserParams to HMMParams.
+
+    Converts user-provided parameters (scale and probabilities in regular space)
+    to internal model parameters (log_scale and log probabilities).
+    """
+    return HMMParams(
+        hmm_params=HMMParams(*(jnp.log(p) for p in user_params)),
+    )
+
+
+def from_hmm_params(params: HMMParams) -> HMMUserParams:
+    """Map from HMMParams to HMMUserParams.
+
+    Converts internal model parameters (log_scale and log probabilities)
+    to user-facing parameters (scale and probabilities in regular space).
+    """
+    # exponentiate and re-normalize
+    initial_prob = jnp.exp(params.hmm_params.log_initial_prob)
+    initial_prob /= initial_prob.sum()
+    transition_prob = jnp.exp(params.hmm_params.log_transition_prob)
+    transition_prob /= transition_prob.sum(axis=1, keepdims=True)
+    return (
+        initial_prob,
+        transition_prob,
+    )
+
+
+@dataclass(frozen=True, repr=False)
+class HMMValidatorMixin:
+    """Validate HMM parameters. Meant to be used as a mixin class for models that use HMMs."""
+
+    n_states: int = field(kw_only=True)  # keyword only and required.
+    expected_param_dims: Tuple[int] = (
+        1,
+        2,
+    )  # (init_prob.ndim, transition_prob.ndim)
+    params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
+        ("check_init_and_transition_prob_shape", None),
+        ("check_init_and_transition_prob_sum_to_1", None),
+    )
+
+    def check_init_and_transition_prob_shape(
+        self, params: HMMUserParams
+    ) -> HMMUserParams:
+        """Check initial and transition probabilities shape."""
+        wrapped = self.wrap_user_params(params)
+        initial_prob, transition_prob = wrapped[-2:]
+        if initial_prob.shape != (self.n_states,):
+            raise ValueError(
+                f"initial_prob must be a 1-dimensional array of shape ``({self.n_states},)``. "
+                f"Provided initial_prob is of shape ``{initial_prob.shape}`` instead."
+            )
+        if transition_prob.shape != (self.n_states, self.n_states):
+            raise ValueError(
+                f"transition_prob must be a 2-dimensional array of shape ``({self.n_states}, {self.n_states})``."
+                f"Provided transition_prob is of shape ``{transition_prob.shape}`` instead."
+            )
+        return params
+
+    def check_init_and_transition_prob_sum_to_1(
+        self, params: HMMUserParams
+    ) -> HMMUserParams:
+        """Check that initial and transition probability sum to 1."""
+        wrapped = self.wrap_user_params(params)
+        initial_prob, transition_prob = wrapped[-2:]
+        if not jnp.allclose(initial_prob.sum(), 1):
+            raise ValueError(
+                f"initial_prob must sum to 1, but got sum = {initial_prob.sum()}. "
+            )
+        if not jnp.allclose(jnp.sum(transition_prob, axis=1), 1):
+            row_sums = jnp.sum(transition_prob, axis=1)
+            raise ValueError(
+                f"transition_prob matrix rows must sum to 1 over columns, but got sum = {row_sums}. "
+                f"Each row i represents the probability distribution of transitioning from state i"
+                f"and must sum to 1. "
+            )
+        return params

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -53,9 +53,10 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         1,
         2,
     )  # (init_prob.ndim, transition_prob.ndim)
-    # indices of user-provided parameters that correspond to HMM parameters
-    # in order (initial_prob, transition_prob)
-    hmm_param_inds: Tuple[int] = None
+    initial_prob_ind: int = None  # index of initial probability in user params tuple
+    transition_prob_ind: int = (
+        None  # index of transition probability in user params tuple
+    )
     model_param_names: Tuple[str] = ("initial_prob", "transition_prob")
     model_class: str = "HMM"
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
@@ -141,9 +142,11 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         self, params: HMMUserProvidedParamsT
     ) -> HMMUserProvidedParamsT:
         """Check initial and transition probabilities shape."""
-        initial_prob, transition_prob = self.wrap_user_params(params)[
-            self.hmm_param_inds
-        ]
+        wrapped = self.wrap_user_params(params)
+        initial_prob, transition_prob = (
+            wrapped[self.initial_prob_ind],
+            wrapped[self.transition_prob_ind],
+        )
         if initial_prob.shape != (self.n_states,):
             raise ValueError(
                 f"initial_prob must be a 1-dimensional array of shape ``({self.n_states},)``. "
@@ -160,9 +163,11 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         self, params: HMMUserProvidedParamsT
     ) -> HMMUserProvidedParamsT:
         """Check that initial and transition probability sum to 1."""
-        initial_prob, transition_prob = self.wrap_user_params(params)[
-            self.hmm_param_inds
-        ]
+        wrapped = self.wrap_user_params(params)
+        initial_prob, transition_prob = (
+            wrapped[self.initial_prob_ind],
+            wrapped[self.transition_prob_ind],
+        )
         if not jnp.allclose(initial_prob.sum(), 1):
             raise ValueError(
                 f"initial_prob must sum to 1, but got sum = {initial_prob.sum()}. "

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -1,11 +1,22 @@
 """Validation mixin class for HMM-based models."""
 
 from dataclasses import dataclass, field
-from typing import Any, Tuple
+from typing import Any, Tuple, Optional
 
 import jax.numpy as jnp
+import jax
 
+from .. import validation
 from .params import HMMParams, HMMUserParams
+from ..base_validator import RegressorValidator
+from typing import TypeVar
+
+# from .typing import ModelParamsT, UserProvidedParamsT
+
+# HMM-type User provided init_params (e.g. for GLM-HMM Tuple[array, array, array, array, array]])
+HMMUserProvidedParamsT = TypeVar("HMMUserProvidedParamsT")
+# HMM-type Model internal representation (e.g. for GLM-s nemos.glm_hmm.glm_hmm.GLMHMMParams)
+HMMModelParamsT = TypeVar("HMMModelParamsT")
 
 
 def to_hmm_params(user_params: HMMUserParams) -> HMMParams:
@@ -26,9 +37,9 @@ def from_hmm_params(params: HMMParams) -> HMMUserParams:
     to user-facing parameters (scale and probabilities in regular space).
     """
     # exponentiate and re-normalize
-    initial_prob = jnp.exp(params.hmm_params.log_initial_prob)
+    initial_prob = jnp.exp(params.log_initial_prob)
     initial_prob /= initial_prob.sum()
-    transition_prob = jnp.exp(params.hmm_params.log_transition_prob)
+    transition_prob = jnp.exp(params.log_transition_prob)
     transition_prob /= transition_prob.sum(axis=1, keepdims=True)
     return (
         initial_prob,
@@ -37,7 +48,7 @@ def from_hmm_params(params: HMMParams) -> HMMUserParams:
 
 
 @dataclass(frozen=True, repr=False)
-class HMMValidatorMixin:
+class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
     """Validate HMM parameters. Meant to be used as a mixin class for models that use HMMs."""
 
     n_states: int = field(kw_only=True)  # keyword only and required.
@@ -45,17 +56,97 @@ class HMMValidatorMixin:
         1,
         2,
     )  # (init_prob.ndim, transition_prob.ndim)
+    # indices of user-provided parameters that correspond to HMM parameters
+    # in order (initial_prob, transition_prob)
+    hmm_param_inds: Tuple[int] = None
+    model_param_names: Tuple[str] = ("initial_prob", "transition_prob")
+    model_class: str = "HMM"
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
         ("check_init_and_transition_prob_shape", None),
         ("check_init_and_transition_prob_sum_to_1", None),
     )
 
-    def check_init_and_transition_prob_shape(
-        self, params: HMMUserParams
-    ) -> HMMUserParams:
-        """Check initial and transition probabilities shape."""
+    def check_array_dimensions(
+        self,
+        params: HMMUserProvidedParamsT,
+        err_msg: Optional[str] = None,
+        err_message_format: str = None,
+    ) -> HMMUserProvidedParamsT:
+        """
+        Check array dimensions with custom error formatting for HMM-based model parameters.
+
+        Overrides the base implementation to provide model-specific error messages
+        that include the actual shapes of the provided parameters. The expected shapes of
+        additional model parameters and error message should be set in the child class (e.g
+        see GLMHMMValidator for an example).
+
+        Parameters
+        ----------
+        params :
+            User-provided parameters as a tuple.
+        err_msg :
+            Custom error message (unused, overridden by err_message_format).
+        err_message_format :
+            Format string for error message that takes two shape arguments.
+
+        Returns
+        -------
+        :
+            The validated parameters.
+
+        Raises
+        ------
+        ValueError
+            If arrays have incorrect dimensionality.
+        """
         wrapped = self.wrap_user_params(params)
-        initial_prob, transition_prob = wrapped[-2:]
+        shapes = tuple(jax.tree_util.tree_map(lambda x: x.shape, p) for p in wrapped)
+        err_msg = err_message_format.format(*shapes)
+        return super().check_array_dimensions(params, err_msg=err_msg)
+
+    def check_user_params_structure(
+        self, params: HMMUserProvidedParamsT, **kwargs
+    ) -> HMMUserProvidedParamsT:
+        """
+        Validate that user parameters are a two-element structure.
+
+        Parameters
+        ----------
+        params :
+            User-provided parameters (should be a tuple/list of length 2).
+        **kwargs
+            Additional keyword arguments (unused).
+
+        Returns
+        -------
+        :
+            The validated parameters.
+
+        Raises
+        ------
+        ValueError
+            If parameters do not have length two.
+        """
+        validation.check_length(
+            params,
+            len(self.expected_param_dims),
+            f"Params must have length {len(self.expected_param_dims)}: "
+            f"({", ".join(self.model_param_names)}).",
+        )
+        if not isinstance(params, (tuple, list)):
+            raise TypeError(
+                f"{self.model_class} params must be a tuple/list of length {len(self.expected_param_dims)}, "
+                f"({", ".join(self.model_param_names)})."
+            )
+        return params
+
+    def check_init_and_transition_prob_shape(
+        self, params: HMMUserProvidedParamsT
+    ) -> HMMUserProvidedParamsT:
+        """Check initial and transition probabilities shape."""
+        initial_prob, transition_prob = self.wrap_user_params(params)[
+            self.hmm_param_inds
+        ]
         if initial_prob.shape != (self.n_states,):
             raise ValueError(
                 f"initial_prob must be a 1-dimensional array of shape ``({self.n_states},)``. "
@@ -69,11 +160,12 @@ class HMMValidatorMixin:
         return params
 
     def check_init_and_transition_prob_sum_to_1(
-        self, params: HMMUserParams
-    ) -> HMMUserParams:
+        self, params: HMMUserProvidedParamsT
+    ) -> HMMUserProvidedParamsT:
         """Check that initial and transition probability sum to 1."""
-        wrapped = self.wrap_user_params(params)
-        initial_prob, transition_prob = wrapped[-2:]
+        initial_prob, transition_prob = self.wrap_user_params(params)[
+            self.hmm_param_inds
+        ]
         if not jnp.allclose(initial_prob.sum(), 1):
             raise ValueError(
                 f"initial_prob must sum to 1, but got sum = {initial_prob.sum()}. "

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Tuple
 
 import jax.numpy as jnp
+
 from .params import HMMParams, HMMUserParams
 
 


### PR DESCRIPTION
A small PR that takes out validation steps specific to HMM-based models from the GLMHMMValidator, and puts them in a separate class, `HMMValidator`. Functions that were moved to this class:
- `check_array_dimensions`
- `check_user_params_structure`
- `check_init_and_transition_prob_shape`
- `check_init_and_transition_prob_sum_to_1`

`check_array_dimensions` is NOT added to the validation sequence in `HMMValidator` so that the child class has full control of the custom error message.

New abstract types were introduced for this class, `HMMUserProvidedParamsT` and `HMMModelParamsT` (echoing `UserProvidedParamsT` and `ModelParamsT`) to be a placeholder for the parameter types of the inheriting model.  `HMMValidator` inherits `RegressorValidator` using these types, so any class inheriting `HMMValidator` only needs to inherit the single class, e.g. `GLMHMMValidator(HMMValidator[GLMHMMUserParams, GLMHMMParams])`

It adds some additional fields that need to be set by the child class for it to function correctly. Specifically:
- ~~`hmm_param_inds`~~ `initial_prob_ind` and `transition_prob_ind`: the indices of the HMM parameters (initial_probability, transition_matrix) in the user provided tuple of input parameters. needed for checks of initial probability and transition matrix without having to convert them to model parameters
- `model_param_names`: a tuple of the names of each model parameter in order. for custom error printing.

 