### PR TITLE
Test speedup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+"""Register a custom option in root."""
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--timeit",
+        action="store_true",
+        default=False,
+        help="Show aggregated parametrized test durations",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import re
 from collections import defaultdict, namedtuple
 from copy import deepcopy
 from functools import partial
+from types import SimpleNamespace
 from typing import Literal
 
 import jax
@@ -67,6 +68,67 @@ def pytest_terminal_summary(terminalreporter):
         terminalreporter.write_line(
             f"{total:6.2f}s total  {avg:.4f}s/param  {n:>5} params  {name}"
         )
+
+
+@pytest.fixture
+def mock_glm_fit(monkeypatch):
+    """Replace GLM.fit with a pure-Python no-op that sets coef_/intercept_ from X/y shapes.
+
+    Use in tests that only care about sklearn routing (cloning, parameter
+    setting, pipeline plumbing) and do not need any fit validation logic.
+    For tests that need validation but not solver iterations, use mock_optimizer_run.
+    """
+
+    def _fit(self, X, y, init_params=None, **kwargs):
+        n_features = X.shape[1]
+        y_arr = y.d if hasattr(y, "d") else np.asarray(y)
+        if y_arr.ndim == 1:
+            self.coef_ = jnp.zeros(n_features)
+            self.intercept_ = jnp.zeros(1)
+        else:
+            self.coef_ = jnp.zeros((n_features, y_arr.shape[1]))
+            self.intercept_ = jnp.zeros(y_arr.shape[1])
+        return self
+
+    monkeypatch.setattr(nmo.glm.GLM, "fit", _fit)
+    monkeypatch.setattr(nmo.glm.PopulationGLM, "fit", _fit)
+
+
+@pytest.fixture
+def mock_optimizer_run(monkeypatch):
+    """Bypass the JAX solver in fit() while keeping all validation logic.
+
+    Patches _initialize_optimizer_and_state to inject a no-op _optimizer_run
+    that returns init_params unchanged with a converged state. Use in tests
+    that only care about pipeline routing or fit side-effects (coef_/intercept_
+    shape, validation errors) and do not check solution quality.
+    """
+    _real_init = nmo.glm.GLM._initialize_optimizer_and_state
+
+    def _patched_init(self, init_params, data, y):
+        result = _real_init(self, init_params, data, y)
+        self._optimizer_run = lambda p, d, t: (p, SimpleNamespace(converged=True), None)
+        return result
+
+    monkeypatch.setattr(nmo.glm.GLM, "_initialize_optimizer_and_state", _patched_init)
+
+
+@pytest.fixture
+def mock_optimizer_update(monkeypatch):
+    """Bypass the JAX solver step in update() while keeping all validation logic.
+
+    Patches _initialize_optimizer_and_state to inject a no-op _optimizer_update
+    that returns the current params and state unchanged. Do NOT use in tests
+    that assert parameters actually changed after calling update().
+    """
+    _real_init = nmo.glm.GLM._initialize_optimizer_and_state
+
+    def _patched_init(self, init_params, data, y):
+        result = _real_init(self, init_params, data, y)
+        self._optimizer_update = lambda p, s, d, t, *a, **kw: (p, s, None)
+        return result
+
+    monkeypatch.setattr(nmo.glm.GLM, "_initialize_optimizer_and_state", _patched_init)
 
 
 # Named tuple for model fixture returns (clearer than tuple indexing)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,8 @@ Note:
 
 import abc
 import os
-from collections import namedtuple
+import re
+from collections import defaultdict, namedtuple
 from copy import deepcopy
 from functools import partial
 from typing import Literal
@@ -33,6 +34,29 @@ from nemos.basis._transformer_basis import TransformerBasis
 from nemos.glm.params import GLMParams
 from nemos.glm.validation import GLMValidator
 from nemos.tree_utils import tree_full_like
