### PR TITLE
Fix solver spec resolution and regularizer/solver consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: ci
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   workflow_dispatch:
   schedule:

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -30,7 +30,7 @@ from .base_validator import RegressorValidator
 from .glm.params import GLMParams
 from .pytrees import FeaturePytree
 from .regularizer import GroupLasso, Regularizer
-from .solvers import SolverProtocol
+from .solvers import SolverProtocol, SolverSpec
 from .type_casting import cast_to_jax
 from .typing import (
     DESIGN_INPUT_TYPE,
@@ -130,16 +130,12 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
         self.regularizer = "UnRegularized" if regularizer is None else regularizer
         self.regularizer_strength = regularizer_strength
 
-        # no solver name provided, use default
-        if solver_name is None:
-            solver_name = self.regularizer.default_solver
-
         self.solver_name = solver_name
 
         if solver_kwargs is None:
             solver_kwargs = dict()
 
-        solver_class = self._solver_spec.implementation
+        solver_class = self.solver_spec.implementation
         self._check_solver_kwargs(solver_class, solver_kwargs)
 
         self.solver_kwargs = solver_kwargs
@@ -263,23 +259,34 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
     @property
     def solver_name(self) -> str:
         """Getter for the solver_name attribute."""
-        return self._solver_spec.full_name
+        return self.solver_spec.algo_name
 
     @solver_name.setter
-    def solver_name(self, solver_name: str):
+    def solver_name(self, solver_name: str | None):
         """Setter for the solver_name attribute."""
-        if not isinstance(solver_name, str):
+        if not isinstance(solver_name, str) and solver_name is not None:
             raise TypeError("solver_name must be a string.")
+        elif solver_name is None:
+            self._solver_spec = None
+        else:
+            # check if solver str passed is valid for regularizer
+            spec = solvers.get_solver(solver_name)
+            self._regularizer.check_solver(spec.algo_name)
+            self._solver_spec = spec
 
-        # check if solver str passed is valid for regularizer
-        spec = solvers.get_solver(solver_name)
-        self._regularizer.check_solver(spec.algo_name)
-        self._solver_spec = spec
+    @property
+    def solver_spec(self) -> SolverSpec:
+        """Getter for the solver specification."""
+        if self._solver_spec is None:
+            spec = solvers.get_solver(self.regularizer.default_solver)
+            self._regularizer.check_solver(spec.algo_name)
+            return spec
+        return self._solver_spec
 
     @property
     def algo_name(self) -> str:
         """Name of the optimization algorithm the solver implements."""
-        return self._solver_spec.algo_name
+        return self.solver_spec.algo_name
 
     @property
     def solver_kwargs(self):
@@ -290,7 +297,7 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
     def solver_kwargs(self, solver_kwargs: dict):
         """Setter for the solver_kwargs attribute."""
         if solver_kwargs:
-            solver_cls = self._solver_spec.implementation
+            solver_cls = self.solver_spec.implementation
             self._check_solver_kwargs(solver_cls, solver_kwargs)
         self._solver_kwargs = solver_kwargs
 
@@ -366,7 +373,7 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
             The solver instance.
         """
         # final check that solver is valid for chosen regularizer
-        self._regularizer.check_solver(self._solver_spec.algo_name)
+        self._regularizer.check_solver(self.solver_spec.algo_name)
 
         if solver_kwargs is None:
             # copy dictionary of kwargs to avoid modifying user settings

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -279,7 +279,6 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
         """Getter for the solver specification."""
         if self._solver_spec is None:
             spec = solvers.get_solver(self.regularizer.default_solver)
-            self._regularizer.check_solver(spec.algo_name)
             return spec
         return self._solver_spec
 

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -127,6 +127,7 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
         solver_name: Optional[str] = None,
         solver_kwargs: Optional[dict] = None,
     ):
+        self._solver_spec = None
         self.regularizer = "UnRegularized" if regularizer is None else regularizer
         self.regularizer_strength = regularizer_strength
 
@@ -246,6 +247,18 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
         # need to use hasattr to avoid class instantiation issues
         if hasattr(self, "_regularizer_strength"):
             self.regularizer_strength = self._regularizer_strength
+
+        # check if solver is not allowed, if it isn't revert to default.
+        # note that, if self._solver_spec is None (default) -> solver always
+        # allowed, so no warning.
+        if self.solver_name not in self.regularizer.allowed_solvers:
+            warnings.warn(
+                f"Solver ``{self.solver_name}`` is not allowed for regularizer {self._regularizer}. "
+                f"Overriding solver with the default allowed solver {self._regularizer.default_solver}.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.solver_name = None
 
     @property
     def regularizer_strength(self) -> Any:

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -296,11 +296,6 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
         return self._solver_spec
 
     @property
-    def algo_name(self) -> str:
-        """Name of the optimization algorithm the solver implements."""
-        return self.solver_spec.algo_name
-
-    @property
     def solver_kwargs(self):
         """Getter for the solver_kwargs attribute."""
         return self._solver_kwargs

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -228,7 +228,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
 
     >>> model = nmo.glm.GLM(solver_name="LBFGS").fit(X, y)
     >>> model.solver_name
-    'LBFGS[...]'
+    'LBFGS'
 
     **Use a Pytree of arrays as Input**
 
@@ -1154,7 +1154,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         regularizer: Ridge()
         regularizer_strength: 0.1...
         solver_kwargs: {'stepsize': 0.1, 'maxiter': 1000, 'tol': 1e-06}
-        solver_name: BFGS[...]
+        solver_name: BFGS
         >>> # Save the model parameters to a file
         >>> model.save_params("model_params.npz")
         >>> # Load the model from the saved file
@@ -1167,7 +1167,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         regularizer: Ridge()
         regularizer_strength: 0.1...
         solver_kwargs: {'stepsize': 0.1, 'maxiter': 1000, 'tol': 1e-06}
-        solver_name: BFGS[...]
+        solver_name: BFGS
 
         >>> # Saving and loading a custom inverse link function
         >>> model = nmo.glm.GLM(
@@ -1188,7 +1188,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         regularizer: UnRegularized()
         regularizer_strength: None
         solver_kwargs: {}
-        solver_name: GradientDescent[...]
+        solver_name: GradientDescent
         """
 
         # initialize saving dictionary

--- a/src/nemos/io/io.py
+++ b/src/nemos/io/io.py
@@ -77,7 +77,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     regularizer: Ridge()
     regularizer_strength: 0.1...
     solver_kwargs: {'stepsize': 0.1, 'maxiter': 1000, 'tol': 1e-06}
-    solver_name: BFGS[...]
+    solver_name: BFGS
     >>> # Save the model parameters to a file
     >>> model.save_params("model_params.npz")
     >>> # Load the model from the saved file
@@ -90,7 +90,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     regularizer: Ridge()
     regularizer_strength: 0.1...
     solver_kwargs: {'stepsize': 0.1, 'maxiter': 1000, 'tol': 1e-06}
-    solver_name: BFGS[...]
+    solver_name: BFGS
 
     >>> # Loading a custom inverse link function
     >>> model = nmo.glm.GLM(inverse_link_function=lambda x: x**2)
@@ -108,7 +108,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     regularizer: UnRegularized()
     regularizer_strength: None
     solver_kwargs: {}
-    solver_name: GradientDescent[...]
+    solver_name: GradientDescent
     """
     # load the model from a .npz file
     filename = Path(filename)

--- a/src/nemos/solvers/_compute_defaults.py
+++ b/src/nemos/solvers/_compute_defaults.py
@@ -58,7 +58,7 @@ def glm_compute_optimal_stepsize_configs(
     )
 
     # look-up table for selecting the optimal step and batch
-    if model.algo_name in ("SVRG", "ProxSVRG"):
+    if model.solver_name in ("SVRG", "ProxSVRG"):
         compute_optimal_params = svrg_optimal_batch_and_stepsize
 
     # get the smoothness parameter compute function

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,6 +306,7 @@ class MockRegressor(BaseRegressor):
     def __init__(self, std_param: int = 0):
         """Initialize a MockBaseRegressor instance with optional standard parameters."""
         self.std_param = std_param
+        self._solver_spec = None
         super().__init__()
 
     def fit(self, X, y):

--- a/tests/test_base_class.py
+++ b/tests/test_base_class.py
@@ -96,13 +96,33 @@ class TestRegularizerSetter:
     @pytest.mark.parametrize(
         "new_regularizer, solver_name, expectation, solver_spec_is_none",
         [
-            (Ridge(), "LBFGS", does_not_raise(), False),  # LBFGS compat with Ridge: spec preserved
-            (Lasso(), "LBFGS", pytest.warns(UserWarning, match="not allowed"), True),  # incompatible: reset + warn
-            (Lasso(), None, does_not_raise(), True),  # no explicit solver: stays None, no warning
+            (
+                Ridge(),
+                "LBFGS",
+                does_not_raise(),
+                False,
+            ),  # LBFGS compat with Ridge: spec preserved
+            (
+                Lasso(),
+                "LBFGS",
+                pytest.warns(UserWarning, match="not allowed"),
+                True,
+            ),  # incompatible: reset + warn
+            (
+                Lasso(),
+                None,
+                does_not_raise(),
+                True,
+            ),  # no explicit solver: stays None, no warning
         ],
     )
     def test_solver_spec_on_regularizer_switch(
-        self, mock_regressor, new_regularizer, solver_name, expectation, solver_spec_is_none
+        self,
+        mock_regressor,
+        new_regularizer,
+        solver_name,
+        expectation,
+        solver_spec_is_none,
     ):
         if solver_name is not None:
             mock_regressor.solver_name = solver_name
@@ -114,7 +134,7 @@ class TestRegularizerSetter:
         "new_regularizer, solver_name",
         [
             (Ridge(), "LBFGS"),  # LBFGS compat with Ridge
-            (Lasso(), None),     # no explicit solver: no warning regardless of regularizer
+            (Lasso(), None),  # no explicit solver: no warning regardless of regularizer
         ],
     )
     def test_no_warning_on_compatible_switch(

--- a/tests/test_base_class.py
+++ b/tests/test_base_class.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext as does_not_raise
 from typing import Union
 from unittest.mock import MagicMock, patch
 
@@ -7,7 +8,7 @@ from numpy.typing import NDArray
 
 from nemos.base_class import Base
 from nemos.base_regressor import BaseRegressor
-from nemos.regularizer import Ridge
+from nemos.regularizer import Lasso, Ridge
 
 
 class MockBaseRegressorInvalid(BaseRegressor):
@@ -87,6 +88,43 @@ def test_invalid_concrete_class():
 def test_empty_set(mock_regressor):
     """Check that an empty set_params returns self."""
     assert mock_regressor.set_params() is mock_regressor
+
+
+class TestRegularizerSetter:
+    """Test solver_spec and warning behavior when switching regularizers."""
+
+    @pytest.mark.parametrize(
+        "new_regularizer, solver_name, expectation, solver_spec_is_none",
+        [
+            (Ridge(), "LBFGS", does_not_raise(), False),  # LBFGS compat with Ridge: spec preserved
+            (Lasso(), "LBFGS", pytest.warns(UserWarning, match="not allowed"), True),  # incompatible: reset + warn
+            (Lasso(), None, does_not_raise(), True),  # no explicit solver: stays None, no warning
+        ],
+    )
+    def test_solver_spec_on_regularizer_switch(
+        self, mock_regressor, new_regularizer, solver_name, expectation, solver_spec_is_none
+    ):
+        if solver_name is not None:
+            mock_regressor.solver_name = solver_name
+        with expectation:
+            mock_regressor.regularizer = new_regularizer
+        assert (mock_regressor._solver_spec is None) == solver_spec_is_none
+
+    @pytest.mark.parametrize(
+        "new_regularizer, solver_name",
+        [
+            (Ridge(), "LBFGS"),  # LBFGS compat with Ridge
+            (Lasso(), None),     # no explicit solver: no warning regardless of regularizer
+        ],
+    )
+    def test_no_warning_on_compatible_switch(
+        self, mock_regressor, new_regularizer, solver_name, recwarn
+    ):
+        if solver_name is not None:
+            mock_regressor.solver_name = solver_name
+        mock_regressor.regularizer = new_regularizer
+        user_warnings = [w for w in recwarn if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 0
 
 
 def test_glm_varargs_error():

--- a/tests/test_base_class.py
+++ b/tests/test_base_class.py
@@ -118,6 +118,7 @@ class TestInstantiateSolverOverrides:
     @pytest.fixture
     def mock_get_solver(self, mock_solver_cls):
         spec = MagicMock()
+        spec.algo_name = "GradientDescent"
         spec.implementation = mock_solver_cls
         return MagicMock(return_value=spec)
 
@@ -137,7 +138,7 @@ class TestInstantiateSolverOverrides:
             regressor._instantiate_solver(
                 lambda p, X, y: None, None, solver_name=solver_name_override
             )
-        mock_get_solver.assert_called_once_with(expected)
+        mock_get_solver.assert_called_with(expected)
 
     @pytest.mark.parametrize("regularizer_override", [None, Ridge()])
     def test_regularizer_resolution(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1872,8 +1872,8 @@ class TestGLMObservationModel:
         """
         default_solver_name = nmo.solvers.get_solver(
             nmo.regularizer.UnRegularized().default_solver
-        ).full_name
-        lbfgs_solver_name = nmo.solvers.get_solver("LBFGS").full_name
+        ).algo_name
+        lbfgs_solver_name = nmo.solvers.get_solver("LBFGS").algo_name
         if "poisson" in model_instantiation:
             observation_model = "PoissonObservations()"
             inverse_link_function = "exp"

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -188,7 +188,7 @@ def test_allow_solver(regularizer_class):
         with does_not_raise():
             reg1.check_solver(new_solver)
             model = nmo.glm.GLM(regularizer=reg1, solver_name=new_solver)
