### PR TITLE
allow 1x1 conv

### DIFF
--- a/src/nemos/basis/_identity.py
+++ b/src/nemos/basis/_identity.py
@@ -156,7 +156,9 @@ class HistoryBasis(AtomicBasisMixin, Basis):
             Identity matrix of shape ``(*samples.shape, n_basis_funcs)``.
 
         """
-        sample_pts = jnp.squeeze(jnp.asarray(sample_pts))
+        # allow only array with one non-trivial axis: (n_samples,1,1,1,1,...) are ok.
+        squeeze = tuple([k + 1 for (k, s) in enumerate(sample_pts.shape[1:]) if s == 1])
+        sample_pts = jnp.squeeze(jnp.asarray(sample_pts), axis=squeeze)
         if sample_pts.ndim != 1:
             raise ValueError("`evaluate` for HistoryBasis allows 1D input only.")
         # this is called by set kernel.

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -199,15 +199,18 @@ def nan_pad(
     Raises
     ------
     ValueError
-        - If `pad_size` is not a positive integer.
+        - If `pad_size` is negative.
         - If `predictor_causality` is not one of the expected values ('causal', 'acausal', 'anti-causal').
         - If `axis` is not a valid axis for any of the arrays in `conv_time_series`, specifically
           if `axis >= array.ndim` for any array.
         - If any array in `conv_time_series` does not have a floating-point data type.
     """
-    if not isinstance(pad_size, int) or pad_size <= 0:
+    if pad_size == 0:
+        return conv_time_series
+
+    if not isinstance(pad_size, int) or pad_size < 0:
         raise ValueError(
-            f"pad_size must be a positive integer! Pad size of {pad_size} provided instead!"
+            f"pad_size must be a non-negative integer! Pad size of {pad_size} provided instead!"
         )
 
     causality_choices = ["causal", "acausal", "anti-causal"]

--- a/src/nemos/validation.py
+++ b/src/nemos/validation.py
@@ -316,8 +316,6 @@ def _check_basis_matrix_shape(basis_matrix):
             "basis_matrix must be a 2 dimensional array! "
             f"{basis_matrix.ndim} dimensions provided instead."
         )
-    if basis_matrix.shape[0] == 1:
-        raise ValueError("`basis_matrix.shape[0]` should be at least 2!")
     return basis_matrix
 
 

--- a/tests/test_base_class.py
+++ b/tests/test_base_class.py
@@ -189,7 +189,10 @@ class TestInstantiateSolverOverrides:
     @pytest.mark.parametrize(
         "solver_name_override, expected",
         [
-            (None, "GradientDescent[optax+optimistix]"),  # None → falls back to self.solver_spec.full_name
+            (
+                None,
+                "GradientDescent[optax+optimistix]",
+            ),  # None → falls back to self.solver_spec.full_name
             ("LBFGS[optax+optimistix]", "LBFGS[optax+optimistix]"),
         ],
     )

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -16,8 +16,6 @@ import nemos as nmo
 
 # Import helpers from conftest
 from conftest import MockRegressor, is_population_model
-from nemos.solvers._fista import OptimistixNAG
-from nemos.solvers._optax_optimistix_solvers import OptimistixOptaxGradientDescent
 from nemos._observation_model_builder import AVAILABLE_OBSERVATION_MODELS
 from nemos.glm.params import GLMParams
 from nemos.glm.validation import (
@@ -27,6 +25,8 @@ from nemos.glm.validation import (
     PopulationGLMValidator,
 )
 from nemos.inverse_link_function_utils import LINK_NAME_TO_FUNC
+from nemos.solvers._fista import OptimistixNAG
+from nemos.solvers._optax_optimistix_solvers import OptimistixOptaxGradientDescent
 
 MODEL_REGISTRY = {
     "GLM": nmo.glm.GLM,

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -2310,6 +2310,17 @@ class TestHistoryBasis(BasisFuncsTesting):
             inp.reshape(inp.shape[0], -1),
         )
 
+    @pytest.mark.requires_x64
+    def test_history_conv_window_size_1(self):
+        """window_size=1 with causal convention: output is x shifted by 1, with a leading NaN."""
+        rng = np.random.default_rng(0)
+        x = rng.standard_normal(20)
+        bas = HistoryConv(window_size=1)
+        out = bas.compute_features(x)
+        assert out.shape == (20, 1), f"Expected shape (20, 1), got {out.shape}"
+        assert np.isnan(out[0, 0])
+        np.testing.assert_allclose(out[1:, 0], x[:-1])
+
 
 class TestRaisedCosineLogBasis(BasisFuncsTesting):
     cls = {"eval": basis.RaisedCosineLogEval, "conv": basis.RaisedCosineLogConv}

--- a/tests/test_glm_hmm_analytic_mstep.py
+++ b/tests/test_glm_hmm_analytic_mstep.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -130,7 +131,7 @@ def generate_data_gaussian(request):
         (GLMParams(_COEF_SINGLE, _INTERCEPT_SINGLE), (), lambda x: x),
         (GLMParams(_COEF_SINGLE, _INTERCEPT_SINGLE), (), jnp.exp),
         (GLMParams(_COEF_POP, _INTERCEPT_POP), (4,), lambda x: x),
-        (GLMParams(_COEF_POP, _INTERCEPT_POP), (4,), jnp.exp),
+        (GLMParams(_COEF_POP, _INTERCEPT_POP), (4,), jax.nn.softplus),
     ],
     indirect=True,
 )