+
+_totals = defaultdict(float)
+_counts = defaultdict(int)
+
+
+def pytest_runtest_logreport(report):
+    if report.when == "call":
+        # strip [param] suffix to group by base test name
+        base = re.sub(r"\[.*\]$", "", report.nodeid)
+        _totals[base] += report.duration
+        _counts[base] += 1
+
+
+def pytest_terminal_summary(terminalreporter):
+    terminalreporter.write_sep("=", "aggregated param durations")
+    rows = sorted(_totals.items(), key=lambda x: -x[1])
+    for name, total in rows:
+        n = _counts[name]
+        avg = total / n
+        terminalreporter.write_line(
+            f"{total:6.2f}s total  {avg:.4f}s/param  {n:>5} params  {name}"
+        )
+
 
 # Named tuple for model fixture returns (clearer than tuple indexing)
 ModelFixture = namedtuple(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,17 @@ from nemos.tree_utils import tree_full_like
 _totals = defaultdict(float)
 _counts = defaultdict(int)
 
+_TIMEIT_ENABLED = False
+
+
+def pytest_configure(config):
+    global _TIMEIT_ENABLED
+    _TIMEIT_ENABLED = config.getoption("timeit")
+
 
 def pytest_runtest_logreport(report):
+    if not _TIMEIT_ENABLED:
+        return
     if report.when == "call":
         # strip [param] suffix to group by base test name
         base = re.sub(r"\[.*\]$", "", report.nodeid)
@@ -48,6 +57,8 @@ def pytest_runtest_logreport(report):
 
 
 def pytest_terminal_summary(terminalreporter):
+    if not _TIMEIT_ENABLED:
+        return
     terminalreporter.write_sep("=", "aggregated param durations")
     rows = sorted(_totals.items(), key=lambda x: -x[1])
     for name, total in rows:

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -10,12 +10,12 @@ import pytest
 import scipy as sp
 import scipy.stats as sts
 import statsmodels.api as sm
-
-# Import helpers from conftest
-from conftest import is_population_model
 from numba import njit
 
 import nemos as nmo
+
+# Import helpers from conftest
+from conftest import is_population_model
 from nemos._observation_model_builder import AVAILABLE_OBSERVATION_MODELS
 from nemos.glm.params import GLMParams
 from nemos.glm.validation import (

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -11,6 +11,10 @@ import jax.numpy
 import numpy as np
 import pynapple as nap
 import pytest
+
+import nemos._inspect_utils as inspect_utils
+import nemos.basis.basis as basis
+import nemos.convolve as convolve
 from conftest import (
     DEFAULT_KWARGS,
     BasisFuncsTesting,
@@ -21,10 +25,6 @@ from conftest import (
     list_all_basis_classes,
     list_all_real_basis_classes,
 )
-
-import nemos._inspect_utils as inspect_utils
-import nemos.basis.basis as basis
-import nemos.convolve as convolve
 from nemos.basis import (
     CustomBasis,
     FourierEval,

--- a/tests/test_custom_basis.py
+++ b/tests/test_custom_basis.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import numpy as np
 import pynapple as nap
 import pytest
+from numpy.typing import NDArray
+
 from conftest import (
     SizeTerminal,
     basis_collapse_all_non_vec_axis,
@@ -12,8 +14,6 @@ from conftest import (
     custom_basis,
     custom_basis_2d,
 )
-from numpy.typing import NDArray
-
 from nemos.basis._custom_basis import CustomBasis, apply_f_vectorized
 
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -11,7 +11,6 @@ import pytest
 import scipy.stats as sts
 import sklearn
 import statsmodels.api as sm
-from conftest import initialize_feature_mask_for_population_glm
 from pynapple import Tsd, TsdFrame
 from sklearn.linear_model import (
     GammaRegressor,
@@ -22,6 +21,7 @@ from sklearn.linear_model import (
 from sklearn.model_selection import GridSearchCV
 
 import nemos as nmo
+from conftest import initialize_feature_mask_for_population_glm
 from nemos._observation_model_builder import instantiate_observation_model
 from nemos._regularizer_builder import instantiate_regularizer
 from nemos.inverse_link_function_utils import identity, log_softmax

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1751,95 +1751,6 @@ class TestGLMObservationModel:
             raise ValueError("Unknown model instantiation")
 
     @pytest.fixture
-    def dof_lasso_strength(self, model_instantiation):
-        """
-        Fixture for test_estimate_dof_resid
-        """
-        if "poisson" in model_instantiation:
-            return 1.0
-
-        elif "gamma" in model_instantiation:
-            return 0.02
-
-        elif "bernoulli" in model_instantiation:
-            return 0.1
-
-        elif "negativeBinomial" in model_instantiation:
-            return 0.01
-
-        elif "gaussian" in model_instantiation:
-            return 1.0
-
-        elif "classifier" in model_instantiation:
-            return 0.1
-
-        else:
-            raise ValueError("Unknown model instantiation")
-
-    @pytest.fixture
-    def dof_lasso_dof(self, glm_type, model_instantiation):
-        """
-        Fixture for test_estimate_dof_resid
-        """
-        if "poisson" in model_instantiation:
-            if is_population_glm_type(glm_type):
-                return np.array([3, 0, 0])
-            else:
-                return np.array([3])
-
-        elif "gamma" in model_instantiation:
-            if is_population_glm_type(glm_type):
-                return np.array([1, 4, 3])
-            else:
-                return np.array([3])
-
-        elif "bernoulli" in model_instantiation:
-            if is_population_glm_type(glm_type):
-                return np.array([3, 2, 1])
-            else:
-                return np.array([3])
-
-        elif "negativeBinomial" in model_instantiation:
-            if is_population_glm_type(glm_type):
-                return np.array([3, 2, 4])
-            else:
-                return np.array([5])
-
-        elif "gaussian" in model_instantiation:
-            if is_population_glm_type(glm_type):
-                return np.array([5, 5, 5])
-            else:
-                return np.array([3])
-
-        elif "classifier" in model_instantiation:
-            # Classifier models have (n_features, n_classes) coef shape
-            # For lasso, count surviving coefficients across all classes
-            # Note: LASSO convergence can vary slightly across environments
-            if is_population_glm_type(glm_type):
-                return np.array([6, 4, 5])
-            else:
-                return np.array([5])
-
-        else:
-            raise ValueError("Unknown model instantiation")
-
-    @pytest.fixture
-    def dof_non_lasso_dof(self, glm_type, model_instantiation):
-        """
-        Fixture for test_estimate_dof_resid
-        """
-        if "classifier" in model_instantiation:
-            if "population" in glm_type:
-                return np.array([10, 10, 10])
-            else:
-                return np.array([10])
-        else:
-            if "population" in glm_type:
-                return np.array([5, 5, 5])
-            else:
-                return np.array([5])
-
-    @pytest.fixture
     def obs_has_defaults(self, model_instantiation):
         """
         Fixture for test_optimize_solver_params
@@ -2049,44 +1960,6 @@ class TestGLMObservationModel:
     #####################
     # Test model.update #
     #####################
-    @pytest.mark.parametrize(
-        "n_samples, expectation",
-        [
-            (None, does_not_raise()),
-            (100, does_not_raise()),
-            (
-                1.0,
-                pytest.raises(
-                    TypeError, match="`n_samples` must be `None` or of type `int`"
-                ),
-            ),
-            (
-                "str",
-                pytest.raises(
-                    TypeError, match="`n_samples` must be `None` or of type `int`"
-                ),
-            ),
-        ],
-    )
-    @pytest.mark.parametrize("batch_size", [1, 10])
-    @pytest.mark.solver_related
-    def test_update_n_samples(
-        self, n_samples, expectation, batch_size, request, glm_type, model_instantiation
-    ):
-        X, y, model, true_params, firing_rate = request.getfixturevalue(
-            glm_type + model_instantiation
-        )
-        params = model.initialize_params(X, y)
-        state = model.initialize_optimizer_and_state(params, X, y)
-        with expectation:
-            model.update(
-                params,
-                state,
-                X[:batch_size],
-                y[:batch_size],
-                n_samples=n_samples,
-            )
-
     @pytest.mark.parametrize("batch_size", [1, 10])
     @pytest.mark.solver_related
     def test_update_params_stored(
@@ -2106,92 +1979,6 @@ class TestGLMObservationModel:
         assert model.coef_ is not None
         assert model.intercept_ is not None
         assert model.scale_ is not None
-
-    @pytest.mark.parametrize("nan_inputs", [True, False])
-    @pytest.mark.parametrize(
-        "solver_name", ["ProximalGradient", "GradientDescent", "LBFGS", "BFGS"]
-    )
-    @pytest.mark.solver_related
-    def test_update_params_are_finite(
-        self, nan_inputs, solver_name, request, glm_type, model_instantiation
-    ):
-        """
-        Fitting a GLM to data containing NaNs with the jaxopt.LBFGS solver worked when using GLM.fit,
-        but not when writing the training loop in Python and calling GLM.update repeatedly.
-        The problem was that this solver uses the data to initialize its state, and the state was populated
-        with NaNs by GLM.initialize_state.
-        The solution was dropping NaNs from the input data in GLM.initialize_state -- as is done in GLM.update and GLM.run.
-        """
-        X, y, model, true_params, firing_rate = request.getfixturevalue(
-            glm_type + model_instantiation
-        )
-        model.solver_name = solver_name
-
-        if nan_inputs:
-            X[: X.shape[0] // 2, :] = np.nan
-
-        params = model.initialize_params(X, y)
-        state = model.initialize_optimizer_and_state(params, X, y)
-        assert model.coef_ is None
-        assert model.intercept_ is None
-        if "gamma" not in model_instantiation and "gaussian" not in model_instantiation:
-            # gamma model instantiation sets the scale
-            assert model.scale_ is None
-
-        # take an update step using the initialized state
-        _, _ = model.update(params, state, X, y)
-
-        assert model.coef_ is not None
-        assert model.intercept_ is not None
-        assert model.scale_ is not None
-
-        # parameters should not have NaN
-        assert jnp.all(jnp.isfinite(model.coef_))
-        assert jnp.all(jnp.isfinite(model.intercept_))
-        assert jnp.all(jnp.isfinite(model.scale_))
-
-    @pytest.mark.parametrize("batch_size", [2, 10])
-    @pytest.mark.solver_related
-    @pytest.mark.requires_x64
-    def test_update_nan_drop_at_jit_comp(
-        self, batch_size, request, glm_type, model_instantiation
-    ):
-        """Test that jit compilation does not affect the update in the presence of nans."""
-        X, y, model, true_params, firing_rate = request.getfixturevalue(
-            glm_type + model_instantiation
-        )
-        model.solver_kwargs.update({"stepsize": 0.01})
-        params = model.initialize_params(X, y)
-        state = model.initialize_optimizer_and_state(params, X, y)
-        # extract batch and add nans
-        Xnan = X[:batch_size]
-        Xnan[: batch_size // 2] = np.nan
-
-        # run 3 iterations
-        tot_iter = 3
-        jit_update = deepcopy(params)
-        jit_state = deepcopy(state)
-        for _ in range(tot_iter):
-            jit_update, jit_state = model.update(
-                jit_update, jit_state, Xnan, y[:batch_size]
-            )
-        # make sure there is an update
-        assert not jnp.allclose(params[0], jit_update[0]) or not jnp.allclose(
-            params[1], jit_update[1]
-        )
-
-        # update without jitting
-        nojit_update = deepcopy(params)
-        nojit_state = deepcopy(state)
-        with jax.disable_jit(True):
-            for _ in range(tot_iter):
-                nojit_update, nojit_state = model.update(
-                    nojit_update, nojit_state, Xnan, y[:batch_size]
-                )
-        # check for equivalence update
-        assert jnp.allclose(nojit_update[0], jit_update[0]) and jnp.allclose(
-            nojit_update[1], jit_update[1]
-        )
 
     #######################
     # Test model.simulate #
@@ -2271,20 +2058,6 @@ class TestGLMObservationModel:
     ########################################
     # Compare with standard implementation #
     ########################################
-    @pytest.mark.solver_related
-    @pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
-    def test_compatibility_with_sklearn_cv(
-        self, request, glm_type, model_instantiation
-    ):
-        X, y, model, true_params, firing_rate = request.getfixturevalue(
-            glm_type + model_instantiation
-        )
-        param_grid = {"solver_name": ["BFGS", "GradientDescent"]}
-        model.solver_kwargs.update(dict(maxiter=2))
-        cls = GridSearchCV(model, param_grid).fit(X, y)
-        # check that the repr works after cloning
-        repr(cls)
-
     @staticmethod
     def _format_sklearn_params(sklearn_model, nemos_model):
         """Format sklearn params for comparison with nemos.
@@ -2466,60 +2239,9 @@ class TestGLMObservationModel:
             model.coef_
         ) == jax.tree_util.tree_structure(X)
 
-    #####################
-    # Test residual DOF #
-    #####################
-    @pytest.mark.parametrize(
-        "reg, dof, strength",
-        [
-            (nmo.regularizer.UnRegularized(), "dof_non_lasso_dof", None),
-            (
-                nmo.regularizer.Lasso(),
-                "dof_lasso_dof",
-                "dof_lasso_strength",
-            ),  # this lasso fit has only 3 coeff of the first neuron
-            # surviving
-            (nmo.regularizer.Ridge(), "dof_non_lasso_dof", 1.0),
-        ],
-    )
-    @pytest.mark.parametrize("n_samples", [1, 20])
-    @pytest.mark.solver_related
-    @pytest.mark.requires_x64
-    def test_estimate_dof_resid(
-        self,
-        n_samples,
-        strength,
-        dof,
-        reg,
-        request,
-        glm_type,
-        model_instantiation,
-    ):
-        """
-        Test that the dof is an integer.
-        """
-        X, y, model, true_params, firing_rate = request.getfixturevalue(
-            glm_type + model_instantiation
-        )
-        # different dof for different obs models with lasso
-        dof = request.getfixturevalue(dof)
-        # need different strengths for different obs models with lasso reg
-        # for 3 coefs to survive
-        if isinstance(strength, str):
-            strength = request.getfixturevalue(strength)
-        n_m1_classes = getattr(model, "n_classes", 2) - 1
-        model.set_params(regularizer=reg, regularizer_strength=strength)
-        model.solver_name = model.regularizer.default_solver
-        model.solver_kwargs.update({"maxiter": 10**5})
-        model.fit(X, y)
-        num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
-        expected_dof_resid = n_samples - dof - n_m1_classes
-        assert np.allclose(num, expected_dof_resid)
-
     ######################
     # Optimizer defaults #
     ######################
-    @pytest.mark.parametrize("reg_setup", ["", "_pytree"])
     @pytest.mark.parametrize("batch_size", [None, 1, 10])
     @pytest.mark.parametrize("stepsize", [None, 0.01])
     @pytest.mark.parametrize(
@@ -2552,13 +2274,10 @@ class TestGLMObservationModel:
         obs_has_defaults,
         request,
         glm_type,
-        reg_setup,
         model_instantiation,
     ):
         """Test the behavior of `optimize_solver_params` for different solver, regularizer, and observation model configurations."""
-        X, y, model, _, _ = request.getfixturevalue(
-            glm_type + model_instantiation + reg_setup
-        )
+        X, y, model, _, _ = request.getfixturevalue(glm_type + model_instantiation)
 
         obs = model.observation_model
         model.inverse_link_function = inv_link
@@ -2979,6 +2698,259 @@ class TestPopulationGLM:
             model.initialize_params(X_pytree, y)
 
 
+# -----------------------------------------------------------------------
+# test_estimate_dof_resid
+# Moved out of TestGLMObservationModel. _estimate_resid_degrees_of_freedom
+# only reads coef_, intercept_, regularizer, and X — it never calls any
+# obs-model method.  We therefore set those attributes directly to a fixed
+# sparse state and bypass model.fit entirely.
+# -----------------------------------------------------------------------
+_DOF_N_FEATURES = 5  # features in the test design matrix
+_DOF_N_NEURONS = 3  # neurons for population models
+_DOF_N_CLASSES = 3  # classes for classifier models
+
+
+def _set_sparse_state(model, glm_type, model_instantiation):
+    """Assign a fixed sparse coef_/intercept_ and return (X, n_nonzero).
+
+    X is the (_DOF_N_FEATURES × _DOF_N_FEATURES) identity matrix (full rank).
+    n_nonzero is the count of non-zero coefficients, shaped to match the
+    output of _estimate_resid_degrees_of_freedom for Lasso-type regularizers.
+    """
+    nf = _DOF_N_FEATURES
+    X = jnp.eye(nf)
+    is_pop = "population_" in glm_type
+    is_cls = "classifier" in model_instantiation
+
+    if is_pop and is_cls:
+        # coef shape: (nf, n_neurons, n_classes)
+        # Set first 3 features, all neurons, first class = 1 → 3 non-zeros/neuron
+        coef = jnp.zeros((nf, _DOF_N_NEURONS, _DOF_N_CLASSES)).at[:3, :, 0].set(1.0)
+        intercept = jnp.zeros((_DOF_N_NEURONS, _DOF_N_CLASSES))
+        n_nonzero = jnp.full((_DOF_N_NEURONS,), 3)
+    elif is_pop:
+        # coef shape: (nf, n_neurons)
+        coef = (
+            jnp.zeros((nf, _DOF_N_NEURONS)).at[:3, 0].set(1.0).at[:1, 1].set(1.0)
+        )  # neuron 0: 3, neuron 1: 1, neuron 2: 0
+        intercept = jnp.zeros((_DOF_N_NEURONS,))
+        n_nonzero = jnp.array([3, 1, 0])
+    elif is_cls:
+        # coef shape: (nf, n_classes)
+        coef = jnp.zeros((nf, _DOF_N_CLASSES)).at[:3, 0].set(1.0)  # 3 non-zeros
+        intercept = jnp.zeros((_DOF_N_CLASSES,))
+        n_nonzero = 3
+    else:
+        # coef shape: (nf,)
+        coef = jnp.zeros((nf,)).at[:3].set(1.0)  # 3 non-zeros
+        intercept = jnp.zeros((1,))
+        n_nonzero = 3
+
+    model.coef_ = coef
+    model.intercept_ = intercept
+    return X, n_nonzero
+
+
+@pytest.mark.parametrize("glm_type", ["", "population_"])
+@pytest.mark.parametrize(
+    "model_instantiation",
+    ["poissonGLM_model_instantiation", "classifierGLM_model_instantiation"],
+)
+@pytest.mark.parametrize(
+    "reg",
+    [
+        nmo.regularizer.UnRegularized(),
+        nmo.regularizer.Lasso(),
+        nmo.regularizer.Ridge(),
+    ],
+)
+@pytest.mark.parametrize("n_samples", [1, 20])
+@pytest.mark.requires_x64
+def test_estimate_dof_resid(n_samples, reg, request, glm_type, model_instantiation):
+    """_estimate_resid_degrees_of_freedom returns the correct residual DOF.
+
+    Uses a fixed sparse coef_ so no solver run is needed.
+    """
+    _, _, model, _, _ = request.getfixturevalue(glm_type + model_instantiation)
+    model.set_params(regularizer=reg)
+
+    X, n_nonzero = _set_sparse_state(model, glm_type, model_instantiation)
+
+    is_cls = "classifier" in model_instantiation
+    n_m1_classes = getattr(model, "n_classes", 2) - 1
+
+    if isinstance(reg, (nmo.regularizer.Lasso, nmo.regularizer.ElasticNet)):
+        dof = n_nonzero
+    elif isinstance(reg, nmo.regularizer.Ridge):
+        dof = n_m1_classes * _DOF_N_FEATURES if is_cls else _DOF_N_FEATURES
+    else:  # UnRegularized
+        rank = int(jnp.linalg.matrix_rank(X))
+        dof = rank * n_m1_classes if is_cls else rank
+
+    expected = n_samples - dof - n_m1_classes
+    num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
+    assert np.allclose(num, expected)
+
+
+# Tests moved out of TestGLMObservationModel because the behaviour under test
+# lives in the base class and does not vary across observation models.
+# Using only two representative observation models (Poisson + Gaussian) keeps
+# coverage while avoiding redundant JAX recompilation for every obs model.
+_UPDATE_GLM_TYPES = ["", "population_"]
+_UPDATE_MODEL_INSTANTIATIONS = [
+    "poissonGLM_model_instantiation",
+    "gaussianGLM_model_instantiation",
+]
+
+
+@pytest.mark.parametrize("glm_type", _UPDATE_GLM_TYPES)
+@pytest.mark.parametrize("model_instantiation", _UPDATE_MODEL_INSTANTIATIONS)
+@pytest.mark.parametrize(
+    "n_samples, expectation",
+    [
+        (None, does_not_raise()),
+        (100, does_not_raise()),
+        (
+            1.0,
+            pytest.raises(
+                TypeError, match="`n_samples` must be `None` or of type `int`"
+            ),
+        ),
+        (
+            "str",
+            pytest.raises(
+                TypeError, match="`n_samples` must be `None` or of type `int`"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.solver_related
+def test_update_n_samples(
+    n_samples, expectation, batch_size, request, glm_type, model_instantiation
+):
+    X, y, model, true_params, firing_rate = request.getfixturevalue(
+        glm_type + model_instantiation
+    )
+    params = model.initialize_params(X, y)
+    state = model.initialize_optimizer_and_state(params, X, y)
+    with expectation:
+        model.update(
+            params,
+            state,
+            X[:batch_size],
+            y[:batch_size],
+            n_samples=n_samples,
+        )
+
+
+@pytest.mark.parametrize("glm_type", _UPDATE_GLM_TYPES)
+@pytest.mark.parametrize("model_instantiation", _UPDATE_MODEL_INSTANTIATIONS)
+@pytest.mark.parametrize("nan_inputs", [True, False])
+@pytest.mark.parametrize(
+    "solver_name", ["ProximalGradient", "GradientDescent", "LBFGS", "BFGS"]
+)
+@pytest.mark.solver_related
+def test_update_params_are_finite(
+    nan_inputs, solver_name, request, glm_type, model_instantiation
+):
+    """
+    Fitting a GLM to data containing NaNs with the jaxopt.LBFGS solver worked when using GLM.fit,
+    but not when writing the training loop in Python and calling GLM.update repeatedly.
+    The problem was that this solver uses the data to initialize its state, and the state was populated
+    with NaNs by GLM.initialize_state.
+    The solution was dropping NaNs from the input data in GLM.initialize_state -- as is done in GLM.update and GLM.run.
+    """
+    X, y, model, true_params, firing_rate = request.getfixturevalue(
+        glm_type + model_instantiation
+    )
+    model.solver_name = solver_name
+
+    if nan_inputs:
+        X[: X.shape[0] // 2, :] = np.nan
+
+    params = model.initialize_params(X, y)
+    state = model.initialize_optimizer_and_state(params, X, y)
+    assert model.coef_ is None
+    assert model.intercept_ is None
+    if "gamma" not in model_instantiation and "gaussian" not in model_instantiation:
+        # gamma model instantiation sets the scale
+        assert model.scale_ is None
+
+    # take an update step using the initialized state
+    _, _ = model.update(params, state, X, y)
+
+    assert model.coef_ is not None
+    assert model.intercept_ is not None
+    assert model.scale_ is not None
+
+    # parameters should not have NaN
+    assert jnp.all(jnp.isfinite(model.coef_))
+    assert jnp.all(jnp.isfinite(model.intercept_))
+    assert jnp.all(jnp.isfinite(model.scale_))
+
+
+@pytest.mark.parametrize("glm_type", _UPDATE_GLM_TYPES)
+@pytest.mark.parametrize("model_instantiation", _UPDATE_MODEL_INSTANTIATIONS)
+@pytest.mark.parametrize("batch_size", [10])
+@pytest.mark.solver_related
+@pytest.mark.requires_x64
+def test_update_nan_drop_at_jit_comp(
+    batch_size, request, glm_type, model_instantiation
+):
+    """Test that jit compilation does not affect the update in the presence of nans."""
+    X, y, model, true_params, firing_rate = request.getfixturevalue(
+        glm_type + model_instantiation
+    )
+    model.solver_kwargs.update({"stepsize": 0.01})
+    params = model.initialize_params(X, y)
+    state = model.initialize_optimizer_and_state(params, X, y)
+    # extract batch and add nans
+    Xnan = X[:batch_size]
+    Xnan[: batch_size // 2] = np.nan
+
+    # run 3 iterations
+    tot_iter = 1
+    jit_update = deepcopy(params)
+    jit_state = deepcopy(state)
+    for _ in range(tot_iter):
+        jit_update, jit_state = model.update(
+            jit_update, jit_state, Xnan, y[:batch_size]
+        )
+    # make sure there is an update
+    assert not jnp.allclose(params[0], jit_update[0]) or not jnp.allclose(
+        params[1], jit_update[1]
+    )
+
+    # update without jitting
+    nojit_update = deepcopy(params)
+    nojit_state = deepcopy(state)
+    with jax.disable_jit(True):
+        for _ in range(tot_iter):
+            nojit_update, nojit_state = model.update(
+                nojit_update, nojit_state, Xnan, y[:batch_size]
+            )
+    # check for equivalence update
+    assert jnp.allclose(nojit_update[0], jit_update[0]) and jnp.allclose(
+        nojit_update[1], jit_update[1]
+    )
+
+
+@pytest.mark.parametrize("glm_type", _UPDATE_GLM_TYPES)
+@pytest.mark.parametrize("model_instantiation", _UPDATE_MODEL_INSTANTIATIONS)
+@pytest.mark.solver_related
+@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
+def test_compatibility_with_sklearn_cv(request, glm_type, model_instantiation):
+    X, y, model, true_params, firing_rate = request.getfixturevalue(
+        glm_type + model_instantiation
+    )
+    param_grid = {"solver_name": ["BFGS", "GradientDescent"]}
+    model.solver_kwargs.update(dict(maxiter=2))
+    cls = GridSearchCV(model, param_grid).fit(X, y)
+    # check that the repr works after cloning
+    repr(cls)
+
+
 @pytest.mark.parametrize(
     "model_instantiation",
     [
@@ -3311,7 +3283,7 @@ class TestPoissonGLM:
 
     @pytest.mark.parametrize("glm_type", ["", "population_"])
     @pytest.mark.parametrize("regr_setup", ["", "_pytree"])
-    @pytest.mark.parametrize("key", [jax.random.key(0), jax.random.key(19)])
+    @pytest.mark.parametrize("key", [jax.random.key(0)])
     @pytest.mark.parametrize(
         "regularizer_class, solver_name",
         [
@@ -3345,7 +3317,7 @@ class TestPoissonGLM:
 
         N = y.shape[0]
         batch_size = 1
-        maxiter = 3  # number of epochs
+        maxiter = 1  # number of epochs
         tol = 1e-12
         stepsize = 1e-3
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -3033,7 +3033,6 @@ class TestPopulationGLMObservationModel:
                     [0, 1, 0],
                 ]
             ),
-            {"input_1": np.array([0, 1, 0]), "input_2": np.array([1, 0, 1])},
         ],
     )
     @pytest.mark.solver_related

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2808,6 +2808,18 @@ def test_estimate_dof_resid(n_samples, reg, request, glm_type, model_instantiati
     assert np.allclose(num, expected)
 
 
+@pytest.mark.parametrize("glm_type", ["", "population_"])
+@pytest.mark.requires_x64
+def test_estimate_dof_resid_classifier_invalid_n_samples(glm_type, request):
+    """ClassifierGLM._estimate_resid_degrees_of_freedom raises TypeError for non-int n_samples."""
+    _, _, model, _, _ = request.getfixturevalue(
+        glm_type + "classifierGLM_model_instantiation"
+    )
+    X, _ = _set_sparse_state(model, glm_type, "classifierGLM_model_instantiation")
+    with pytest.raises(TypeError, match="`n_samples` must be `None` or of type `int`"):
+        model._estimate_resid_degrees_of_freedom(X, n_samples=1.0)
+
+
 # Tests moved out of TestGLMObservationModel because the behaviour under test
 # lives in the base class and does not vary across observation models.
 # Using only two representative observation models (Poisson + Gaussian) keeps
@@ -2879,7 +2891,6 @@ def test_update_params_are_finite(
     request,
     glm_type,
     model_instantiation,
-    mock_optimizer_update,
 ):
     """
     Fitting a GLM to data containing NaNs with the jaxopt.LBFGS solver worked when using GLM.fit,

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -175,7 +175,9 @@ def model_instantiation_type(glm_class_type):
 @pytest.mark.parametrize("glm_class_type", ["glm_class", "population_glm_class"])
 @pytest.mark.solver_related
 @pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
-def test_get_fit_attrs(request, glm_class_type, model_instantiation_type):
+def test_get_fit_attrs(
+    request, glm_class_type, model_instantiation_type, mock_optimizer_run
+):
     X, y, model = request.getfixturevalue(model_instantiation_type)[:3]
     expected_state = {
         "coef_": None,
@@ -186,7 +188,6 @@ def test_get_fit_attrs(request, glm_class_type, model_instantiation_type):
         "aux_": None,
     }
     assert model._get_fit_state() == expected_state
-    model.solver_kwargs = {"maxiter": 1}
     model.fit(X, y)
     assert not model._has_aux
     assert all(
@@ -242,6 +243,7 @@ class TestGLM:
         request,
         glm_class_type,
         model_instantiation_type,
+        mock_optimizer_run,
     ):
         """
         Test the `fit` method with weight matrices of different dimensionalities.
@@ -276,6 +278,7 @@ class TestGLM:
         request,
         glm_class_type,
         model_instantiation_type,
+        mock_optimizer_run,
     ):
         """
         Test the `fit` method with intercepts of different dimensionalities. Check for correct dimensionality.
@@ -431,6 +434,7 @@ class TestGLM:
         model_instantiation_type,
         expectation,
         init_params_by_model,
+        mock_optimizer_run,
     ):
         """
         Test the `fit` method with various types of initial parameters. Ensure that the provided initial parameters
@@ -459,6 +463,7 @@ class TestGLM:
         request,
         glm_class_type,
         model_instantiation_type,
+        mock_optimizer_run,
     ):
         """
         Test the `fit` method for inconsistencies between data features and initial weights provided.
@@ -657,7 +662,13 @@ class TestGLM:
         ],
     )
     def test_predict_is_fit(
-        self, is_fit, expectation, request, glm_class_type, model_instantiation_type
+        self,
+        is_fit,
+        expectation,
+        request,
+        glm_class_type,
+        model_instantiation_type,
+        mock_glm_fit,
     ):
         """
         Test the `score` method on models based on their fit status.
@@ -2228,12 +2239,16 @@ class TestGLMObservationModel:
     @pytest.mark.parametrize("pytree_x_factory", _PYTREE_X_FACTORIES)
     @pytest.mark.solver_related
     def test_coef_tree_structure_after_fit_pytree_x(
-        self, pytree_x_factory, request, glm_type, model_instantiation
+        self,
+        pytree_x_factory,
+        request,
+        glm_type,
+        model_instantiation,
+        mock_optimizer_run,
     ):
         """model.coef_ tree structure matches X structure after fit with pytree X."""
         _, y, model, _, _ = request.getfixturevalue(glm_type + model_instantiation)
         X = pytree_x_factory(y.shape[0])
-        model.solver_kwargs = {"maxiter": 1}
         model.fit(X, y)
         assert jax.tree_util.tree_structure(
             model.coef_
@@ -2339,7 +2354,9 @@ class TestGLMObservationModel:
 
     @pytest.mark.solver_related
     @pytest.mark.requires_x64
-    def test_fit_mask_grouplasso(self, glm_type, model_instantiation, request):
+    def test_fit_mask_grouplasso(
+        self, glm_type, model_instantiation, request, mock_optimizer_run
+    ):
         """Test that the group lasso fit goes through"""
         X, y, model, _, _ = request.getfixturevalue(glm_type + model_instantiation)
 
@@ -2619,8 +2636,9 @@ class TestPopulationGLM:
             "_pytree",
         ],
     )
-    @pytest.mark.solver_related
-    def test_metadata_pynapple_fit(self, model_suffix, request, model_instantiation):
+    def test_metadata_pynapple_fit(
+        self, model_suffix, request, model_instantiation, mock_optimizer_run
+    ):
         X, y, model, true_params, firing_rate = request.getfixturevalue(
             model_instantiation + model_suffix
         )
@@ -2639,9 +2657,8 @@ class TestPopulationGLM:
             "_pytree",
         ],
     )
-    @pytest.mark.solver_related
     def test_metadata_pynapple_is_deepcopied(
-        self, model_suffix, model_instantiation, request
+        self, model_suffix, model_instantiation, request, mock_optimizer_run
     ):
         X, y, model, true_params, firing_rate = request.getfixturevalue(
             model_instantiation + model_suffix
@@ -2664,9 +2681,8 @@ class TestPopulationGLM:
             "_pytree",
         ],
     )
-    @pytest.mark.solver_related
     def test_metadata_pynapple_predict(
-        self, model_suffix, model_instantiation, request
+        self, model_suffix, model_instantiation, request, mock_optimizer_run
     ):
         X, y, model, true_params, firing_rate = request.getfixturevalue(
             model_instantiation + model_suffix
@@ -2827,7 +2843,13 @@ _UPDATE_MODEL_INSTANTIATIONS = [
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.solver_related
 def test_update_n_samples(
-    n_samples, expectation, batch_size, request, glm_type, model_instantiation
+    n_samples,
+    expectation,
+    batch_size,
+    request,
+    glm_type,
+    model_instantiation,
+    mock_optimizer_update,
 ):
     X, y, model, true_params, firing_rate = request.getfixturevalue(
         glm_type + model_instantiation
@@ -2852,7 +2874,12 @@ def test_update_n_samples(
 )
 @pytest.mark.solver_related
 def test_update_params_are_finite(
-    nan_inputs, solver_name, request, glm_type, model_instantiation
+    nan_inputs,
+    solver_name,
+    request,
+    glm_type,
+    model_instantiation,
+    mock_optimizer_update,
 ):
     """
     Fitting a GLM to data containing NaNs with the jaxopt.LBFGS solver worked when using GLM.fit,
@@ -2940,12 +2967,13 @@ def test_update_nan_drop_at_jit_comp(
 @pytest.mark.parametrize("model_instantiation", _UPDATE_MODEL_INSTANTIATIONS)
 @pytest.mark.solver_related
 @pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
-def test_compatibility_with_sklearn_cv(request, glm_type, model_instantiation):
+def test_compatibility_with_sklearn_cv(
+    request, glm_type, model_instantiation, mock_glm_fit
+):
     X, y, model, true_params, firing_rate = request.getfixturevalue(
         glm_type + model_instantiation
     )
     param_grid = {"solver_name": ["BFGS", "GradientDescent"]}
-    model.solver_kwargs.update(dict(maxiter=2))
     cls = GridSearchCV(model, param_grid).fit(X, y)
     # check that the repr works after cloning
     repr(cls)

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -3008,28 +3008,16 @@ class TestPopulationGLMObservationModel:
                 {"tol": 10**-9},
             ),
             (
-                nmo.regularizer.Ridge(),
-                1.0,
-                "LBFGS",
-                {"stepsize": 0.1, "tol": 10**-9},
-            ),
-            (
                 nmo.regularizer.Lasso(),
                 0.001,
                 "ProximalGradient",
-                {"tol": 10**-8, "maxiter": 10**5},
-            ),
-            (
-                nmo.regularizer.Lasso(),
-                0.1,
-                "ProximalGradient",
-                {"tol": 10**-14},
+                {"tol": 10**-8, "maxiter": 10**3},
             ),
             (
                 nmo.regularizer.ElasticNet(),
                 (1.0, 0.5),
                 "ProximalGradient",
-                {"tol": 10**-14},
+                {"tol": 10**-8},
             ),
         ],
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,6 +9,8 @@ from sklearn.pipeline import Pipeline
 from nemos import basis
 from nemos.basis._transformer_basis import TransformerBasis
 
+# mock_glm_fit, mock_optimizer_run, mock_optimizer_update are defined in conftest.py
+
 
 @pytest.mark.parametrize(
     "bas",
@@ -20,10 +22,10 @@ from nemos.basis._transformer_basis import TransformerBasis
         basis.RaisedCosineLinearEval(5),
     ],
 )
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
-def test_sklearn_transformer_pipeline(bas, poissonGLM_model_instantiation):
+def test_sklearn_transformer_pipeline(
+    bas, poissonGLM_model_instantiation, mock_glm_fit
+):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = TransformerBasis(bas).set_input_shape(*([1] * bas._n_inputs))
     pipe = pipeline.Pipeline([("eval", bas), ("fit", model)])
     pipe.fit(X[:, : bas.basis._n_inputs] ** 2, y)
@@ -37,10 +39,10 @@ def test_sklearn_transformer_pipeline(bas, poissonGLM_model_instantiation):
         basis.RaisedCosineLogEval(5),
     ],
 )
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
-def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
+def test_sklearn_transformer_pipeline_cv(
+    bas, poissonGLM_model_instantiation, mock_glm_fit
+):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = TransformerBasis(bas).set_input_shape(*([1] * bas._n_inputs))
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
     param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
@@ -48,10 +50,8 @@ def test_sklearn_transformer_pipeline_cv(bas, poissonGLM_model_instantiation):
     gridsearch.fit(X[:, : bas._n_inputs] ** 2, y)
 
 
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
-def test_sklearn_cv_clone(population_poissonGLM_model_instantiation):
+def test_sklearn_cv_clone(population_poissonGLM_model_instantiation, mock_glm_fit):
     X, y, model, _, _ = population_poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = basis.CyclicBSplineEval(5)
     bas = TransformerBasis(bas).set_input_shape(*([1] * bas._n_inputs))
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
@@ -71,12 +71,10 @@ def test_sklearn_cv_clone(population_poissonGLM_model_instantiation):
         basis.RaisedCosineLogEval(5),
     ],
 )
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
 def test_sklearn_transformer_pipeline_cv_multiprocess(
-    bas, poissonGLM_model_instantiation
+    bas, poissonGLM_model_instantiation, mock_glm_fit
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = TransformerBasis(bas).set_input_shape(*([1] * bas._n_inputs))
     pipe = pipeline.Pipeline([("basis", bas), ("fit", model)])
     param_grid = dict(basis__n_basis_funcs=(4, 5, 10))
@@ -98,12 +96,10 @@ def test_sklearn_transformer_pipeline_cv_multiprocess(
         basis.RaisedCosineLogEval,
     ],
 )
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
 def test_sklearn_transformer_pipeline_cv_directly_over_basis(
-    bas_cls, poissonGLM_model_instantiation
+    bas_cls, poissonGLM_model_instantiation, mock_glm_fit
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = TransformerBasis(bas_cls(5))
     bas.set_input_shape(*([1] * bas._n_inputs))
     pipe = pipeline.Pipeline([("transformerbasis", bas), ("fit", model)])
@@ -128,12 +124,10 @@ def test_sklearn_transformer_pipeline_cv_directly_over_basis(
         basis.RaisedCosineLogEval,
     ],
 )
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
 def test_sklearn_transformer_pipeline_cv_illegal_combination(
-    bas_cls, poissonGLM_model_instantiation
+    bas_cls, poissonGLM_model_instantiation, mock_glm_fit
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = TransformerBasis(bas_cls(5))
     bas.set_input_shape(*([1] * bas._n_inputs))
     pipe = pipeline.Pipeline([("transformerbasis", bas), ("fit", model)])
@@ -186,13 +180,11 @@ def test_sklearn_transformer_pipeline_cv_illegal_combination(
         ),
     ],
 )
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
 def test_sklearn_transformer_pipeline_pynapple(
-    bas, poissonGLM_model_instantiation, expected_nans
+    bas, poissonGLM_model_instantiation, expected_nans, mock_glm_fit
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
     X = X[:, :2]
-    model.solver_kwargs.update({"maxiter": 2})
     # transform input to pynapple
     ep = nap.IntervalSet(start=[0, 20.5], end=[20, X.shape[0]])
     X_nap = nap.TsdFrame(t=np.arange(X.shape[0]), d=X, time_support=ep)
@@ -276,12 +268,10 @@ def test_pipeline_multiplicative_bases_with_labels(poissonGLM_model_instantiatio
     assert all(new_items[k] == nem_params[k] for k in new_items.keys())
 
 
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
 def test_cross_validate_multiplicative_basis_in_pipe_with_label(
-    poissonGLM_model_instantiation,
+    poissonGLM_model_instantiation, mock_glm_fit
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = basis.RaisedCosineLinearEval(4, label="x") * basis.MSplineEval(5, label="y")
     pipe = Pipeline(
         [("bas", bas.to_transformer().set_input_shape(1, 1)), ("fit", model)]
@@ -296,12 +286,10 @@ def test_cross_validate_multiplicative_basis_in_pipe_with_label(
     assert cls.best_estimator_.get_params()["bas__y__n_basis_funcs"] == 6
 
 
-@pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
 def test_cross_validate_additive_basis_in_pipe_with_label(
-    poissonGLM_model_instantiation,
+    poissonGLM_model_instantiation, mock_glm_fit
 ):
     X, y, model, _, _ = poissonGLM_model_instantiation
-    model.solver_kwargs.update({"maxiter": 2})
     bas = basis.RaisedCosineLinearEval(4, label="x") + basis.MSplineEval(5, label="y")
     pipe = Pipeline(
         [("bas", bas.to_transformer().set_input_shape(1, 1)), ("fit", model)]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -33,9 +33,7 @@ def test_sklearn_transformer_pipeline(bas, poissonGLM_model_instantiation):
     "bas",
     [
         basis.MSplineEval(5),
-        basis.BSplineEval(5),
         basis.CyclicBSplineEval(5),
-        basis.RaisedCosineLinearEval(5),
         basis.RaisedCosineLogEval(5),
     ],
 )

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -8,16 +8,16 @@ from unittest.mock import patch
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from sklearn.base import clone as sk_clone
+from sklearn.pipeline import Pipeline
+
+import nemos as nmo
 from conftest import (
     CombinedBasis,
     basis_with_add_kwargs,
     list_all_basis_classes,
     list_all_real_basis_classes,
 )
-from sklearn.base import clone as sk_clone
-from sklearn.pipeline import Pipeline
-
-import nemos as nmo
 from nemos import basis
 from nemos._inspect_utils import get_subclass_methods, list_abstract_methods
 from nemos.basis import (

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -799,11 +799,8 @@ def test_transformer_fit_transform_input_struct(
     [
         0.1
         * np.random.randn(
-            100,
+            10,
         ),
-        0.1 * np.random.randn(100, 1),
-        0.1 * np.random.randn(100, 2),
-        0.1 * np.random.randn(100, 1, 2),
     ],
 )
 @pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
@@ -834,7 +831,7 @@ def test_transformer_in_pipeline(basis_cls, inp, basis_class_specific_params):
         np.exp(log_mu[~np.isnan(log_mu)] - np.nanmean(log_mu))
     )
     model = nmo.glm.GLM(
-        regularizer="Ridge", regularizer_strength=0.001, solver_kwargs={"maxiter": 3}
+        regularizer="Ridge", regularizer_strength=0.001, solver_kwargs={"maxiter": 1}
     ).fit(X, y)
 
     # pipeline
@@ -846,7 +843,7 @@ def test_transformer_in_pipeline(basis_cls, inp, basis_class_specific_params):
                 nmo.glm.GLM(
                     regularizer="Ridge",
                     regularizer_strength=0.001,
-                    solver_kwargs={"maxiter": 3},
+                    solver_kwargs={"maxiter": 1},
                 ),
             ),
         ]


### PR DESCRIPTION
## Summary

- Profiled per-test execution time and identified three dominant overhead sources: JAX JIT recompilation per unique array shape, full solver runs in tests that only check structure or routing, and Cartesian-product parametrize expansions over obs-model-agnostic logic.
- Introduced three solver-bypass fixtures in `conftest.py` and applied them selectively across `test_glm.py` and `test_pipeline.py`.
- Trimmed parametrize dimensions in `test_glm.py`, `test_transformer_basis.py`, and `test_pipeline.py`.
- Added a `--timeit` CLI flag for future profiling.
- Coverage verified against `development`: overall line coverage unchanged (92.58%); one previously uncovered line recovered with a new targeted test.

## Motivation

The full test suite took ~920 s. The top-10 tests accounted for ~48% of total time; the top-10% for ~83%. Three patterns dominated:

1. **Solver runs in structure-only tests**: many tests called `model.fit` or `model.update` only to attach fitted parameters, then checked coef_ shape, metadata, repr, or error messages — never the solution. Each call triggered JAX JIT compilation and solver iteration.
2. **Over-parametrization on the observation-model axis**: tests in `TestGLMObservationModel` inherited the class-level 6-obs-model × 2-glm-type Cartesian product even when the behaviour under test lives in `BaseGLM` and is obs-model-agnostic.
3. **Tight solver settings in fixture-heavy tests**: e.g. `test_estimate_dof_resid` called `model.fit` with `maxiter=10^5` to obtain a sparse solution, even though `_estimate_resid_degrees_of_freedom` only reads `coef_`, `intercept_`, `regularizer`, and `X`.

## Description of the Changes and Rationale

### Principle 1 — solver-bypass fixtures (`conftest.py`)

Three fixtures were added to `conftest.py`, with a clear hierarchy based on how much of the fit pipeline a test actually needs:

- **`mock_glm_fit`**: replaces `GLM.fit` with a pure-Python no-op that sets `coef_`/`intercept_` from X/y shapes. No JAX at all. Use when a test only needs a model in a fitted state (e.g. routing tests, `test_predict_is_fit`).
- **`mock_optimizer_run`**: runs the real `_initialize_optimizer_and_state` (preserving input validation, shape checks, metadata propagation) but replaces the solver call with a no-op that returns the initial parameters. Use when a test checks fit side-effects — coef_ tree structure, error messages, metadata — but not solution quality (e.g. `test_fit_weights_dimensionality`, `test_coef_tree_structure_after_fit_pytree_x`, `test_metadata_pynapple_fit`).
- **`mock_optimizer_update`**: same idea for `model.update` — real initialization, no-op update step. Use when a test checks update-API correctness but not that parameters changed (e.g. `test_update_n_samples`). Do not use when the test asserts on the values of the updated parameters (e.g. `test_update_params_are_finite`, `test_update_nan_drop_at_jit_comp`).

The fixture choice is always driven by test intent: tests that validate the solve must not use a mock; tests that validate the surrounding infrastructure should.

### Principle 2 — reducing parametrize dimensions

Where a test's behaviour is independent of a parametrize axis, that axis is trimmed. Two recurring patterns:

- **Obs-model axis**: tests that live conceptually in `BaseGLM` were moved out of `TestGLMObservationModel` (which inherits 6-obs-model × 2-glm-type) and re-parametrized over 2 representative models (Poisson + Gaussian). Examples: `test_update_n_samples` (96 → 32 params), `test_update_params_are_finite` (96 → 32 params, real solver retained), `test_compatibility_with_sklearn_cv` (12 → 4 params).
- **Redundant solver/shape dimensions**: axes that duplicate coverage present elsewhere are removed. Examples: `test_glm_update_consistent_with_fit_with_svrg` drops one random key and reduces epochs (64 → 8 params, −88 s); `test_optimize_solver_params` drops the pytree variant of `reg_setup` (÷2 params).

### Principle 3 — bypass `model.fit` when the tested method does not need it

Where a method only reads a subset of model state, that state is set directly rather than obtained via fit. `test_estimate_dof_resid` is the primary example: `_estimate_resid_degrees_of_freedom` only reads `coef_`, `intercept_`, `regularizer`, and `X`, so the test now assigns a fixed sparse `coef_`/`intercept_` directly and calls the method — no solver run. Result: 72 → 24 params, 14.7 s → 1.3 s.

### `tests/test_transformer_basis.py`

`test_transformer_in_pipeline`: reduced `inp` from 4 array shapes to 1 and `maxiter` from 3 to 1. Each distinct shape triggers a full JAX recompilation; the broadcasting logic is covered elsewhere. 76 → 19 params, ~−76%.

### `tests/test_pipeline.py`

All tests that verify sklearn pipeline routing (cloning, parameter setting, CV mechanics) now use `mock_glm_fit`, replacing the real solver with a pure-Python no-op. Additionally, `test_sklearn_transformer_pipeline_cv` is reduced from 5 basis types to 3.

## Before / After (Baseline Timings)

| Test | Before | After | Δ |
|------|--------|-------|---|
| `test_glm_update_consistent_with_fit_with_svrg` | 118.4 s / 64 params | ~14 s / 8 params | −88% |
| `test_transformer_in_pipeline` | 65.5 s / 76 params | ~16 s / 19 params | −76% |
| `test_optimize_solver_params` | 37.7 s / 10800 params | ~19 s / 5400 params | −50% |
| `test_update_nan_drop_at_jit_comp` | 31.4 s / 24 params | ~5 s / 4 params | −84% |
| `test_compatibility_with_sklearn_cv` | 31.1 s / 12 params | <1 s / 4 params | −97% |
| `test_update_params_are_finite` | 24.5 s / 96 params | ~11 s / 32 params | −55% |
| `test_update_n_samples` | 22.5 s / 96 params | ~3 s / 32 params | −87% |
| `test_sklearn_transformer_pipeline_cv` (pipeline) | 20.9 s / 5 params | <1 s / 3 params | −97% |
| `test_estimate_dof_resid` | 14.7 s / 72 params | 1.3 s / 24 params | −91% |

Combined, these 9 tests accounted for ~367 s (40% of total).

## Coverage

Compared `coverage_test-speedup.xml` against `coverage_development.xml`:

- **Overall**: 6193/6689 lines (92.58%) — identical to `development`.
- **`classifier_glm.py:322`**: one line lost (the `TypeError` path in `ClassifierGLM._estimate_resid_degrees_of_freedom`, no longer exercised since `test_estimate_dof_resid` bypasses fit). Recovered by the new `test_estimate_dof_resid_classifier_invalid_n_samples` (2 params, ~1 s).
- **`glm.py:776`**: one line gained (convergence fallback branch for solvers without a `.converged` attribute), now hit by `mock_optimizer_run`.

## Open Questions for Reviewers

Several tests were reduced from 6 obs models to 2 (Poisson + Gaussian) on the grounds that the behaviour under test lives in `BaseGLM`. Current coverage is unchanged, but the reduction weakens the test as a regression net: if a future change introduces obs-model-specific behaviour in one of the dropped models (e.g. Gamma, Bernoulli), the test will no longer catch it — and since coverage won't drop at the point of that change, the gap will go unnoticed unless CodeCov is checked explicitly.

The specific tests affected are `test_update_n_samples`, `test_update_params_are_finite`, `test_update_nan_drop_at_jit_comp`, and `test_compatibility_with_sklearn_cv`. Are the `update` and sklearn-compatibility code paths sufficiently obs-model-agnostic that 2 models are a safe long-term choice, or should one or two additional models be retained as sentinels?