-            assert model.algo_name == new_solver
+            assert model.solver_name == new_solver
 
         # allowing a solver already allowed does nothing
         _default_solver = regularizer_class._default_solver

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -156,7 +156,7 @@ def test_svrg_glm_instantiate_solver(regularizer_name, solver_class, mask):
     solver = glm._instantiate_solver(glm._compute_loss, np.zeros(1))
 
     # currently glm._solver is a Wrapped(Prox)SVRG
-    assert glm.algo_name == solver_name
+    assert glm.solver_name == solver_name
     assert isinstance(solver._solver, solver_class)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -669,7 +669,7 @@ def test_inspect_npz(tmp_path, model_class, monkeypatch, capsys):
         "regularizer            : {'class': 'nemos.regularizer.Ridge'}",
         "regularizer_strength   : 0.1",
         "solver_kwargs          : None",
-        f"solver_name            : BFGS[{nmo.solvers._solver_registry._resolve_backend('BFGS', False)}]",
+        "solver_name            : BFGS",
         "",
         "Model fit parameters",
         "--------------------",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -577,7 +577,7 @@ class ComplexParam(Base):
             nmo.glm.GLM(inverse_link_function=deepcopy(jax.numpy.exp)),
             None,
             [],
-            f"GLM(observation_model=PoissonObservations(), inverse_link_function=<PjitFunction>, regularizer=UnRegularized(), solver_name='GradientDescent[{nmo.solvers._solver_registry._resolve_backend('GradientDescent', False)}]')",
+            "GLM(observation_model=PoissonObservations(), inverse_link_function=<PjitFunction>, regularizer=UnRegularized(), solver_name='GradientDescent')",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- Replace eager `solver_name` resolution at init with a lazy `solver_spec` property
- Fix `regularizer` setter to warn and reset solver only when an explicitly set solver is incompatible with the new regularizer
- Remove redundant `algo_name` property from `BaseRegressor` (use `solver_name` or `solver_spec` directly)