--- a/tests/test_glm_hmm_analytic_mstep.py
+++ b/tests/test_glm_hmm_analytic_mstep.py
@@ -210,9 +210,7 @@ class TestAnalyticMStepScale:
         def analytical_update_fn(params, X, y, posteriors):
             # Update model parameters using solver
             new_model_params, _, _ = solver.run(params, X, y, posteriors)
-            predicted_rate = compute_rate_per_state(
-                X, new_model_params, obs.default_inverse_link_function
-            )
+            predicted_rate = compute_rate_per_state(X, new_model_params, inv_link_func)
             # Update scale parameters using analytical update
             new_log_scale, _, _ = update(
                 params.log_scale,
@@ -245,9 +243,7 @@ class TestAnalyticMStepScale:
         def numerical_update_fn(params, X, y, posteriors):
             # Update model parameters using solver
             new_model_params, _, _ = solver.run(params, X, y, posteriors)
-            predicted_rate = compute_rate_per_state(
-                X, new_model_params, obs.default_inverse_link_function
-            )
+            predicted_rate = compute_rate_per_state(X, new_model_params, inv_link_func)
             # Update scale parameters using separate solver
             new_log_scale, _, _ = solver_scale.run(
                 params.log_scale,

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -830,6 +830,8 @@ def test_transformer_in_pipeline(basis_cls, inp, basis_class_specific_params):
     y[~np.isnan(log_mu)] = np.random.poisson(
         np.exp(log_mu[~np.isnan(log_mu)] - np.nanmean(log_mu))
     )
+    # make sure that not all vals are the same
+    y[-1] = 1 if y[~np.isnan(log_mu)][0] != 1 else 2
     model = nmo.glm.GLM(
         regularizer="Ridge", regularizer_strength=0.001, solver_kwargs={"maxiter": 1}
     ).fit(X, y)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,10 +131,10 @@ class TestPadding:
     @pytest.mark.parametrize("array", [np.zeros([2, 4, 5])])
     @pytest.mark.parametrize("pad_size", [0.1, -1, 0, 1, 2, 3, 5, 6])
     def test_padding_nan_causal(self, pad_size, array):
-        raise_exception = (not isinstance(pad_size, int)) or (pad_size <= 0)
+        raise_exception = (not isinstance(pad_size, int)) or (pad_size < 0)
         if raise_exception:
             with pytest.raises(
-                ValueError, match="pad_size must be a positive integer!"
+                ValueError, match="pad_size must be a non-negative integer!"
             ):
                 utils.nan_pad(array, pad_size, "anti-causal")
         else:
@@ -152,10 +152,10 @@ class TestPadding:
     @pytest.mark.parametrize("array", [np.zeros([2, 5, 4])])
     @pytest.mark.parametrize("pad_size", [0, 1, 2, 3, 5, 6])
     def test_padding_nan_anti_causal(self, pad_size, array):
-        raise_exception = (not isinstance(pad_size, int)) or (pad_size <= 0)
+        raise_exception = (not isinstance(pad_size, int)) or (pad_size < 0)
         if raise_exception:
             with pytest.raises(
-                ValueError, match="pad_size must be a positive integer!"
+                ValueError, match="pad_size must be a non-negative integer!"
             ):
                 utils.nan_pad(array, pad_size, "anti-causal")
         else:
@@ -173,10 +173,10 @@ class TestPadding:
     @pytest.mark.parametrize("array", [np.zeros([2, 5, 4])])
     @pytest.mark.parametrize("pad_size", [-1, 0.2, 0, 1, 3, 5])
     def test_padding_nan_acausal(self, pad_size, array):
-        raise_exception = (not isinstance(pad_size, int)) or (pad_size <= 0)
+        raise_exception = (not isinstance(pad_size, int)) or (pad_size < 0)
         if raise_exception:
             with pytest.raises(
-                ValueError, match="pad_size must be a positive integer!"
+                ValueError, match="pad_size must be a non-negative integer!"
             ):
                 utils.nan_pad(array, pad_size, "acausal")
 
@@ -281,11 +281,15 @@ class TestPadding:
         [
             (
                 -1,
-                pytest.raises(ValueError, match="pad_size must be a positive integer"),
+                pytest.raises(
+                    ValueError, match="pad_size must be a non-negative integer"
+                ),
             ),
             (
                 1.0,
-                pytest.raises(ValueError, match="pad_size must be a positive integer"),
+                pytest.raises(
+                    ValueError, match="pad_size must be a non-negative integer"
+                ),
             ),
             (1, does_not_raise()),
             (2, does_not_raise()),


### PR DESCRIPTION
Quick PR for allowing convolutions with 1x1 kernels. This are just multiplication by a scalar, but still, if we allow them, we can have history basis shifting the history of 1 that can be useful for using a single step of past history as predictor.

This is usually what people do when modeling choice history effects.