## Motivation

Two related bugs existed in `BaseRegressor`:

1. **Stale solver on regularizer switch.** `__init__` immediately resolved `solver_name=None` to the regularizer's default and stored it in `_solver_spec`. If the user later changed the regularizer, `_solver_spec` still held the old default, silently producing a solver/regularizer mismatch.

2. **Silent solver reset when not needed.** The `regularizer` setter unconditionally reset `solver_name = None` when the current solver was not in the new regularizer's `allowed_solvers`. When `_solver_spec` was `None` (user never set a solver), this branch was still reached because `solver_name` resolved to the old regularizer's default — triggering a spurious reset and/or error.

## Description of Changes and Rationale

### Lazy `solver_spec` property

`_solver_spec` is now `None` when no explicit solver is set. A new `solver_spec` property resolves the default on demand:

```python
@property
def solver_spec(self) -> SolverSpec:
    if self._solver_spec is None:
        return solvers.get_solver(self.regularizer.default_solver)
    return self._solver_spec
```

`solver_name` getter delegates to `solver_spec.algo_name`. The consequence is that after `model.regularizer = Lasso()`, `model.solver_name` automatically returns `Lasso`'s default — no stale state.

### `regularizer` setter — guarded reset

The check now only fires when `_solver_spec is not None` (user explicitly set a solver) **and** that solver is incompatible with the new regularizer. When `_solver_spec is None`, `solver_name` resolves to the new regularizer's own default, which is always in `allowed_solvers`, so the branch is never entered spuriously.

```python
if self.solver_name not in self.regularizer.allowed_solvers:
    warnings.warn(...)
    self.solver_name = None   # reset to lazy default
```

### `algo_name` removed

`BaseRegressor.algo_name` was a thin wrapper around `solver_spec.algo_name`, already accessible via `solver_name`. Callers updated to use `solver_name`; internal `_compute_defaults.py` updated accordingly.

### Test updates

| Change | Reason |
|---|---|
| `mock_get_solver` fixture: `spec.algo_name = "GradientDescent"` | Lazy `solver_spec` now calls `get_solver` inside `_instantiate_solver`; mock spec needs a valid `algo_name` for `check_solver` |
| `assert_called_once_with` → `assert_called_with` in `test_solver_name_resolution` | `get_solver` is now called more than once per `_instantiate_solver` call |
| New `TestRegularizerSetter` class | Covers the three cases: compatible switch (spec preserved, no warning), incompatible switch (spec reset, warning), and default solver switch (spec stays `None`, no warning) |
| `model.algo_name` → `model.solver_name` in `test_regularizer.py`, `test_solvers.py` | `algo_name` removed |
