### PR TITLE
Initialization of `BaseHMM` class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 #v7.3.1
         with:
           enable-cache: true
+          cache-suffix: "v2"
 
       - name: Run tox
         run: uvx --with tox-uv tox -e skip_solver_related
@@ -85,6 +86,7 @@ jobs:
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 #v7.3.1
         with:
           enable-cache: true
+          cache-suffix: "v2"
 
       - name: Run solver-dependent tests with JAXopt backend
         run: uvx --with tox-uv tox -e backend-jaxopt
@@ -119,6 +121,7 @@ jobs:
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 #v7.3.1
         with:
           enable-cache: true
+          cache-suffix: "v2"
 
       - name: Run solver-dependent tests with Optimistix backend
         run: uvx --with tox-uv tox -e backend-optimistix
@@ -148,6 +151,7 @@ jobs:
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 #v7.3.1
         with:
           enable-cache: true
+          cache-suffix: "v2"
 
       - name: Run tox
         run: uvx --with tox-uv tox -e check

--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -128,6 +128,7 @@ VALID_PAIRS = [
     {"initial_proba_init", "initial_proba_init_kwargs"},
     {"transition_proba_init", "transition_proba_init_kwargs"},
     {"initial_proba_init_kwargs", "transition_proba_init_kwargs"},
+    {"is_nan", "is_nap"},
 ]
 
 

--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -129,6 +129,7 @@ VALID_PAIRS = [
     {"transition_proba_init", "transition_proba_init_kwargs"},
     {"initial_proba_init_kwargs", "transition_proba_init_kwargs"},
     {"is_nan", "is_nap"},
+    {"dirichlet_initial_proba", "dirichlet_transition_proba"},
 ]
 
 

--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -130,6 +130,7 @@ VALID_PAIRS = [
     {"initial_proba_init_kwargs", "transition_proba_init_kwargs"},
     {"is_nan", "is_nap"},
     {"dirichlet_initial_proba", "dirichlet_transition_proba"},
+    {"random_key_pair", "random_key"},
 ]
 
 

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -611,6 +611,7 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
         self,
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
+        **kwargs,
     ) -> ModelParamsT:
         """Model specific initialization logic."""
         pass

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -630,6 +630,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams]):
         self,
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
+        **kwargs,
     ) -> GLMParams:
         """Initialize the parameters based on the structure and dimensions X and y.
 

--- a/src/nemos/glm_hmm/algorithm_configs.py
+++ b/src/nemos/glm_hmm/algorithm_configs.py
@@ -477,12 +477,17 @@ def prepare_mstep_update_fn(
     objective_param = prepare_mstep_nll_objective_param(
         is_population_glm, observation_model, inverse_link_function
     )
-    params_update_fn = setup_solver(objective_param, init_params=init_params).run
 
     # if scale is separable and needs to be optimized, get update function for optimizing scale
     if observation_model._separable_scale and (
         type(observation_model) not in _NO_SCALE
     ):
+        # GLM params solver only needs coef and intercept — exclude log_scale
+        glm_init_params = GLMParams(init_params.coef, init_params.intercept)
+        params_update_fn = setup_solver(
+            objective_param, init_params=glm_init_params
+        ).run
+
         scale_update_fn = get_analytical_scale_update(
             observation_model, is_population_glm
         )
@@ -501,19 +506,20 @@ def prepare_mstep_update_fn(
 
         # combine param and scale updates into a single function for use in M-step
         def update_fn(params, X, y, posteriors):
-            new_model_params, state_params, aux_params = params_update_fn(
-                params, X, y, posteriors
+            glm_params = GLMParams(params.coef, params.intercept)
+            new_glm_params, state_params, aux_params = params_update_fn(
+                glm_params, X, y, posteriors
             )
             predicted_rate = compute_rate_per_state(
-                X, new_model_params, inverse_link_function=inverse_link_function
+                X, new_glm_params, inverse_link_function=inverse_link_function
             )
             new_scale, state_scale, aux_scale = scale_update_fn(
                 params.log_scale, y, predicted_rate, posteriors
             )
             return (
                 GLMHMMModelParams(
-                    new_model_params.coef,
-                    new_model_params.intercept,
+                    new_glm_params.coef,
+                    new_glm_params.intercept,
                     new_scale,
                 ),
                 (state_params, state_scale),
@@ -523,4 +529,6 @@ def prepare_mstep_update_fn(
         return update_fn
 
     else:
+        # scale is not separable: joint objective over all params including scale
+        params_update_fn = setup_solver(objective_param, init_params=init_params).run
         return params_update_fn

--- a/src/nemos/glm_hmm/algorithm_configs.py
+++ b/src/nemos/glm_hmm/algorithm_configs.py
@@ -224,7 +224,7 @@ def prepare_estep_log_likelihood(
             out_axes=state_axes,
         )
 
-    def log_likelihood(X, y, params):
+    def log_likelihood(params, X, y):
         rate = compute_rate_per_state(X, params, inverse_link_function)
         scale = jnp.exp(params.log_scale) if params.log_scale is not None else None
         log_like = log_likelihood_per_sample(y, rate, scale)

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -74,10 +74,9 @@ class GLMHMMValidator(HMMValidator[GLMHMMUserParams, GLMHMMParams]):
         2,
         1,
         1,
-        *HMMValidator.expected_param_dims,
+        1,
+        2,
     )  # (coef.ndim, intercept.ndim, scale.ndim, init_prob.ndim, transition_prob.ndim)
-    initial_prob_ind: int = 3
-    transition_prob_ind: int = 4
     model_param_names: Tuple[str] = (
         "coef",
         "intercept",

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -14,28 +14,6 @@ from ..typing import DESIGN_INPUT_TYPE
 from .params import GLMHMMModelParams, GLMHMMParams, GLMHMMUserParams
 
 
-def has_nans_only_at_border(arr):
-    """Check if NaNs appear only at the start and end along axis=0."""
-    # Check which rows have any NaN values
-    is_nan = jnp.any(jnp.isnan(arr.reshape(arr.shape[0], -1)), axis=1)
-
-    # If no NaNs, it's valid
-    if not jnp.any(is_nan):
-        return True
-
-    # If all NaNs, it's valid
-    if jnp.all(is_nan):
-        return True
-
-    # Find first and last non-NaN positions
-    non_nan_indices = jnp.where(~is_nan)[0]
-    first_valid = non_nan_indices[0]
-    last_valid = non_nan_indices[-1]
-
-    # Check if there are any NaNs between first and last valid values
-    return not jnp.any(is_nan[first_valid : last_valid + 1])
-
-
 def to_glm_hmm_params(user_params: GLMHMMUserParams) -> GLMHMMParams:
     """Map from GLMHMMUserParams to GLMHMMParams.
 
@@ -43,7 +21,7 @@ def to_glm_hmm_params(user_params: GLMHMMUserParams) -> GLMHMMParams:
     to internal model parameters (log_scale and log probabilities).
     """
     return GLMHMMParams(
-        model_params=GLMHMMModelParams(user_params[:3]),
+        model_params=GLMHMMModelParams(*user_params[:3]),
         hmm_params=to_hmm_params(user_params[3:]),
     )
 

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -195,8 +195,3 @@ class GLMHMMValidator(HMMValidator[GLMHMMUserParams, GLMHMMParams]):
     def get_empty_params(self, X, y) -> GLMHMMParams:
         """Return the param shape given the input data."""
         pass
-
-    @staticmethod
-    def validate_init_funcs(init_funcs: dict):
-        """Validate the keys of the initialization funcs provided."""
-        pass

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -6,12 +6,10 @@ from typing import Any, Callable, Optional, Tuple, Union
 import jax
 import jax.numpy as jnp
 from jax.typing import DTypeLike
-from pynapple import Tsd, TsdFrame
 
 from ..base_validator import RegressorValidator
 from ..glm.validation import GLMValidator
 from ..hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
-from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE
 from .params import GLMHMMModelParams, GLMHMMParams, GLMHMMUserParams
 
@@ -193,56 +191,6 @@ class GLMHMMValidator(HMMValidator[GLMHMMUserParams, GLMHMMParams]):
         """Check consistency of feature_mask and params."""
         self._glm_validator.feature_mask_consistency(feature_mask, params.model_params)
         return
-
-    def validate_inputs(
-        self,
-        X: Optional[DESIGN_INPUT_TYPE] = None,
-        y: Optional[jnp.ndarray | Tsd | TsdFrame] = None,
-    ):
-        """Validate inputs for GLM-HMM model."""
-        super().validate_inputs(X, y)
-
-        # Additional checks due to the time-series structure.
-        # (the forward-backward implementation assumes no nans in the inputs)
-        # Skip NaN border check if y is None (e.g., during simulation)
-        if y is None:
-            if X is not None and not has_nans_only_at_border(X):
-                raise ValueError(
-                    "GLM-HMM requires continuous time-series data. NaN values must only "
-                    "appear at the beginning or end of the data, not in the middle."
-                )
-            return
-
-        if is_pynapple_tsd(X):
-            # loop over epochs and check that nans are all at the border
-            epoch_slices = [
-                X.get_slice(ep.start[0], ep.end[0]) for ep in X.time_support
-            ]
-            y_array = jnp.asarray(y)
-            is_continuous = all(
-                has_nans_only_at_border(X.d[s]) and has_nans_only_at_border(y_array[s])
-                for s in epoch_slices
-            )
-        elif is_pynapple_tsd(y):
-            # loop over epochs and check that nans are all at the border
-            epoch_slices = [
-                y.get_slice(ep.start[0], ep.end[0]) for ep in y.time_support
-            ]
-            is_continuous = all(
-                has_nans_only_at_border(X[s]) and has_nans_only_at_border(y.d[s])
-                for s in epoch_slices
-            )
-        else:
-            # check nans at the border
-            is_continuous = has_nans_only_at_border(X) and has_nans_only_at_border(y)
-        if not is_continuous:
-            raise ValueError(
-                "GLM-HMM requires continuous time-series data. NaN values must only "
-                "appear at the beginning or end of the data, not in the middle. "
-                "Found NaN values within the time series, which would break the "
-                "forward-backward algorithm. Please ensure your data is continuous "
-                "or split it into separate epochs at the gaps."
-            )
 
     def get_empty_params(self, X, y) -> GLMHMMParams:
         """Return the param shape given the input data."""

--- a/src/nemos/glm_hmm/validation.py
+++ b/src/nemos/glm_hmm/validation.py
@@ -195,3 +195,8 @@ class GLMHMMValidator(HMMValidator[GLMHMMUserParams, GLMHMMParams]):
     def get_empty_params(self, X, y) -> GLMHMMParams:
         """Return the param shape given the input data."""
         pass
+
+    @staticmethod
+    def validate_init_funcs(init_funcs: dict):
+        """Validate the keys of the initialization funcs provided."""
+        pass

--- a/src/nemos/hmm/expectation_maximization.py
+++ b/src/nemos/hmm/expectation_maximization.py
@@ -13,7 +13,7 @@ from .m_step_analytical_updates import (
     _analytical_m_step_log_transition_prob,
 )
 from .params import HMMParams
-from .utils import Array, initialize_new_session
+from .utils import Array, initialize_is_new_session
 
 
 class EMState(eqx.Module):
@@ -257,7 +257,7 @@ def forward_pass(
     log_transition_prob = params.hmm_params.log_transition_prob
 
     # Initialize variables
-    is_new_session = initialize_new_session(y.shape[0], is_new_session)
+    is_new_session = initialize_is_new_session(X, y, is_new_session)
 
     # Compute log-likelihoods
     log_conditionals = log_likelihood_func(X, y, model_params)
@@ -444,7 +444,7 @@ def forward_backward(
 
     # Initialize variables
     n_time_bins = y.shape[0]
-    is_new_session = initialize_new_session(y.shape[0], is_new_session)
+    is_new_session = initialize_is_new_session(X, y, is_new_session)
 
     # Compute log-likelihoods
     log_conditionals = log_likelihood_func(X, y, model_params)
@@ -800,7 +800,7 @@ def em_hmm(
     state :
         Final EMState containing all parameters and diagnostics.
     """
-    is_new_session = initialize_new_session(y.shape[0], is_new_session)
+    is_new_session = initialize_is_new_session(X, y, is_new_session)
 
     state = EMState(
         data_log_likelihood=-jnp.array(jnp.inf),
@@ -897,7 +897,7 @@ def max_sum(
     n_states = log_init.shape[0]
 
     # initialize new session
-    is_new_session = initialize_new_session(y.shape[0], is_new_session)
+    is_new_session = initialize_is_new_session(X, y, is_new_session)
 
     log_emission = log_likelihood_func(X, y, model_params)
 

--- a/src/nemos/hmm/expectation_maximization.py
+++ b/src/nemos/hmm/expectation_maximization.py
@@ -13,7 +13,7 @@ from .m_step_analytical_updates import (
     _analytical_m_step_log_transition_prob,
 )
 from .params import HMMParams
-from .utils import Array, initialize_is_new_session
+from .utils import Array
 
 
 class EMState(eqx.Module):
@@ -257,7 +257,11 @@ def forward_pass(
     log_transition_prob = params.hmm_params.log_transition_prob
 
     # Initialize variables
-    is_new_session = initialize_is_new_session(X, y, is_new_session)
+    is_new_session = (
+        is_new_session
+        if is_new_session is not None
+        else jnp.zeros(y.shape[0], dtype=bool).at[0].set(1)
+    )
 
     # Compute log-likelihoods
     log_conditionals = log_likelihood_func(X, y, model_params)
@@ -444,7 +448,11 @@ def forward_backward(
 
     # Initialize variables
     n_time_bins = y.shape[0]
-    is_new_session = initialize_is_new_session(X, y, is_new_session)
+    is_new_session = (
+        is_new_session
+        if is_new_session is not None
+        else jnp.zeros(y.shape[0], dtype=bool).at[0].set(1)
+    )
 
     # Compute log-likelihoods
     log_conditionals = log_likelihood_func(X, y, model_params)
@@ -800,7 +808,11 @@ def em_hmm(
     state :
         Final EMState containing all parameters and diagnostics.
     """
-    is_new_session = initialize_is_new_session(X, y, is_new_session)
+    is_new_session = (
+        is_new_session
+        if is_new_session is not None
+        else jnp.zeros(y.shape[0], dtype=bool).at[0].set(1)
+    )
 
     state = EMState(
         data_log_likelihood=-jnp.array(jnp.inf),
@@ -897,7 +909,11 @@ def max_sum(
     n_states = log_init.shape[0]
 
     # initialize new session
-    is_new_session = initialize_is_new_session(X, y, is_new_session)
+    is_new_session = (
+        is_new_session
+        if is_new_session is not None
+        else jnp.zeros(y.shape[0], dtype=bool).at[0].set(1)
+    )
 
     log_emission = log_likelihood_func(X, y, model_params)
 

--- a/src/nemos/hmm/expectation_maximization.py
+++ b/src/nemos/hmm/expectation_maximization.py
@@ -515,8 +515,8 @@ def run_m_step(
     m_step_fn_model_params: Callable[
         [ModelParamsT, Array, Array, Array], Tuple[ModelParamsT, SolverState, Aux]
     ],
-    dirichlet_prior_alphas_init_prob: Array | None = None,
-    dirichlet_prior_alphas_transition: Array | None = None,
+    dirichlet_initial_proba: Array | None = None,
+    dirichlet_transition_proba: Array | None = None,
 ) -> Tuple[ModelParamsT, SolverState]:
     r"""
     Perform the M-step of the EM algorithm for an HMM.
@@ -543,9 +543,9 @@ def run_m_step(
         Callable that performs the M-step update for model parameters (e.g., coefficients and intercepts for a GLM).
         Should have signature: ``f(model_params, X, y, posteriors) -> (updated_params, state, aux)``.
         The regularizer/prior for the parameters should be configured within this callable.
-    dirichlet_prior_alphas_init_prob :
+    dirichlet_initial_proba :
         Prior for the initial states, shape ``(n_states,)``.
-    dirichlet_prior_alphas_transition :
+    dirichlet_transition_proba :
         Prior for the transition probabilities, shape ``(n_states, n_states)``.
 
     Returns
@@ -567,10 +567,10 @@ def run_m_step(
     log_initial_prob = _analytical_m_step_log_initial_prob(
         log_posteriors,
         is_new_session=is_new_session,
-        dirichlet_prior_alphas=dirichlet_prior_alphas_init_prob,
+        dirichlet_prior_alphas=dirichlet_initial_proba,
     )
     log_transition_prob = _analytical_m_step_log_transition_prob(
-        log_joint_posterior, dirichlet_prior_alphas=dirichlet_prior_alphas_transition
+        log_joint_posterior, dirichlet_prior_alphas=dirichlet_transition_proba
     )
 
     # Minimize negative log-likelihood to update model parameters

--- a/src/nemos/hmm/expectation_maximization.py
+++ b/src/nemos/hmm/expectation_maximization.py
@@ -264,7 +264,7 @@ def forward_pass(
     )
 
     # Compute log-likelihoods
-    log_conditionals = log_likelihood_func(X, y, model_params)
+    log_conditionals = log_likelihood_func(model_params, X, y)
 
     # Compute forward pass
     log_alphas, log_normalizers = _forward_pass(
@@ -455,7 +455,7 @@ def forward_backward(
     )
 
     # Compute log-likelihoods
-    log_conditionals = log_likelihood_func(X, y, model_params)
+    log_conditionals = log_likelihood_func(model_params, X, y)
 
     # Compute forward pass
     log_alphas, log_normalization = _forward_pass(
@@ -915,7 +915,7 @@ def max_sum(
         else jnp.zeros(y.shape[0], dtype=bool).at[0].set(1)
     )
 
-    log_emission = log_likelihood_func(X, y, model_params)
+    log_emission = log_likelihood_func(model_params, X, y)
 
     # Forward pass: similar to forward-backward, scan over all time points
     def forward_max_sum(omega_prev, xs):

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import abc
+import warnings
 from numbers import Number
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Literal, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
+import pynapple as nap
+from numpy.typing import ArrayLike, NDArray
 
+from .. import tree_utils
 from ..base_regressor import BaseRegressor
+from ..hmm.expectation_maximization import (
+    forward_backward,
+    forward_pass,
+    max_sum,
+)
 from ..regularizer import Regularizer
+from ..type_casting import support_pynapple
 from ..typing import (
     DESIGN_INPUT_TYPE,
 )
@@ -22,6 +32,7 @@ from .initialize_parameters import (
     setup_hmm_initialization,
 )
 from .params import HMMModelParamsT, HMMUserParams, HMMUserProvidedParamsT
+from .utils import _check_state_format
 from .validation import HMMValidator
 
 
@@ -384,3 +395,347 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
             X=X, y=y, is_new_session=is_new_session
         )
         return params, X, y, is_new_session
+
+    @abc.abstractmethod
+    def _log_likelihood(self, params: HMMModelParamsT, X, y):
+        """Compute the log-likelihood of the data given the model parameters."""
+        pass
+
+    def _score(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Private score compute."""
+        # filter for non-nans, grab data if needed
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+
+        # smooth with forward backward
+        _, log_norm = forward_pass(
+            params=params,
+            X=data,
+            y=y,
+            is_new_session=is_new_session,
+            # do we store this in the model during initialization?
+            log_likelihood_func=self._log_likelihood,
+        )
+        return jnp.sum(log_norm)
+
+    def score(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: ArrayLike,
+        is_new_session: Optional[ArrayLike] = None,
+        score_type: Literal[
+            "log-likelihood", "pseudo-r2-McFadden", "pseudo-r2-Cohen"
+        ] = "log-likelihood",
+        null_model: Optional[Literal["constant", "glm"]] = None,
+    ) -> jnp.ndarray:
+        """Compute the model score."""
+        if score_type == "log-likelihood" and null_model is not None:
+            warnings.warn(
+                "The null model is not used for the log-likelihood computation.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if score_type != "log-likelihood":
+            raise NotImplementedError(
+                f"score of type {score_type} not implemented yet!"
+            )
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        return self._score(params, X, y, is_new_session)
+
+    @support_pynapple(conv_type="jax")
+    def _smooth_proba(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Private smooth_proba compute."""
+        # filter for non-nans, grab data if needed
+        valid = tree_utils.get_valid_multitree(X, y)
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+
+        # smooth with forward backward
+        log_posteriors, _, _, _, _, _ = forward_backward(
+            params=params,
+            X=data,
+            y=y,
+            is_new_session=is_new_session,
+            log_likelihood_func=self._log_likelihood,
+        )
+        proba = jnp.exp(log_posteriors)
+        # renormalize (numerical precision due to exponentiation)
+        proba /= proba.sum(axis=1, keepdims=True)
+        # re-attach nans
+        proba = jnp.full((valid.shape[0], proba.shape[1]), jnp.nan).at[valid].set(proba)
+        return proba
+
+    def smooth_proba(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: Optional[ArrayLike] = None,
+    ) -> jnp.ndarray | nap.TsdFrame:
+        """Compute smoothing posterior probabilities over hidden states.
+
+        Computes the probability of being in each hidden state at each time point,
+        conditioned on the entire observed sequence. This method uses the forward-backward
+        algorithm to incorporate information from both past and future observations,
+        providing optimal state estimates given all available data.
+
+        The smoothing posteriors answer: "Given all observations, what is the probability
+        that the system was in state k at time t?"
+
+        Parameters
+        ----------
+        X
+            Predictors, shape ``(n_time_points, n_features)``.
+        y
+            Observations, shape ``(n_time_points,)`` for single observation or
+            ``(n_time_points, n_observations)`` for population.
+
+        Returns
+        -------
+        posteriors
+            Smoothing posterior probabilities, shape ``(n_time_points, n_states)``.
+            Each row sums to 1 and represents the probability distribution over states
+            at that time point.
+
+        Raises
+        ------
+        ValueError
+            If the model has not been fit (``fit()`` must be called first).
+        ValueError
+            If inputs contain NaN values in the middle of epochs (only boundary NaNs allowed).
+        ValueError
+            If X and y have inconsistent shapes or features.
+
+        See Also
+        --------
+        filter_proba : Compute filtering posteriors (conditioned on past observations only).
+        decode_state : Compute most likely state sequence (Viterbi decoding).
+
+        Notes
+        -----
+        - Smoothing provides better state estimates than filtering because it uses all data
+        - The algorithm properly handles session boundaries and NaN values at epoch borders
+        """
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        return self._smooth_proba(params, X, y, is_new_session)
+
+    @support_pynapple(conv_type="jax")
+    def _filter_proba(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Compute filtering probabilities without validation (internal method)."""
+        # filter for non-nans, grab data if needed
+        valid = tree_utils.get_valid_multitree(X, y)
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+        log_proba, _ = forward_pass(
+            params,
+            data,
+            y,
+            is_new_session=is_new_session,
+            log_likelihood_func=self._log_likelihood,
+        )
+        proba = jnp.exp(log_proba)
+        # renormalize (numerical errors due to exponentiating)
+        proba /= proba.sum(axis=1, keepdims=True)
+        # re-attach nans
+        proba = jnp.full((valid.shape[0], proba.shape[1]), jnp.nan).at[valid].set(proba)
+        return proba
+
+    def filter_proba(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: Optional[ArrayLike] = None,
+    ) -> jnp.ndarray | nap.TsdFrame:
+        """Compute filtering posterior probabilities over hidden states.
+
+        Computes the probability of being in each hidden state at each time point,
+        conditioned only on observations up to that time point. This method uses the
+        forward pass of the forward-backward algorithm, providing causal (online) state
+        estimates that only use past and current observations.
+
+        The filtering posteriors answer: "Given observations up to time t, what is the
+        probability that the system is in state k at time t?"
+
+        Parameters
+        ----------
+        X
+            Predictors, shape ``(n_time_points, n_features)``.
+        y
+            Observations, shape ``(n_time_points,)`` for single observation or
+            ``(n_time_points, n_observations)`` for population.
+
+        Returns
+        -------
+        posteriors
+            Filtering posterior probabilities, shape ``(n_time_points, n_states)``.
+            Each row sums to 1 and represents the probability distribution over states
+            at that time point conditioned on past observations.
+
+        Raises
+        ------
+        ValueError
+            If the model has not been fit (``fit()`` must be called first).
+        ValueError
+            If inputs contain NaN values in the middle of epochs (only boundary NaNs allowed).
+        ValueError
+            If X and y have inconsistent shapes or features.
+
+        See Also
+        --------
+        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
+        decode_state : Compute most likely state sequence (Viterbi decoding).
+
+        Notes
+        -----
+        - Filtering provides causal state estimates suitable for online/real-time applications
+        - Smoothing provides better estimates but requires all data (non-causal)
+        - The algorithm properly handles session boundaries and NaN values at epoch borders
+        - NaN values are removed before inference, but session markers are preserved
+        - For pynapple inputs, the output TsdFrame has columns named "state_0", "state_1", etc.
+        """
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        return self._filter_proba(params, X, y, is_new_session)
+
+    @support_pynapple(conv_type="jax")
+    def _decode_state(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+        return_index: bool,
+    ) -> jnp.ndarray:
+        """Decode most likely state sequence without validation (internal method)."""
+        # filter for non-nans, grab data if needed
+        valid = tree_utils.get_valid_multitree(X, y)
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+
+        decoded_states = max_sum(
+            params,
+            data,
+            y,
+            is_new_session=is_new_session,
+            log_likelihood_func=self._log_likelihood,
+            return_index=return_index,
+        )
+
+        # reattach nans
+        decoded_states = (
+            jnp.full((valid.shape[0], *decoded_states.shape[1:]), jnp.nan)
+            .at[valid]
+            .set(decoded_states)
+        )
+        return decoded_states
+
+    def decode_state(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: ArrayLike,
+        is_new_session: Optional[ArrayLike] = None,
+        state_format: Literal["one-hot", "index"] = "one-hot",
+    ) -> jnp.ndarray | nap.TsdFrame:
+        """Compute the most likely hidden state sequence (Viterbi decoding).
+
+        Finds the single most likely sequence of hidden states that best explains
+        the observed data. This method uses the Viterbi (max-sum) algorithm to
+        compute the state sequence that maximizes the joint probability of states
+        and observations.
+
+        Unlike ``smooth_proba()`` and ``filter_proba()`` which return probability
+        distributions over states at each time point, this method makes a deterministic
+        choice of the single best state sequence.
+
+        The decoded states answer: "What is the most likely sequence of states that
+        generated the observed data?"
+
+        Parameters
+        ----------
+        X
+            Predictors, shape ``(n_time_points, n_features)``.
+        y
+            Observations, shape ``(n_time_points,)`` for single observation or
+            ``(n_time_points, n_observations)`` for population.
+        state_format
+            Format of the returned states:
+
+            - ``"one-hot"``: Binary matrix of shape ``(n_time_points, n_states)`` where
+              each row has a single 1 indicating the decoded state.
+            - ``"index"``: Integer array of shape ``(n_time_points,)`` with values
+              in ``[0, n_states-1]`` indicating the decoded state.
+
+        Returns
+        -------
+        decoded_states
+            Most likely state sequence:
+
+            - If ``state_format="one-hot"``: shape ``(n_time_points, n_states)``.
+              Each row is a one-hot vector with 1 in the position of the decoded state.
+            - If ``state_format="index"``: shape ``(n_time_points,)``.
+              Integer indices of the decoded states.
+
+        Raises
+        ------
+        ValueError
+            If the model has not been fit (``fit()`` must be called first).
+        ValueError
+            If inputs contain NaN values in the middle of epochs (only boundary NaNs allowed).
+        ValueError
+            If X and y have inconsistent shapes or features.
+
+        See Also
+        --------
+        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
+        filter_proba : Compute filtering posteriors (conditioned on past observations only).
+
+        Notes
+        -----
+        - Viterbi decoding finds the globally optimal state sequence, not the sequence
+          of individually most likely states from ``smooth_proba()``
+        - This is a hard assignment (single best path) unlike probabilistic posteriors
+        - The algorithm properly handles session boundaries and NaN values at epoch borders
+        - Decoding is useful for segmenting continuous data into discrete behavioral states
+        - For uncertainty estimates about states, use ``smooth_proba()`` instead
+        """
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        # validate state_format
+        _check_state_format(state_format)
+        # define the return type for the max-sum
+        return_index = False if state_format == "one-hot" else True
+        return self._decode_state(params, X, y, is_new_session, return_index)

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -288,37 +288,6 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         """Validate and set the dictionary of initialization functions for HMM parameters."""
         self._hmm_initialization_funcs = _validate_init_funcs_keys(value)
 
-    def _check_hmm_is_fit(self):
-        """Ensure the HMM parameters have been fitted."""
-        flat_params = [
-            self.initial_prob_,
-            self.transition_prob_,
-        ]
-        is_missing = [x is None for x in flat_params]
-        if any(is_missing):
-            param_labels = [
-                "initial_prob_",
-                "transition_prob_",
-            ]
-            missing_params = [
-                p for p, missing in zip(param_labels, is_missing) if missing
-            ]
-            raise ValueError(
-                f"This {self._validator.model_class} instance is not fitted yet. The following attributes are not set:"
-                f" {missing_params}.\nPlease fit the HMM model first or "
-                "set the missing attributes."
-            )
-
-    @abc.abstractmethod
-    def _check_model_is_fit(self):
-        """Ensure the model-specific parameters have been fitted."""
-        pass
-
-    def _check_is_fit(self):
-        """Ensure the model has been fitted."""
-        self._check_hmm_is_fit()
-        self._check_model_is_fit()
-
     def _hmm_params_initialization(
         self,
         X: DESIGN_INPUT_TYPE,
@@ -371,6 +340,37 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         else:
             return self._validator.to_model_params(user_params)
 
+    def _check_hmm_is_fit(self):
+        """Ensure the HMM parameters have been fitted."""
+        flat_params = [
+            self.initial_prob_,
+            self.transition_prob_,
+        ]
+        is_missing = [x is None for x in flat_params]
+        if any(is_missing):
+            param_labels = [
+                "initial_prob_",
+                "transition_prob_",
+            ]
+            missing_params = [
+                p for p, missing in zip(param_labels, is_missing) if missing
+            ]
+            raise ValueError(
+                f"This {self._validator.model_class} instance is not fitted yet. The following attributes are not set:"
+                f" {missing_params}.\nPlease fit the HMM model first or "
+                "set the missing attributes."
+            )
+
+    @abc.abstractmethod
+    def _check_model_is_fit(self):
+        """Ensure the model-specific parameters have been fitted."""
+        pass
+
+    def _check_is_fit(self):
+        """Ensure the model has been fitted."""
+        self._check_hmm_is_fit()
+        self._check_model_is_fit()
+
     def _validate_and_prepare_inputs(self, X, y, is_new_session=None):
         """Validate and prepare inputs."""
         # check if the model was fit
@@ -384,8 +384,3 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
             X=X, y=y, is_new_session=is_new_session
         )
         return params, X, y, is_new_session
-
-    @abc.abstractmethod
-    def _log_likelihood(self, params: HMMModelParamsT, X, y):
-        """Compute the log-likelihood of the data given the model parameters."""
-        pass

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -1,0 +1,391 @@
+"""Base class for HMM models."""
+
+from __future__ import annotations
+
+import abc
+from numbers import Number
+from typing import Any, Callable, Optional, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+
+from ..base_regressor import BaseRegressor
+from ..regularizer import Regularizer
+from ..typing import (
+    DESIGN_INPUT_TYPE,
+)
+from .initialize_parameters import (
+    INITIALIZATION_FN_DICT,
+    _resolve_dirichlet_priors,
+    _validate_init_funcs_keys,
+    generate_hmm_initial_params,
+    setup_hmm_initialization,
+)
+from .params import HMMModelParamsT, HMMUserParams, HMMUserProvidedParamsT
+from .validation import HMMValidator
+
+
+class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
+    """Base class for HMM models.
+
+    This class implements the core functionality for HMMs, handling tasks related to HMM parameters that are common
+    across HMM-based models. Model-specific parameters and methods should be implemented in subclasses, where required
+    abstract methods are defined.
+
+    Parameters
+    ----------
+    n_states :
+        The number of hidden states in the HMM. Must be a positive integer.
+    dirichlet_prior_alphas_init_prob :
+        Alpha parameters for the Dirichlet prior over the initial state probabilities.
+        Shape ``(n_states,)``. If None, a flat (uninformative) prior is assumed.
+    dirichlet_prior_alphas_transition :
+        Alpha parameters for the Dirichlet prior over the transition probabilities.
+        Shape ``(n_states, n_states)``. If None, a flat (uninformative) prior is assumed.
+    regularizer :
+        Regularization to use for model parameter optimization. Defines the regularization scheme
+        and related parameters. Default is UnRegularized.
+    regularizer_strength :
+        Typically a float. Default is None. Sets the regularizer strength for the model parameters.
+        If a user does not pass a value, and it is needed for regularization,
+        a warning will be raised and the strength will default to 1.0.
+    solver_name :
+        Solver to use for GLM optimization within the M-step. Defines the optimization scheme
+        and related parameters. The solver must be an appropriate match for the chosen regularizer.
+        Default is None. If no solver specified, one will be chosen based on the regularizer.
+        See the table above for regularizer/optimizer pairings.
+    solver_kwargs :
+        Optional dictionary for keyword arguments that are passed to the solver when instantiated.
+        E.g., stepsize, tol, acceleration, etc.
+    maxiter :
+        Maximum number of EM iterations. Default is 1000.
+    tol :
+        Convergence tolerance for the EM algorithm. The algorithm stops when the absolute change
+        in log-likelihood between consecutive iterations falls below this threshold. Default is 1e-8.
+    seed :
+        JAX PRNG key for random number generation during initialization. Default is
+        ``jax.random.PRNGKey(123)``.
+    hmm_initialization_funcs :
+        Dictionary specifying the initialization functions for the HMM parameters. This parameter is
+        included at initialization for scikit-learn compatibility; however, users should set up the
+        initialization functions using the :meth:`~nemos.hmm.hmm.BaseHMM.setup` method after model
+        instantiation.
+    """
+
+    _validator_class: type[HMMValidator[HMMUserProvidedParamsT, HMMModelParamsT]]
+
+    def __init__(
+        self,
+        n_states: int,
+        dirichlet_prior_alphas_init_prob: Union[
+            jnp.ndarray, None
+        ] = None,  # (n_state, )
+        dirichlet_prior_alphas_transition: Union[
+            jnp.ndarray | None
+        ] = None,  # (n_state, n_state):
+        regularizer: Optional[Union[str, Regularizer]] = None,
+        regularizer_strength: Optional[
+            Any
+        ] = None,  # this is used to regularize model params
+        solver_name: str = None,
+        solver_kwargs: Optional[dict] = None,
+        maxiter: int = 1000,
+        tol: float = 1e-8,
+        seed=jax.random.PRNGKey(123),
+        hmm_initialization_funcs: INITIALIZATION_FN_DICT = {},
+    ):
+        super().__init__(
+            regularizer=regularizer,
+            regularizer_strength=regularizer_strength,
+            solver_name=solver_name,
+            solver_kwargs=solver_kwargs,
+        )
+        self.n_states = n_states
+        # set the prior params
+        self.dirichlet_prior_alphas_init_prob = dirichlet_prior_alphas_init_prob
+        self.dirichlet_prior_alphas_transition = dirichlet_prior_alphas_transition
+
+        self.seed = seed
+        self.maxiter = maxiter
+        self.tol = tol
+
+        # fit attributes
+        self.transition_prob_: jnp.ndarray | None = None
+        self.initial_prob_: jnp.ndarray | None = None
+
+        self.hmm_initialization_funcs = hmm_initialization_funcs
+
+    def setup(
+        self,
+        initial_proba_init: Optional[str | Callable] = None,
+        initial_proba_init_kwargs: Optional[dict] = None,
+        transition_proba_init: Optional[str | Callable] = None,
+        transition_proba_init_kwargs: Optional[dict] = None,
+    ):
+        """
+        Set up the HMM model with specified initialization functions for the initial and transition probabilities.
+
+        An optional initialization step that allows for users to specify initialization functions other than the
+        defaulst for initial and transition probabilities. The user can specify other built-in initialization functions
+        or provide custom ones. If no initialization functions are provided, default initialization will be used.
+
+        Available built-in initialization functions include:
+        - For initial probabilities: "uniform" (default), "random", "kmeans"
+        - For transition probabilities: "sticky" (default), "uniform", "random", "kmeans"
+
+        Parameters
+        ----------
+        initial_proba_init :
+            A string identifier for a built-in initialization function or a custom callable for initializing the
+            initial probabilities of the HMM states.
+        initial_proba_init_kwargs :
+            A dictionary of keyword arguments to pass to the initial probability initialization function.
+        transition_proba_init :
+            A string identifier for a built-in initialization function or a custom callable for initializing the
+            transition probabilities between HMM states.
+        transition_proba_init_kwargs :
+            A dictionary of keyword arguments to pass to the transition probability initialization function.
+        """
+        self._hmm_initialization_funcs = setup_hmm_initialization(
+            initial_proba_init=initial_proba_init,
+            initial_proba_init_kwargs=initial_proba_init_kwargs,
+            transition_proba_init=transition_proba_init,
+            transition_proba_init_kwargs=transition_proba_init_kwargs,
+            init_funcs=self._hmm_initialization_funcs,
+        )
+
+    @property
+    def n_states(self) -> int:
+        """Number of hidden states of the HMM."""
+        return self._n_states
+
+    @n_states.setter
+    def n_states(self, n_states: int):
+        """Set the number of hidden states and validator."""
+        # quick sanity check and assignment
+        if isinstance(n_states, int) and n_states > 0:
+            self._n_states = n_states
+            self._validator = self._validator_class(n_states=n_states)
+            return
+
+        # further checks for other valid numeric types (like non-negative float with no-decimals)
+        if not isinstance(n_states, Number):
+            raise TypeError(
+                f"n_states must be a positive integer. "
+                f"n_states is of type ``{type(n_states)}`` instead."
+            )
+
+        # provided a non-integer number (check that has no decimals)
+        int_n_states = int(n_states)
+        if int_n_states != n_states:
+            raise TypeError(
+                f"n_states must be a positive integer. ``{n_states}`` provided instead."
+            )
+        elif int_n_states < 1:
+            raise ValueError(
+                f"n_states must be a positive integer. ``{n_states}`` provided instead."
+            )
+        self._n_states = int_n_states
+        self._validator = self._validator_class(n_states=n_states)
+
+    @property
+    def maxiter(self):
+        """EM maximum number of iterations."""
+        return self._maxiter
+
+    @maxiter.setter
+    def maxiter(self, maxiter: int):
+        """Validate and set the maximum number of iterations for the EM algorithm."""
+        if not isinstance(maxiter, Number) or maxiter != int(maxiter) or maxiter <= 0:
+            raise ValueError(
+                f"``maxiter`` must be a strictly positive integer. {maxiter} provided."
+            )
+        self._maxiter = int(maxiter)
+
+    @property
+    def tol(self):
+        """Tolerance for the EM algorithm convergence criterion.
+
+        The algorithm stops when the absolute change in log-likelihood between
+        consecutive iterations falls below this threshold:
+        |log_likelihood_current - log_likelihood_previous| < tol
+
+        Returns
+        -------
+            float: Convergence tolerance value.
+        """
+        return self._tol
+
+    @tol.setter
+    def tol(self, tol: float):
+        """Validate and set the tolerance for the EM algorithm convergence criterion."""
+        if not isinstance(tol, Number) or tol <= 0:
+            raise ValueError(
+                f"``tol`` must be a strictly positive float. {tol} provided."
+            )
+        self._tol = float(tol)
+
+    @property
+    def dirichlet_prior_alphas_init_prob(self) -> jnp.ndarray | None:
+        """Alpha parameters of the Dirichlet prior over the initial probabilities of HMM states.
+
+        If ``None``, a flat prior is assumed.
+        """
+        return self._dirichlet_prior_alphas_init_prob
+
+    @dirichlet_prior_alphas_init_prob.setter
+    def dirichlet_prior_alphas_init_prob(self, value: jnp.ndarray | None):
+        """Validate and set the alpha parameters of the Dirichlet prior over the initial probabilities."""
+        self._dirichlet_prior_alphas_init_prob = _resolve_dirichlet_priors(
+            value, (self._n_states,)
+        )
+
+    @property
+    def dirichlet_prior_alphas_transition(self) -> jnp.ndarray | None:
+        """Alpha parameters of the Dirichlet prior over the initial probabilities of HMM states.
+
+        If ``None``, a flat prior is assumed.
+        """
+        return self._dirichlet_prior_alphas_transition
+
+    @dirichlet_prior_alphas_transition.setter
+    def dirichlet_prior_alphas_transition(self, value: jnp.ndarray | None):
+        """Validate and set the alpha parameters of the Dirichlet prior over the transition probabilities."""
+        self._dirichlet_prior_alphas_transition = _resolve_dirichlet_priors(
+            value, (self._n_states, self._n_states)
+        )
+
+    @property
+    def seed(self):
+        """Random seed as a jax PRNG key."""
+        return self._seed
+
+    @seed.setter
+    def seed(self, value):
+        """Validate and set the random seed as a JAX PRNG key."""
+        try:
+            value = jnp.asarray(value)
+        except (TypeError, ValueError) as e:
+            raise TypeError(
+                f"seed must be a JAX PRNG key (jax.random.PRNGKey). "
+                f"Got {type(value).__name__} instead."
+            ) from e
+        # Validate it's a JAX PRNG key
+        if value.shape != (2,) or value.dtype != jnp.uint32:
+            raise TypeError(
+                f"seed must be a JAX PRNG key (jax.random.PRNGKey). "
+                f"Got {type(value).__name__} with shape {getattr(value, 'shape', 'N/A')}"
+            )
+        self._seed = value
+
+    @property
+    def hmm_initialization_funcs(self):
+        """Dictionary of initialization functions for HMM parameters."""
+        return self._hmm_initialization_funcs
+
+    @hmm_initialization_funcs.setter
+    def hmm_initialization_funcs(self, value: INITIALIZATION_FN_DICT | dict):
+        """Validate and set the dictionary of initialization functions for HMM parameters."""
+        self._hmm_initialization_funcs = _validate_init_funcs_keys(value)
+
+    def _check_hmm_is_fit(self):
+        """Ensure the HMM parameters have been fitted."""
+        flat_params = [
+            self.initial_prob_,
+            self.transition_prob_,
+        ]
+        is_missing = [x is None for x in flat_params]
+        if any(is_missing):
+            param_labels = [
+                "initial_prob_",
+                "transition_prob_",
+            ]
+            missing_params = [
+                p for p, missing in zip(param_labels, is_missing) if missing
+            ]
+            raise ValueError(
+                f"This {self._validator.model_class} instance is not fitted yet. The following attributes are not set:"
+                f" {missing_params}.\nPlease fit the HMM model first or "
+                "set the missing attributes."
+            )
+
+    @abc.abstractmethod
+    def _check_model_is_fit(self):
+        """Ensure the model-specific parameters have been fitted."""
+        pass
+
+    def _check_is_fit(self):
+        """Ensure the model has been fitted."""
+        self._check_hmm_is_fit()
+        self._check_model_is_fit()
+
+    def _hmm_params_initialization(
+        self,
+        X: DESIGN_INPUT_TYPE,
+        y: jnp.ndarray,
+        is_new_session: jnp.ndarray,
+    ) -> Tuple[HMMUserParams, bool]:
+        """HMM parameter initialization."""
+        hmm_params = generate_hmm_initial_params(
+            self._n_states,
+            X,
+            y,
+            random_key=self._seed,
+            init_funcs=self._hmm_initialization_funcs,
+        )
+        validate_params = self._hmm_initialization_funcs.get(
+            "initial_proba_init_custom", True
+        ) or self._hmm_initialization_funcs.get("transition_proba_init_custom", True)
+        return hmm_params, validate_params
+
+    @abc.abstractmethod
+    def _model_params_initialization(self, X, y, is_new_session):
+        """
+        Model-specific parameter initialization.
+
+        Should return a tuple of (model_params, validate_model) where model_params is the
+        initialized model parameters and validate_model is a boolean indicating whether the
+        initialized parameters need to be validated.
+        """
+        pass
+
+    def _model_specific_initialization(self, X, y, is_new_session):
+        """Model-specific initialization."""
+        hmm_params, validate_hmm = self._hmm_params_initialization(
+            X,
+            y,
+            is_new_session,
+        )
+        model_params, validate_model = self._model_params_initialization(
+            X,
+            y,
+            is_new_session,
+        )
+        user_params = self._validator.wrap_user_params(
+            model_params
+        ) + self._validator.wrap_user_params(hmm_params)
+        if validate_hmm or validate_model:
+            model_params = self._validator.validate_and_cast_params(user_params)
+            self._validator.validate_consistency(model_params, X=X, y=y)
+            return model_params
+        else:
+            return self._validator.to_model_params(user_params)
+
+    def _validate_and_prepare_inputs(self, X, y, is_new_session=None):
+        """Validate and prepare inputs."""
+        # check if the model was fit
+        self._check_is_fit()
+        params = self._get_model_params()
+
+        # validate inputs
+        self._validator.validate_inputs(X=X, y=y)
+        self._validator.validate_consistency(params, X=X, y=y)
+        is_new_session = self._validator.validate_and_cast_is_new_session(
+            X=X, y=y, is_new_session=is_new_session
+        )
+        return params, X, y, is_new_session
+
+    @abc.abstractmethod
+    def _log_likelihood(self, params: HMMModelParamsT, X, y):
+        """Compute the log-likelihood of the data given the model parameters."""
+        pass

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -25,7 +25,9 @@ from ..typing import (
     DESIGN_INPUT_TYPE,
 )
 from .initialize_parameters import (
+    INITIALIZATION_FN_DICT,
     _resolve_dirichlet_priors,
+    _validate_init_funcs_keys,
     generate_hmm_initial_params,
     setup_hmm_initialization,
 )
@@ -87,7 +89,7 @@ class BaseHMM(
     """
 
     _validator_class: type[HMMValidator[HMMUserProvidedParamsT, HMMModelParamsT]]
-    _default_init_dict: Optional[dict] = None
+    _default_init_dict: dict = INITIALIZATION_FN_DICT
 
     def __init__(
         self,
@@ -180,6 +182,7 @@ class BaseHMM(
             transition_proba_init=transition_proba_init,
             transition_proba_init_kwargs=transition_proba_init_kwargs,
             init_funcs=self._initialization_funcs,
+            default_init_dict=self._default_init_dict,
         )
 
     @property
@@ -319,7 +322,10 @@ class BaseHMM(
         This should only be called by __init__ for sklearn cloning, users should
         use the `setup` method to set initialization functions.
         """
-        self._initialization_funcs = value
+        # always key validated in a model dependent way
+        self._initialization_funcs = _validate_init_funcs_keys(
+            value, self._default_init_dict
+        )
         self.setup()
 
     def _hmm_params_initialization(
@@ -337,7 +343,6 @@ class BaseHMM(
             is_new_session,
             random_key_pair=random_key_pair,
             init_funcs=self._initialization_funcs,
-            default_init_dict=self._default_init_dict,
         )
         validate_params = self._initialization_funcs.get(
             "initial_proba_init_custom", True

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -319,8 +319,9 @@ class BaseHMM(
         """
         Set the dictionary of initialization functions for HMM parameters.
 
-        This should only be called by __init__ for sklearn cloning, users should
-        use the `setup` method to set initialization functions.
+        Validates keys against the model-specific ``_default_init_dict`` and merges
+        with defaults before storing. Calls :meth:`setup` afterward to apply any
+        function/kwargs updates. May be called directly or via ``__init__``.
         """
         # always key validated in a model dependent way
         self._initialization_funcs = _validate_init_funcs_keys(
@@ -335,7 +336,28 @@ class BaseHMM(
         is_new_session: jnp.ndarray,
         random_key_pair: jax.Array,
     ) -> Tuple[HMMUserParams, bool]:
-        """HMM parameter initialization."""
+        """
+        Initialize HMM parameters (initial and transition probabilities).
+
+        Parameters
+        ----------
+        X :
+            Design matrix.
+        y :
+            Target observations.
+        is_new_session :
+            Boolean array marking the start of new sessions.
+        random_key_pair :
+            Pair of JAX PRNG keys passed to the initial-prob and transition-prob
+            initialization functions respectively.
+
+        Returns
+        -------
+        :
+            Tuple of ``(hmm_params, validate_params)`` where ``hmm_params`` is an
+            ``HMMUserParams`` and ``validate_params`` is True when custom initialization
+            functions were used (requiring downstream parameter validation).
+        """
         hmm_params = generate_hmm_initial_params(
             self._n_states,
             X,
@@ -354,9 +376,22 @@ class BaseHMM(
         """
         Model-specific parameter initialization.
 
-        Should return a tuple of (model_params, validate_model) where model_params is the
-        initialized model parameters and validate_model is a boolean indicating whether the
-        initialized parameters need to be validated.
+        Parameters
+        ----------
+        X :
+            Design matrix.
+        y :
+            Target observations.
+        is_new_session :
+            Boolean array marking the start of new sessions.
+        random_key :
+            JAX PRNG key for any stochastic initialization.
+
+        Returns
+        -------
+        :
+            Tuple of ``(model_params, validate_model)`` where ``validate_model`` is True
+            when the initialized parameters require downstream validation.
         """
         pass
 

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -328,6 +328,7 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
             self._n_states,
             X,
             y,
+            is_new_session,
             random_key=self._seed,
             init_funcs=self._hmm_initialization_funcs,
         )

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -87,7 +87,7 @@ class BaseHMM(
     """
 
     _validator_class: type[HMMValidator[HMMUserProvidedParamsT, HMMModelParamsT]]
-    _valid_init_funcs: Optional[dict] = None
+    _default_init_dict: Optional[dict] = None
 
     def __init__(
         self,
@@ -337,7 +337,7 @@ class BaseHMM(
             is_new_session,
             random_key_pair=random_key_pair,
             init_funcs=self._initialization_funcs,
-            valid_funcs=self._valid_init_funcs,
+            default_init_dict=self._default_init_dict,
         )
         validate_params = self._initialization_funcs.get(
             "initial_proba_init_custom", True

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -134,12 +134,27 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         Set up the HMM model with specified initialization functions for the initial and transition probabilities.
 
         An optional initialization step that allows for users to specify initialization functions other than the
-        defaulst for initial and transition probabilities. The user can specify other built-in initialization functions
+        defaults for initial and transition probabilities. The user can specify other built-in initialization functions
         or provide custom ones. If no initialization functions are provided, default initialization will be used.
 
         Available built-in initialization functions include:
         - For initial probabilities: "uniform" (default), "random", "kmeans"
         - For transition probabilities: "sticky" (default), "uniform", "random", "kmeans"
+
+        Any custom initialization function provided by the user should be a callable that matches the following input
+        (n_states, X, y, is_new_session, random_key, **kwargs) and returns an array of the appropriate shape for the
+        parameters it initializes (initial probabilities should return shape (n_states,) and transition probabilities
+        should return shape (n_states, n_states)). Even if the function does not use all the inputs, they should be
+        included in the function signature to ensure compatibility with the setup process.
+
+        An example of a custom initialization function for initial probabilities could be:
+        ```
+        def custom_initial_proba_init(n_states, X, y, is_new_session, random_key, min_prob=0.05):
+            init_prob = jax.random.uniform(random_key, (n_states,), dtype=float)
+            init_prob = init_prob / init_prob.sum()  # normalize to sum to 1
+            init_prob = jnp.clip(init_prob, a_min=min_prob)  # enforce minimum probability
+            return init_prob / init_prob.sum()  # renormalize after clipping
+        ```
 
         Parameters
         ----------

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import warnings
 from numbers import Number
-from typing import Any, Callable, Literal, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Generic, Literal, Optional, Tuple, TypeVar, Union
 
 import jax
 import jax.numpy as jnp
@@ -25,7 +25,6 @@ from ..typing import (
     DESIGN_INPUT_TYPE,
 )
 from .initialize_parameters import (
-    INITIALIZATION_FN_DICT,
     _resolve_dirichlet_priors,
     generate_hmm_initial_params,
     setup_hmm_initialization,
@@ -37,7 +36,10 @@ from .validation import HMMValidator
 INITIALIZATION_FN_DICT_T = TypeVar("INITIALIZATION_FN_DICT_T")
 
 
-class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
+class BaseHMM(
+    BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT],
+    Generic[HMMModelParamsT, HMMUserProvidedParamsT, INITIALIZATION_FN_DICT_T],
+):
     """Base class for HMM models.
 
     This class implements the core functionality for HMMs, handling tasks related to HMM parameters that are common
@@ -304,12 +306,12 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         self._seed = value
 
     @property
-    def initialization_funcs(self):
+    def initialization_funcs(self) -> INITIALIZATION_FN_DICT_T | None:
         """Dictionary of initialization functions for HMM parameters."""
         return self._initialization_funcs
 
     @initialization_funcs.setter
-    def initialization_funcs(self, value: INITIALIZATION_FN_DICT | None):
+    def initialization_funcs(self, value: INITIALIZATION_FN_DICT_T | None):
         """
         Set the dictionary of initialization functions for HMM parameters.
 

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -397,7 +397,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         return params, X, y, is_new_session
 
     @abc.abstractmethod
-    def _log_likelihood(self, params: HMMModelParamsT, X, y):
+    def _log_likelihood(
+        self, params: HMMModelParamsT, X: DESIGN_INPUT_TYPE, y: ArrayLike
+    ) -> jnp.ndarray:
         """Compute the log-likelihood of the data given the model parameters."""
         pass
 

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -27,7 +27,6 @@ from ..typing import (
 from .initialize_parameters import (
     INITIALIZATION_FN_DICT,
     _resolve_dirichlet_priors,
-    _validate_init_funcs_keys,
     generate_hmm_initial_params,
     setup_hmm_initialization,
 )
@@ -47,10 +46,10 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
     ----------
     n_states :
         The number of hidden states in the HMM. Must be a positive integer.
-    dirichlet_prior_alphas_init_prob :
+    dirichlet_initial_proba :
         Alpha parameters for the Dirichlet prior over the initial state probabilities.
         Shape ``(n_states,)``. If None, a flat (uninformative) prior is assumed.
-    dirichlet_prior_alphas_transition :
+    dirichlet_transition_proba :
         Alpha parameters for the Dirichlet prior over the transition probabilities.
         Shape ``(n_states, n_states)``. If None, a flat (uninformative) prior is assumed.
     regularizer :
@@ -88,10 +87,8 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
     def __init__(
         self,
         n_states: int,
-        dirichlet_prior_alphas_init_prob: Union[
-            jnp.ndarray, None
-        ] = None,  # (n_state, )
-        dirichlet_prior_alphas_transition: Union[
+        dirichlet_initial_proba: Union[jnp.ndarray, None] = None,  # (n_state, )
+        dirichlet_transition_proba: Union[
             jnp.ndarray | None
         ] = None,  # (n_state, n_state):
         regularizer: Optional[Union[str, Regularizer]] = None,
@@ -103,7 +100,7 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         maxiter: int = 1000,
         tol: float = 1e-8,
         seed=jax.random.PRNGKey(123),
-        hmm_initialization_funcs: INITIALIZATION_FN_DICT = {},
+        hmm_initialization_funcs: Optional[INITIALIZATION_FN_DICT] = None,
     ):
         super().__init__(
             regularizer=regularizer,
@@ -113,16 +110,16 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         )
         self.n_states = n_states
         # set the prior params
-        self.dirichlet_prior_alphas_init_prob = dirichlet_prior_alphas_init_prob
-        self.dirichlet_prior_alphas_transition = dirichlet_prior_alphas_transition
+        self.dirichlet_initial_proba = dirichlet_initial_proba
+        self.dirichlet_transition_proba = dirichlet_transition_proba
 
         self.seed = seed
         self.maxiter = maxiter
         self.tol = tol
 
         # fit attributes
-        self.transition_prob_: jnp.ndarray | None = None
-        self.initial_prob_: jnp.ndarray | None = None
+        self.transition_prob_: Optional[jnp.ndarray] = None
+        self.initial_prob_: Optional[jnp.ndarray] = None
 
         self.hmm_initialization_funcs = hmm_initialization_funcs
 
@@ -237,32 +234,32 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         self._tol = float(tol)
 
     @property
-    def dirichlet_prior_alphas_init_prob(self) -> jnp.ndarray | None:
+    def dirichlet_initial_proba(self) -> jnp.ndarray | None:
         """Alpha parameters of the Dirichlet prior over the initial probabilities of HMM states.
 
         If ``None``, a flat prior is assumed.
         """
-        return self._dirichlet_prior_alphas_init_prob
+        return self._dirichlet_initial_proba
 
-    @dirichlet_prior_alphas_init_prob.setter
-    def dirichlet_prior_alphas_init_prob(self, value: jnp.ndarray | None):
+    @dirichlet_initial_proba.setter
+    def dirichlet_initial_proba(self, value: jnp.ndarray | None):
         """Validate and set the alpha parameters of the Dirichlet prior over the initial probabilities."""
-        self._dirichlet_prior_alphas_init_prob = _resolve_dirichlet_priors(
+        self._dirichlet_initial_proba = _resolve_dirichlet_priors(
             value, (self._n_states,)
         )
 
     @property
-    def dirichlet_prior_alphas_transition(self) -> jnp.ndarray | None:
+    def dirichlet_transition_proba(self) -> jnp.ndarray | None:
         """Alpha parameters of the Dirichlet prior over the initial probabilities of HMM states.
 
         If ``None``, a flat prior is assumed.
         """
-        return self._dirichlet_prior_alphas_transition
+        return self._dirichlet_transition_proba
 
-    @dirichlet_prior_alphas_transition.setter
-    def dirichlet_prior_alphas_transition(self, value: jnp.ndarray | None):
+    @dirichlet_transition_proba.setter
+    def dirichlet_transition_proba(self, value: jnp.ndarray | None):
         """Validate and set the alpha parameters of the Dirichlet prior over the transition probabilities."""
-        self._dirichlet_prior_alphas_transition = _resolve_dirichlet_priors(
+        self._dirichlet_transition_proba = _resolve_dirichlet_priors(
             value, (self._n_states, self._n_states)
         )
 
@@ -295,9 +292,15 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         return self._hmm_initialization_funcs
 
     @hmm_initialization_funcs.setter
-    def hmm_initialization_funcs(self, value: INITIALIZATION_FN_DICT | dict):
-        """Validate and set the dictionary of initialization functions for HMM parameters."""
-        self._hmm_initialization_funcs = _validate_init_funcs_keys(value)
+    def hmm_initialization_funcs(self, value: INITIALIZATION_FN_DICT | None):
+        """
+        Set the dictionary of initialization functions for HMM parameters.
+
+        This should only be called by __init__ for sklearn cloning, users should
+        use the `setup` method to set initialization functions.
+        """
+        self._hmm_initialization_funcs = value
+        self.setup()
 
     def _hmm_params_initialization(
         self,

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -363,7 +363,7 @@ class BaseHMM(
             X,
             y,
             is_new_session,
-            random_keys=hmm_keys,
+            random_key_pair=hmm_keys,
         )
         model_params, validate_model = self._model_params_initialization(
             X,

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -395,7 +395,7 @@ class BaseHMM(
         """
         pass
 
-    def _model_specific_initialization(self, X, y, is_new_session):
+    def _model_specific_initialization(self, X, y, is_new_session=None):
         """Model-specific initialization."""
         keys = jax.random.split(self._seed, 3)
         hmm_keys = keys[:2]

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -25,7 +25,7 @@ from ..typing import (
     DESIGN_INPUT_TYPE,
 )
 from .initialize_parameters import (
-    INITIALIZATION_FN_DICT,
+    DEFAULT_INIT_FUNCTIONS,
     _resolve_dirichlet_priors,
     _validate_init_funcs_keys,
     generate_hmm_initial_params,
@@ -89,7 +89,7 @@ class BaseHMM(
     """
 
     _validator_class: type[HMMValidator[HMMUserProvidedParamsT, HMMModelParamsT]]
-    _default_init_dict: dict = INITIALIZATION_FN_DICT
+    _default_init_dict: dict = DEFAULT_INIT_FUNCTIONS
 
     def __init__(
         self,

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -440,7 +440,36 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         ] = "log-likelihood",
         null_model: Optional[Literal["constant", "glm"]] = None,
     ) -> jnp.ndarray:
-        """Compute the model score."""
+        """
+        Compute the model score.
+
+        Scores the model by computing the log-likelihood of the data given the model parameters.
+        Other score metrics are currently not implemented.
+
+        Parameters
+        ----------
+        X :
+            Input data/design matrix, shape ``(n_samples, n_features)``.
+        y :
+            Output data/observations, shape ``(n_samples, n_observations)``.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_samples,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
+        score_type :
+            The type of score to compute. Currently, only "log-likelihood" is implemented.
+        null_model :
+            Used for scoring metrics that require a null model (e.g., pseudo-R2).
+            Currently not used as only log-likelihood is implemented.
+
+        Returns
+        -------
+        :
+            The computed model score.
+        """
         if score_type == "log-likelihood" and null_model is not None:
             warnings.warn(
                 "The null model is not used for the log-likelihood computation.",
@@ -539,8 +568,10 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         See Also
         --------
-        filter_proba : Compute filtering posteriors (conditioned on past observations only).
-        decode_state : Compute most likely state sequence (Viterbi decoding).
+        :meth:`~nemos.hmm.BaseHMM.filter_proba`
+            Compute filtering posteriors (conditioned on past observations only).
+        :meth:`~nemos.hmm.BaseHMM.decode_state`
+            Compute most likely state sequence (Viterbi decoding).
 
         Notes
         -----
@@ -633,8 +664,10 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         See Also
         --------
-        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
-        decode_state : Compute most likely state sequence (Viterbi decoding).
+        :meth:`~nemos.hmm.BaseHMM.smooth_proba`
+            Compute smoothing posteriors (conditioned on all observations).
+        :meth:`~nemos.hmm.BaseHMM.decode_state`
+            Compute most likely state sequence (Viterbi decoding).
 
         Notes
         -----
@@ -750,8 +783,10 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         See Also
         --------
-        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
-        filter_proba : Compute filtering posteriors (conditioned on past observations only).
+        :meth:`~nemos.hmm.BaseHMM.smooth_proba`
+            Compute smoothing posteriors (conditioned on all observations).
+        :meth:`~nemos.hmm.BaseHMM.filter_proba`
+            Compute filtering posteriors (conditioned on past observations only).
 
         Notes
         -----

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import warnings
 from numbers import Number
-from typing import Any, Callable, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Literal, Optional, Tuple, TypeVar, Union
 
 import jax
 import jax.numpy as jnp
@@ -33,6 +33,8 @@ from .initialize_parameters import (
 from .params import HMMModelParamsT, HMMUserParams, HMMUserProvidedParamsT
 from .utils import _check_state_format
 from .validation import HMMValidator
+
+INITIALIZATION_FN_DICT_T = TypeVar("INITIALIZATION_FN_DICT_T")
 
 
 class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
@@ -75,7 +77,7 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
     seed :
         JAX PRNG key for random number generation during initialization. Default is
         ``jax.random.PRNGKey(123)``.
-    hmm_initialization_funcs :
+    initialization_funcs :
         Dictionary specifying the initialization functions for the HMM parameters. This parameter is
         included at initialization for scikit-learn compatibility; however, users should set up the
         initialization functions using the :meth:`~nemos.hmm.hmm.BaseHMM.setup` method after model
@@ -100,7 +102,7 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         maxiter: int = 1000,
         tol: float = 1e-8,
         seed=jax.random.PRNGKey(123),
-        hmm_initialization_funcs: Optional[INITIALIZATION_FN_DICT] = None,
+        initialization_funcs: Optional[INITIALIZATION_FN_DICT_T] = None,
     ):
         super().__init__(
             regularizer=regularizer,
@@ -121,7 +123,7 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         self.transition_prob_: Optional[jnp.ndarray] = None
         self.initial_prob_: Optional[jnp.ndarray] = None
 
-        self.hmm_initialization_funcs = hmm_initialization_funcs
+        self.initialization_funcs = initialization_funcs
 
     def setup(
         self,
@@ -169,12 +171,12 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         transition_proba_init_kwargs :
             A dictionary of keyword arguments to pass to the transition probability initialization function.
         """
-        self._hmm_initialization_funcs = setup_hmm_initialization(
+        self._initialization_funcs = setup_hmm_initialization(
             initial_proba_init=initial_proba_init,
             initial_proba_init_kwargs=initial_proba_init_kwargs,
             transition_proba_init=transition_proba_init,
             transition_proba_init_kwargs=transition_proba_init_kwargs,
-            init_funcs=self._hmm_initialization_funcs,
+            init_funcs=self._initialization_funcs,
         )
 
     @property
@@ -302,19 +304,19 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         self._seed = value
 
     @property
-    def hmm_initialization_funcs(self):
+    def initialization_funcs(self):
         """Dictionary of initialization functions for HMM parameters."""
-        return self._hmm_initialization_funcs
+        return self._initialization_funcs
 
-    @hmm_initialization_funcs.setter
-    def hmm_initialization_funcs(self, value: INITIALIZATION_FN_DICT | None):
+    @initialization_funcs.setter
+    def initialization_funcs(self, value: INITIALIZATION_FN_DICT | None):
         """
         Set the dictionary of initialization functions for HMM parameters.
 
         This should only be called by __init__ for sklearn cloning, users should
         use the `setup` method to set initialization functions.
         """
-        self._hmm_initialization_funcs = value
+        self._initialization_funcs = value
         self.setup()
 
     def _hmm_params_initialization(
@@ -330,11 +332,11 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
             y,
             is_new_session,
             random_key=self._seed,
-            init_funcs=self._hmm_initialization_funcs,
+            init_funcs=self._initialization_funcs,
         )
-        validate_params = self._hmm_initialization_funcs.get(
+        validate_params = self._initialization_funcs.get(
             "initial_proba_init_custom", True
-        ) or self._hmm_initialization_funcs.get("transition_proba_init_custom", True)
+        ) or self._initialization_funcs.get("transition_proba_init_custom", True)
         return hmm_params, validate_params
 
     @abc.abstractmethod

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -87,6 +87,7 @@ class BaseHMM(
     """
 
     _validator_class: type[HMMValidator[HMMUserProvidedParamsT, HMMModelParamsT]]
+    _valid_init_funcs: Optional[dict] = None
 
     def __init__(
         self,
@@ -336,6 +337,7 @@ class BaseHMM(
             is_new_session,
             random_key_pair=random_key_pair,
             init_funcs=self._initialization_funcs,
+            valid_funcs=self._valid_init_funcs,
         )
         validate_params = self._initialization_funcs.get(
             "initial_proba_init_custom", True

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -451,7 +451,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
             raise NotImplementedError(
                 f"score of type {score_type} not implemented yet!"
             )
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         return self._score(params, X, y, is_new_session)
 
     @support_pynapple(conv_type="jax")
@@ -506,15 +508,22 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         Parameters
         ----------
-        X
+        X :
             Predictors, shape ``(n_time_points, n_features)``.
-        y
+        y :
             Observations, shape ``(n_time_points,)`` for single observation or
             ``(n_time_points, n_observations)`` for population.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_time_points,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
 
         Returns
         -------
-        posteriors
+        posteriors :
             Smoothing posterior probabilities, shape ``(n_time_points, n_states)``.
             Each row sums to 1 and represents the probability distribution over states
             at that time point.
@@ -538,7 +547,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         - Smoothing provides better state estimates than filtering because it uses all data
         - The algorithm properly handles session boundaries and NaN values at epoch borders
         """
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         return self._smooth_proba(params, X, y, is_new_session)
 
     @support_pynapple(conv_type="jax")
@@ -596,6 +607,13 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         y
             Observations, shape ``(n_time_points,)`` for single observation or
             ``(n_time_points, n_observations)`` for population.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_time_points,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
 
         Returns
         -------
@@ -626,7 +644,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         - NaN values are removed before inference, but session markers are preserved
         - For pynapple inputs, the output TsdFrame has columns named "state_0", "state_1", etc.
         """
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         return self._filter_proba(params, X, y, is_new_session)
 
     @support_pynapple(conv_type="jax")
@@ -694,6 +714,13 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         y
             Observations, shape ``(n_time_points,)`` for single observation or
             ``(n_time_points, n_observations)`` for population.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_time_points,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
         state_format
             Format of the returned states:
 
@@ -735,7 +762,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         - Decoding is useful for segmenting continuous data into discrete behavioral states
         - For uncertainty estimates about states, use ``smooth_proba()`` instead
         """
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         # validate state_format
         _check_state_format(state_format)
         # define the return type for the max-sum

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -326,6 +326,7 @@ class BaseHMM(
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
         is_new_session: jnp.ndarray,
+        random_key_pair: jax.Array,
     ) -> Tuple[HMMUserParams, bool]:
         """HMM parameter initialization."""
         hmm_params = generate_hmm_initial_params(
@@ -333,7 +334,7 @@ class BaseHMM(
             X,
             y,
             is_new_session,
-            random_key=self._seed,
+            random_key_pair=random_key_pair,
             init_funcs=self._initialization_funcs,
         )
         validate_params = self._initialization_funcs.get(
@@ -342,7 +343,7 @@ class BaseHMM(
         return hmm_params, validate_params
 
     @abc.abstractmethod
-    def _model_params_initialization(self, X, y, is_new_session):
+    def _model_params_initialization(self, X, y, is_new_session, random_key: jax.Array):
         """
         Model-specific parameter initialization.
 
@@ -354,15 +355,21 @@ class BaseHMM(
 
     def _model_specific_initialization(self, X, y, is_new_session):
         """Model-specific initialization."""
+        keys = jax.random.split(self._seed, 3)
+        hmm_keys = keys[:2]
+        # the model needs to figure out how to split the key internally
+        model_key = keys[2]
         hmm_params, validate_hmm = self._hmm_params_initialization(
             X,
             y,
             is_new_session,
+            random_keys=hmm_keys,
         )
         model_params, validate_model = self._model_params_initialization(
             X,
             y,
             is_new_session,
+            random_key=model_key,
         )
         user_params = self._validator.wrap_user_params(
             model_params

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -11,7 +11,7 @@ from numpy.typing import NDArray
 from ..type_casting import is_numpy_array_like
 from ..typing import DESIGN_INPUT_TYPE
 from ..validation import _suggest_keys
-from .utils import initialize_new_session
+from .utils import initialize_is_new_session
 
 sklearn = lazy.load("sklearn")
 
@@ -332,7 +332,7 @@ class KMeansInitializer:
         self.n_states = n_states
         self.minimum_prob = minimum_prob
         self.random_key = random_key
-        self.is_new_session = initialize_new_session(y.shape[0], is_new_session)
+        self.is_new_session = initialize_is_new_session(X, y, is_new_session)
         self.model = sklearn.cluster.KMeans(
             n_clusters=n_states, random_state=random_key
         )
@@ -582,7 +582,7 @@ def _validate_init_funcs_keys(
             )
             for key, suggestion in suggested_keys
         )
-        raise ValueError(
+        raise KeyError(
             "Unexpected or unknown keys found in 'init_funcs' dictionary. \n"
             + "\n".join(error_msg)
         )

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 from ..type_casting import is_numpy_array_like
 from ..typing import DESIGN_INPUT_TYPE
 from ..validation import _suggest_keys
+from .params import HMMUserParams
 from .utils import initialize_is_new_session
 
 sklearn = lazy.load("sklearn")
@@ -858,7 +859,7 @@ def generate_hmm_initial_params(
     is_new_session: NDArray | jnp.ndarray,
     random_key_pair: jax.Array = jax.random.split(jax.random.PRNGKey(1234), 2),
     init_funcs: Optional[dict] = None,
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+) -> HMMUserParams:
     """
     Generate initial HMM parameters using the provided initialization functions.
 

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -694,11 +694,14 @@ def setup_hmm_initialization(
 
 def _validate_init_funcs_keys(
     init_funcs: dict | INITIALIZATION_FN_DICT,
+    valid_funcs: dict | None = None,
 ) -> INITIALIZATION_FN_DICT:
     """Validate that the keys in the init_funcs dictionary are as expected. Set missing values to defaults."""
-    unexpected_keys = init_funcs.keys() - DEFAULT_INIT_FUNCTIONS.keys()
+    if valid_funcs is None:
+        valid_funcs = DEFAULT_INIT_FUNCTIONS
+    unexpected_keys = init_funcs.keys() - valid_funcs.keys()
     if unexpected_keys:
-        suggested_keys = _suggest_keys(unexpected_keys, DEFAULT_INIT_FUNCTIONS.keys())
+        suggested_keys = _suggest_keys(unexpected_keys, valid_funcs.keys())
         error_msg = (
             (
                 f" Unexpected key: '{key}'. Did you mean '{suggestion}'?"
@@ -845,6 +848,7 @@ def generate_hmm_initial_params(
     is_new_session: NDArray | jnp.ndarray,
     random_key_pair: jax.Array = jax.random.split(jax.random.PRNGKey(1234), 2),
     init_funcs: Optional[dict] = None,
+    valid_funcs: Optional[dict] = None,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
     Generate initial HMM parameters using the provided initialization functions.
@@ -870,6 +874,8 @@ def generate_hmm_initial_params(
         Dictionary containing the initialization functions and their kwargs for both initial state probabilities
         and transition probabilities. This dictionary can be set up using the `setup_hmm_initialization` function.
         If not provided, or if specific functions are missing, defaults will be used.
+    valid_funcs :
+        Dictionary containing the valid initialization functions dictionary. This may be model specific.
 
     Returns
     -------
@@ -887,7 +893,7 @@ def generate_hmm_initial_params(
     init_funcs = (
         DEFAULT_INIT_FUNCTIONS.copy()
         if init_funcs is None
-        else _validate_init_funcs_keys(init_funcs)
+        else _validate_init_funcs_keys(init_funcs, valid_funcs=valid_funcs)
     )
 
     # grab initial probability initialization function

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -624,6 +624,7 @@ def setup_hmm_initialization(
     transition_proba_init_kwargs: Optional[dict] = None,
     init_funcs: Optional[dict | INITIALIZATION_FN_DICT] = None,
     default_init_dict: Optional[dict] = None,
+    n_states: Optional[int] = None,
 ) -> INITIALIZATION_FN_DICT:
     """
     Set up HMM initialization functions based on user input, merging with defaults.
@@ -654,6 +655,9 @@ def setup_hmm_initialization(
     default_init_dict :
         Model-specific dictionary of default initialization functions. Defaults to
         ``DEFAULT_INIT_FUNCTIONS`` when None.
+    n_states :
+        Number of HMM states. When provided, ``alphas`` in the init kwargs is validated
+        via :func:`_resolve_dirichlet_priors` (same check as the model property setter).
 
     Returns
     -------
@@ -683,6 +687,10 @@ def setup_hmm_initialization(
         init_funcs["initial_proba_init_kwargs"] = _validate_init_funcs_kwargs(
             init_funcs["initial_proba_init"], initial_proba_init_kwargs
         )
+    if n_states is not None and "alphas" in init_funcs["initial_proba_init_kwargs"]:
+        init_funcs["initial_proba_init_kwargs"]["alphas"] = _resolve_dirichlet_priors(
+            init_funcs["initial_proba_init_kwargs"]["alphas"], (n_states,)
+        )
     if transition_proba_init is not None:
         (
             init_funcs["transition_proba_init"],
@@ -694,6 +702,13 @@ def setup_hmm_initialization(
     elif transition_proba_init_kwargs is not None:
         init_funcs["transition_proba_init_kwargs"] = _validate_init_funcs_kwargs(
             init_funcs["transition_proba_init"], transition_proba_init_kwargs
+        )
+    if n_states is not None and "alphas" in init_funcs["transition_proba_init_kwargs"]:
+        init_funcs["transition_proba_init_kwargs"]["alphas"] = (
+            _resolve_dirichlet_priors(
+                init_funcs["transition_proba_init_kwargs"]["alphas"],
+                (n_states, n_states),
+            )
         )
 
     return init_funcs

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -624,14 +624,17 @@ def setup_hmm_initialization(
     transition_proba_init: Optional[str | Callable] = None,
     transition_proba_init_kwargs: Optional[dict] = None,
     init_funcs: Optional[dict | INITIALIZATION_FN_DICT] = None,
+    default_init_dict: Optional[dict] = None,
 ) -> INITIALIZATION_FN_DICT:
     """
     Set up HMM initialization functions based on user input, merging with defaults.
 
     This function takes user-specified initialization functions (either as strings for built-in functions or callables
-    for custom functions) for both initial state probabilities and transition probabilities, validates them, and merges
+    for custom functions) for both initial state probabilities and transition probabilities, and merges
     them with default initialization functions for ones that are not provided. It ensures that the provided functions
     and kwargs are valid and conform to expected signatures.
+    The function assumes that the function keys are pre-validated, this is convenient because
+    different model require different keys.
 
     Parameters
     ----------
@@ -654,12 +657,11 @@ def setup_hmm_initialization(
     init_funcs :
         Updated or initialized dictionary based on provided inputs.
     """
+    if default_init_dict is None:
+        default_init_dict = DEFAULT_INIT_FUNCTIONS.copy()
 
     if init_funcs is None:
-        init_funcs = DEFAULT_INIT_FUNCTIONS.copy()
-    else:
-        # check for unexpected/unknown keys in init_funcs and backfill with defaults
-        init_funcs = _validate_init_funcs_keys(init_funcs)
+        init_funcs = default_init_dict
 
     # update functions and kwargs for init prob and transition prob
     # if a function is passed but not kwargs, kwargs will be reset
@@ -856,7 +858,6 @@ def generate_hmm_initial_params(
     is_new_session: NDArray | jnp.ndarray,
     random_key_pair: jax.Array = jax.random.split(jax.random.PRNGKey(1234), 2),
     init_funcs: Optional[dict] = None,
-    default_init_dict: Optional[dict] = None,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
     Generate initial HMM parameters using the provided initialization functions.
@@ -882,8 +883,6 @@ def generate_hmm_initial_params(
         Dictionary containing the initialization functions and their kwargs for both initial state probabilities
         and transition probabilities. This dictionary can be set up using the `setup_hmm_initialization` function.
         If not provided, or if specific functions are missing, defaults will be used.
-    default_init_dict :
-        Dictionary containing the valid initialization functions dictionary. This may be model specific.
 
     Returns
     -------
@@ -898,11 +897,7 @@ def generate_hmm_initial_params(
         Function to set up the initialization functions and their kwargs based on user input.
     """
     # check for unexpected/unknown keys in init_funcs if user provided dictionary not made by setup_hmm_initialization
-    init_funcs = (
-        DEFAULT_INIT_FUNCTIONS.copy()
-        if init_funcs is None
-        else _validate_init_funcs_keys(init_funcs, default_init_dict=default_init_dict)
-    )
+    init_funcs = DEFAULT_INIT_FUNCTIONS.copy() if init_funcs is None else init_funcs
 
     # grab initial probability initialization function
     # fallback to defaults if set to None

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -843,7 +843,7 @@ def generate_hmm_initial_params(
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
     is_new_session: NDArray | jnp.ndarray,
-    random_key: int | jax.Array = 123,
+    random_key_pair: jax.Array = jax.random.split(jax.random.PRNGKey(1234), 2),
     init_funcs: Optional[dict] = None,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
@@ -862,9 +862,10 @@ def generate_hmm_initial_params(
         Output data (e.g., neural activity) of shape (n_samples,).
     is_new_session :
         Boolean array of shape (n_samples,) indicating the start of new sessions.
-    random_key :
-        Optional key for random number generation, if needed by the initialization functions. The key is split to
-        ensure different random states for initial probabilities and transition probabilities.
+    random_key_pair :
+        Optional pair of keys for random number generation, if needed by the initialization functions.
+        This function assumes already formatted keys as contract, preventing silent bugs such as keys
+        not being formatted appropriately by upstream models.
     init_funcs :
         Dictionary containing the initialization functions and their kwargs for both initial state probabilities
         and transition probabilities. This dictionary can be set up using the `setup_hmm_initialization` function.
@@ -889,9 +890,6 @@ def generate_hmm_initial_params(
         else _validate_init_funcs_keys(init_funcs)
     )
 
-    if isinstance(random_key, int):
-        random_key = jax.random.PRNGKey(random_key)
-
     # grab initial probability initialization function
     # fallback to defaults if set to None
     initial_proba_init = (
@@ -907,15 +905,12 @@ def generate_hmm_initial_params(
     )
     transition_proba_init_kwargs = init_funcs["transition_proba_init_kwargs"] or {}
 
-    # split seed into two random keys
-    # compute probabilities and validate if custom functions are used
-    keys = jax.random.split(random_key, 2)
     initial_probs = initial_proba_init(
         n_states=n_states,
         X=X,
         y=y,
         is_new_session=is_new_session,
-        random_key=keys[0],
+        random_key=random_key_pair[0],
         **initial_proba_init_kwargs,
     )
     transition_matrix = transition_proba_init(
@@ -923,7 +918,7 @@ def generate_hmm_initial_params(
         X=X,
         y=y,
         is_new_session=is_new_session,
-        random_key=keys[1],
+        random_key=random_key_pair[1],
         **transition_proba_init_kwargs,
     )
 

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -713,30 +713,6 @@ def _validate_custom_init_func(
     return func, kwargs, True
 
 
-def _validate_custom_init_output(proba: jnp.ndarray, n_states: int, key: str):
-    """Validate the output of a custom initialization function to ensure it has the correct shape and properties."""
-    if key == "initial_proba_init":
-        if proba.shape != (n_states,):
-            raise ValueError(
-                f"Custom initial state probability initialization function must return an array of shape "
-                f"({n_states},), but got {proba.shape}."
-            )
-        if not jnp.isclose(proba.sum(), 1.0):
-            raise ValueError(
-                f"Custom initial state probabilities must sum to 1, but got sum={proba.sum()}."
-            )
-    elif key == "transition_proba_init":
-        if proba.shape != (n_states, n_states):
-            raise ValueError(
-                f"Custom transition probability initialization function must return an array of shape "
-                f"({n_states}, {n_states}), but got {proba.shape}."
-            )
-        if not jnp.allclose(proba.sum(axis=1), 1.0):
-            raise ValueError(
-                f"Custom transition probabilities must have rows that sum to 1, but got row sums={proba.sum(axis=1)}."
-            )
-
-
 def generate_hmm_initial_params(
     n_states: int,
     X: DESIGN_INPUT_TYPE,
@@ -806,16 +782,9 @@ def generate_hmm_initial_params(
     initial_probs = initial_proba_init(
         n_states=n_states, X=X, y=y, random_key=keys[0], **initial_proba_init_kwargs
     )
-    if init_funcs["initial_proba_init_custom"]:
-        _validate_custom_init_output(initial_probs, n_states, "initial_proba_init")
-
     transition_matrix = transition_proba_init(
         n_states=n_states, X=X, y=y, random_key=keys[1], **transition_proba_init_kwargs
     )
-    if init_funcs["transition_proba_init_custom"]:
-        _validate_custom_init_output(
-            transition_matrix, n_states, "transition_proba_init"
-        )
 
     return initial_probs, transition_matrix
 

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -696,13 +696,14 @@ def setup_hmm_initialization(
 
 
 def _validate_init_funcs_keys(
-    init_funcs: dict | INITIALIZATION_FN_DICT,
+    init_funcs: dict | INITIALIZATION_FN_DICT | None,
     default_init_dict: Optional[dict[str, Callable]] = None,
-) -> INITIALIZATION_FN_DICT:
+) -> INITIALIZATION_FN_DICT | None:
     """Validate that the keys in the init_funcs dictionary are as expected. Set missing values to defaults."""
     if default_init_dict is None:
         default_init_dict = DEFAULT_INIT_FUNCTIONS.copy()
-
+    if init_funcs is None:
+        return
     unexpected_keys = init_funcs.keys() - default_init_dict.keys()
     if unexpected_keys:
         suggested_keys = _suggest_keys(unexpected_keys, default_init_dict.keys())

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -1,6 +1,7 @@
 """Initialization functions and related utility functions for HMMs."""
 
 import inspect
+from types import MappingProxyType
 from typing import Any, Callable, Literal, Optional, Protocol, Tuple
 
 import jax
@@ -591,30 +592,38 @@ def kmeans_transition_proba_init(
     return initializer.transition_probability()
 
 
-AVAILABLE_INIT_FUNCTIONS = {
-    "initial_proba_init": {
-        "uniform": uniform_initial_proba_init,
-        "random": random_initial_proba_init,
-        "dirichlet": dirichlet_initial_proba_init,
-        "kmeans": kmeans_initial_proba_init,
-    },
-    "transition_proba_init": {
-        "sticky": sticky_transition_proba_init,
-        "uniform": uniform_transition_proba_init,
-        "random": random_transition_proba_init,
-        "dirichlet": dirichlet_transition_proba_init,
-        "kmeans": kmeans_transition_proba_init,
-    },
-}
+AVAILABLE_INIT_FUNCTIONS = MappingProxyType(
+    {
+        "initial_proba_init": MappingProxyType(
+            {
+                "uniform": uniform_initial_proba_init,
+                "random": random_initial_proba_init,
+                "dirichlet": dirichlet_initial_proba_init,
+                "kmeans": kmeans_initial_proba_init,
+            }
+        ),
+        "transition_proba_init": MappingProxyType(
+            {
+                "sticky": sticky_transition_proba_init,
+                "uniform": uniform_transition_proba_init,
+                "random": random_transition_proba_init,
+                "dirichlet": dirichlet_transition_proba_init,
+                "kmeans": kmeans_transition_proba_init,
+            }
+        ),
+    }
+)
 
-DEFAULT_INIT_FUNCTIONS: INITIALIZATION_FN_DICT = {
-    "initial_proba_init": uniform_initial_proba_init,
-    "initial_proba_init_kwargs": {},
-    "initial_proba_init_custom": False,
-    "transition_proba_init": sticky_transition_proba_init,
-    "transition_proba_init_kwargs": {},
-    "transition_proba_init_custom": False,
-}
+DEFAULT_INIT_FUNCTIONS: INITIALIZATION_FN_DICT = MappingProxyType(
+    {
+        "initial_proba_init": uniform_initial_proba_init,
+        "initial_proba_init_kwargs": {},
+        "initial_proba_init_custom": False,
+        "transition_proba_init": sticky_transition_proba_init,
+        "transition_proba_init_kwargs": {},
+        "transition_proba_init_custom": False,
+    }
+)
 
 
 def setup_hmm_initialization(

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -11,7 +11,6 @@ from numpy.typing import NDArray
 from ..type_casting import is_numpy_array_like
 from ..typing import DESIGN_INPUT_TYPE
 from ..validation import _suggest_keys
-from .params import HMMUserParams
 from .utils import initialize_is_new_session
 
 sklearn = lazy.load("sklearn")

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -258,10 +258,8 @@ def dirichlet_transition_proba_init(
     >>> n_states = 3
     >>> alphas = jnp.array([[5.0, 1.0, 1.0],[1.0, 5.0, 1.0],[1.0, 1.0, 5.0]])  # favor self-transitions
     >>> transition_matrix = dirichlet_transition_proba_init(n_states, alphas=alphas, random_key=jax.random.PRNGKey(0))
-    >>> print(transition_matrix)
-    [[0.8081229  0.1293587  0.0625184 ]
-     [0.241275   0.67095065 0.08777437]
-     [0.09245212 0.00998352 0.8975643 ]]
+    >>> transition_matrix  # doctest: +ELLIPSIS
+    Array(...)
     """
     if alphas is None:
         alphas = jnp.ones((n_states, n_states))
@@ -406,7 +404,7 @@ def dirichlet_initial_proba_init(
     >>> alphas = jnp.array([5.0, 1.0, 1.0])  # favor first state
     >>> init_prob = dirichlet_initial_proba_init(n_states, alphas=alphas, random_key=jax.random.PRNGKey(0))
     >>> init_prob  # doctest: +ELLIPSIS
-    Array([...], dtype=float32)
+    Array(...)
     """
     if alphas is None:
         alphas = jnp.ones((n_states,))

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -650,13 +650,17 @@ def setup_hmm_initialization(
     transition_proba_init_kwargs :
         Keyword arguments to pass to the transition probability initialization function.
     init_funcs :
-        Existing dictionary of initialization functions to update. If None, a new dictionary will be created.
-        If the dictionary is missing any keys, they will be backfilled with defaults.
+        Existing dictionary of initialization functions to update. If None, a fresh copy of
+        ``default_init_dict`` is used. Keys must already be validated before calling this function;
+        use :func:`_validate_init_funcs_keys` upstream (e.g., in the class setter).
+    default_init_dict :
+        Model-specific dictionary of default initialization functions. Defaults to
+        ``DEFAULT_INIT_FUNCTIONS`` when None.
 
     Returns
     -------
     init_funcs :
-        Updated or initialized dictionary based on provided inputs.
+        Updated dictionary of initialization functions based on provided inputs.
     """
     if default_init_dict is None:
         default_init_dict = DEFAULT_INIT_FUNCTIONS.copy()
@@ -890,10 +894,10 @@ def generate_hmm_initial_params(
 
     Returns
     -------
-    initial_probs :
-        Initial state probability vector of shape (n_states,) that sums to 1.
-    transition_matrix :
-        Transition probability matrix of shape (n_states, n_states) where each row sums to 1.
+    :
+        ``HMMUserParams`` tuple of ``(initial_probs, transition_matrix)`` where
+        ``initial_probs`` has shape ``(n_states,)`` summing to 1, and
+        ``transition_matrix`` has shape ``(n_states, n_states)`` with rows summing to 1.
 
     See Also
     --------

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -24,6 +24,7 @@ class InitFunctionHMM(Protocol):
         n_states: int,
         X: DESIGN_INPUT_TYPE,
         y: NDArray | jnp.ndarray,
+        is_new_session: NDArray | jnp.ndarray,
         random_key: jax.random.PRNGKey,
         **kwargs: Any,
     ) -> jnp.ndarray:
@@ -61,10 +62,11 @@ INITIALIZATION_FN_DICT = dict[
 
 def sticky_transition_proba_init(
     n_states: int,
+    prob_stay: float = 0.95,
     X: Optional[DESIGN_INPUT_TYPE] = None,
     y: Optional[NDArray | jnp.ndarray] = None,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
     random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
-    prob_stay: float = 0.95,
 ) -> jnp.ndarray:
     """
     Initialize transition probabilities with sticky dynamics.
@@ -78,14 +80,17 @@ def sticky_transition_proba_init(
     ----------
     n_states :
         Number of HMM states. Must be greater than 1.
+    prob_stay :
+        Probability of staying in the current state. Default is 0.95.
     X :
         Optional predictor data. Unused for this particular initialization, but added for API consistency.
     y :
         Optional output data. Unused for this particular initialization, but added for API consistency.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. Unused for this
+        particular initialization, but added for API consistency.
     random_key :
         Random key, unused for this particular initialization, but added for API consistency.
-    prob_stay :
-        Probability of staying in the current state. Default is 0.95.
 
     Returns
     -------
@@ -119,6 +124,7 @@ def uniform_transition_proba_init(
     n_states: int,
     X: Optional[DESIGN_INPUT_TYPE] = None,
     y: Optional[NDArray | jnp.ndarray] = None,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
     random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
 ) -> jnp.ndarray:
     """
@@ -135,6 +141,9 @@ def uniform_transition_proba_init(
         Optional predictor data. Unused for this particular initialization, but added for API consistency.
     y :
         Optional output data. Unused for this particular initialization, but added for API consistency.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. Unused for this
+        particular initialization, but added for API consistency.
     random_key :
         Random key, unused for this particular initialization, but added for API consistency.
 
@@ -160,9 +169,10 @@ def uniform_transition_proba_init(
 
 def random_transition_proba_init(
     n_states: int,
+    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
     X: Optional[DESIGN_INPUT_TYPE] = None,
     y: Optional[NDArray | jnp.ndarray] = None,
-    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """
     Initialize transition probabilities randomly.
@@ -174,12 +184,15 @@ def random_transition_proba_init(
     ----------
     n_states :
         Number of HMM states. Must be greater than 1.
+    random_key :
+        Random key for reproducibility of random initialization.
     X :
         Optional predictor data. Unused for this particular initialization, but added for API consistency.
     y :
         Optional output data. Unused for this particular initialization, but added for API consistency.
-    random_key :
-        Random key for reproducibility of random initialization.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. Unused for this
+        particular initialization, but added for API consistency.
 
     Returns
     -------
@@ -203,10 +216,63 @@ def random_transition_proba_init(
     return prob_transition / prob_transition.sum(axis=1, keepdims=True)
 
 
+def dirichlet_transition_proba_init(
+    n_states: int,
+    alphas: Optional[float | NDArray | jnp.ndarray] = None,
+    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    X: Optional[DESIGN_INPUT_TYPE] = None,
+    y: Optional[NDArray | jnp.ndarray] = None,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
+) -> jnp.ndarray:
+    """
+    Initialize transition probabilities by sampling from a Dirichlet distribution.
+
+    Generates a random transition probability matrix by sampling each row from a Dirichlet distribution with
+    specified concentration parameters (alphas).
+
+    Parameters
+    ----------
+    n_states :
+        Number of HMM states. Must be greater than 1.
+    alphas :
+        Concentration parameters for the Dirichlet distribution. Must be an array of shape (n_states, n_states)
+        specifying the alpha for each transition. If None, defaults to 1.0 for all transitions (uniform).
+    random_key :
+        Random key for reproducibility of random initialization.
+    X :
+        Optional predictor data. Unused for this particular initialization, but added for API consistency.
+    y :
+        Optional output data. Unused for this particular initialization, but added for API consistency.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. Unused for this
+        particular initialization, but added for API consistency.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from nemos.hmm.initialize_parameters import dirichlet_transition_proba_init
+    >>>
+    >>> # Generate transition probabilities for 3 states with Dirichlet initialization
+    >>> n_states = 3
+    >>> alphas = jnp.array([[5.0, 1.0, 1.0],[1.0, 5.0, 1.0],[1.0, 1.0, 5.0]])  # favor self-transitions
+    >>> transition_matrix = dirichlet_transition_proba_init(n_states, alphas=alphas, random_key=jax.random.PRNGKey(0))
+    >>> print(transition_matrix)
+    [[0.8081229  0.1293587  0.0625184 ]
+     [0.241275   0.67095065 0.08777437]
+     [0.09245212 0.00998352 0.8975643 ]]
+    """
+    if alphas is None:
+        alphas = jnp.ones((n_states, n_states))
+    prob = jax.random.dirichlet(random_key, alphas)
+    return prob / prob.sum(axis=1, keepdims=True)
+
+
 def uniform_initial_proba_init(
     n_states: int,
     X: Optional[DESIGN_INPUT_TYPE] = None,
     y: Optional[NDArray | jnp.ndarray] = None,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
     random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
 ) -> jnp.ndarray:
     """
@@ -223,6 +289,9 @@ def uniform_initial_proba_init(
         Optional predictor data. Unused for this particular initialization, but added for API consistency.
     y :
         Optional output data. Unused for this particular initialization, but added for API consistency.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. Unused for this
+        particular initialization, but added for API consistency.
     random_key :
         Random key, unused for this particular initialization, but added for API consistency.
 
@@ -247,9 +316,10 @@ def uniform_initial_proba_init(
 
 def random_initial_proba_init(
     n_states: int,
+    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
     X: Optional[DESIGN_INPUT_TYPE] = None,
     y: Optional[NDArray | jnp.ndarray] = None,
-    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """
     Randomly initialize initial state probabilities.
@@ -261,12 +331,15 @@ def random_initial_proba_init(
     ----------
     n_states :
         Number of HMM states.
+    random_key :
+        Random key for reproducibility of random initialization.
     X :
         Optional predictor data. Unused for this particular initialization, but added for API consistency.
     y :
         Optional output data. Unused for this particular initialization, but added for API consistency.
-    random_key :
-        Random key for reproducibility of random initialization.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. Unused for this
+        particular initialization, but added for API consistency.
 
     Returns
     -------
@@ -288,6 +361,56 @@ def random_initial_proba_init(
     """
     prob = jax.random.uniform(random_key, (n_states,), dtype=float)
     return prob / jnp.sum(prob)
+
+
+def dirichlet_initial_proba_init(
+    n_states: int,
+    alphas: Optional[float | NDArray | jnp.ndarray] = None,
+    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    X: Optional[DESIGN_INPUT_TYPE] = None,
+    y: Optional[NDArray | jnp.ndarray] = None,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
+) -> jnp.ndarray:
+    """
+    Initialize initial state probabilities by sampling from a Dirichlet distribution.
+
+    Generates random initial state probabilities by sampling from a Dirichlet distribution with specified
+    concentration parameters (alphas).
+
+    Parameters
+    ----------
+    n_states :
+        Number of HMM states. Must be greater than 1.
+    alphas :
+        Concentration parameters for the Dirichlet distribution. Must be an array of shape (n_states,)
+        specifying the alpha for each state. If None, defaults to 1.0 for all states (uniform).
+    random_key :
+        Random key for reproducibility of random initialization.
+    X :
+        Optional predictor data. Unused for this particular initialization, but added for API consistency.
+    y :
+        Optional output data. Unused for this particular initialization, but added for API consistency.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. Unused for this
+        particular initialization, but added for API consistency.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from nemos.hmm.initialize_parameters import dirichlet_initial_proba_init
+    >>>
+    >>> # Generate initial state probabilities for 3 states with Dirichlet initialization
+    >>> n_states = 3
+    >>> alphas = jnp.array([5.0, 1.0, 1.0])  # favor first state
+    >>> init_prob = dirichlet_initial_proba_init(n_states, alphas=alphas, random_key=jax.random.PRNGKey(0))
+    >>> print(init_prob)
+    [0.8081229 0.1293587 0.0625184]
+    """
+    if alphas is None:
+        alphas = jnp.ones((n_states,))
+    prob = jax.random.dirichlet(random_key, alphas)
+    return prob / prob.sum()
 
 
 class KMeansInitializer:
@@ -473,12 +596,14 @@ AVAILABLE_INIT_FUNCTIONS = {
     "initial_proba_init": {
         "uniform": uniform_initial_proba_init,
         "random": random_initial_proba_init,
+        "dirichlet": dirichlet_initial_proba_init,
         "kmeans": kmeans_initial_proba_init,
     },
     "transition_proba_init": {
         "sticky": sticky_transition_proba_init,
         "uniform": uniform_transition_proba_init,
         "random": random_transition_proba_init,
+        "dirichlet": dirichlet_transition_proba_init,
         "kmeans": kmeans_transition_proba_init,
     },
 }
@@ -717,6 +842,7 @@ def generate_hmm_initial_params(
     n_states: int,
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
+    is_new_session: NDArray | jnp.ndarray,
     random_key: int | jax.Array = 123,
     init_funcs: Optional[dict] = None,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
@@ -734,6 +860,8 @@ def generate_hmm_initial_params(
         Predictor data (e.g., model design for GLM) of shape (n_samples, n_features).
     y :
         Output data (e.g., neural activity) of shape (n_samples,).
+    is_new_session :
+        Boolean array of shape (n_samples,) indicating the start of new sessions.
     random_key :
         Optional key for random number generation, if needed by the initialization functions. The key is split to
         ensure different random states for initial probabilities and transition probabilities.
@@ -783,10 +911,20 @@ def generate_hmm_initial_params(
     # compute probabilities and validate if custom functions are used
     keys = jax.random.split(random_key, 2)
     initial_probs = initial_proba_init(
-        n_states=n_states, X=X, y=y, random_key=keys[0], **initial_proba_init_kwargs
+        n_states=n_states,
+        X=X,
+        y=y,
+        is_new_session=is_new_session,
+        random_key=keys[0],
+        **initial_proba_init_kwargs,
     )
     transition_matrix = transition_proba_init(
-        n_states=n_states, X=X, y=y, random_key=keys[1], **transition_proba_init_kwargs
+        n_states=n_states,
+        X=X,
+        y=y,
+        is_new_session=is_new_session,
+        random_key=keys[1],
+        **transition_proba_init_kwargs,
     )
 
     return initial_probs, transition_matrix

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 from ..type_casting import is_numpy_array_like
 from ..typing import DESIGN_INPUT_TYPE
 from ..validation import _suggest_keys
+from .params import HMMUserParams
 from .utils import initialize_is_new_session
 
 sklearn = lazy.load("sklearn")
@@ -25,7 +26,7 @@ class InitFunctionHMM(Protocol):
         X: DESIGN_INPUT_TYPE,
         y: NDArray | jnp.ndarray,
         is_new_session: NDArray | jnp.ndarray,
-        random_key: jax.random.PRNGKey,
+        random_key: jax.Array,
         **kwargs: Any,
     ) -> jnp.ndarray:
         """Initialize HMM probabilities."""
@@ -551,7 +552,7 @@ def kmeans_transition_proba_init(
     y: NDArray | jnp.ndarray,
     is_new_session: Optional[jnp.ndarray] = None,
     minimum_prob: float = 0.02,
-    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    random_key: jax.Array = jax.random.PRNGKey(123),
     initializer: Optional[KMeansInitializer] = None,
 ):
     """
@@ -694,14 +695,15 @@ def setup_hmm_initialization(
 
 def _validate_init_funcs_keys(
     init_funcs: dict | INITIALIZATION_FN_DICT,
-    valid_funcs: dict | None = None,
+    default_init_dict: Optional[dict[str, Callable]] = None,
 ) -> INITIALIZATION_FN_DICT:
     """Validate that the keys in the init_funcs dictionary are as expected. Set missing values to defaults."""
-    if valid_funcs is None:
-        valid_funcs = DEFAULT_INIT_FUNCTIONS
-    unexpected_keys = init_funcs.keys() - valid_funcs.keys()
+    if default_init_dict is None:
+        default_init_dict = DEFAULT_INIT_FUNCTIONS.copy()
+
+    unexpected_keys = init_funcs.keys() - default_init_dict.keys()
     if unexpected_keys:
-        suggested_keys = _suggest_keys(unexpected_keys, valid_funcs.keys())
+        suggested_keys = _suggest_keys(unexpected_keys, default_init_dict.keys())
         error_msg = (
             (
                 f" Unexpected key: '{key}'. Did you mean '{suggestion}'?"
@@ -715,12 +717,15 @@ def _validate_init_funcs_keys(
             + "\n".join(error_msg)
         )
     # resolve with defaults and make copy
-    init_funcs = DEFAULT_INIT_FUNCTIONS | init_funcs
+    init_funcs = default_init_dict | init_funcs
     return init_funcs
 
 
 def _resolve_init_funcs(
-    key: str, value: str | Callable, kwargs: Optional[dict] = None
+    key: str,
+    value: str | Callable,
+    kwargs: Optional[dict] = None,
+    available_init_funcs: dict[str, Callable] = None,
 ) -> Tuple[InitFunctionHMM, dict, bool]:
     """
     Validate a provided initialization function.
@@ -737,6 +742,8 @@ def _resolve_init_funcs(
         callable.
     kwargs :
         Optional keyword arguments to pass to the initialization function.
+    available_init_funcs:
+        Dictionary of available initialization functions and their kwargs (if any) to be used for initialization.
 
     Returns
     -------
@@ -751,16 +758,16 @@ def _resolve_init_funcs(
     TypeError
         If the provided value is neither a string nor a callable function.
     """
+    if available_init_funcs is None:
+        available_init_funcs = AVAILABLE_INIT_FUNCTIONS
     if isinstance(value, str):
-        if value not in AVAILABLE_INIT_FUNCTIONS[key]:
+        if value not in available_init_funcs[key]:
             raise ValueError(
                 f"Invalid initialization function name '{value}' for '{key}'. "
-                f"Available options are: {list(AVAILABLE_INIT_FUNCTIONS[key].keys())}."
+                f"Available options are: {list(available_init_funcs[key].keys())}."
             )
-        kwargs = _validate_init_funcs_kwargs(
-            AVAILABLE_INIT_FUNCTIONS[key][value], kwargs
-        )
-        return AVAILABLE_INIT_FUNCTIONS[key][value], kwargs, False
+        kwargs = _validate_init_funcs_kwargs(available_init_funcs[key][value], kwargs)
+        return available_init_funcs[key][value], kwargs, False
     elif callable(value):
         return _validate_custom_init_func(value, kwargs)
     else:
@@ -770,12 +777,14 @@ def _resolve_init_funcs(
         )
 
 
-def _validate_init_funcs_kwargs(func: InitFunctionHMM, kwargs: dict | None) -> dict:
+def _validate_init_funcs_kwargs(
+    func: InitFunctionHMM, kwargs: dict | None, protocol=InitFunctionHMM
+) -> dict:
     """Validate that the provided kwargs match the expected signature of the initialization functions."""
     if kwargs is None:
         return {}
 
-    reserved_params = _get_protocol_parameters(InitFunctionHMM)
+    reserved_params = _get_protocol_parameters(protocol)
     for key in reserved_params:
         if key in kwargs:
             raise ValueError(
@@ -848,7 +857,7 @@ def generate_hmm_initial_params(
     is_new_session: NDArray | jnp.ndarray,
     random_key_pair: jax.Array = jax.random.split(jax.random.PRNGKey(1234), 2),
     init_funcs: Optional[dict] = None,
-    valid_funcs: Optional[dict] = None,
+    default_init_dict: Optional[dict] = None,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
     Generate initial HMM parameters using the provided initialization functions.
@@ -874,7 +883,7 @@ def generate_hmm_initial_params(
         Dictionary containing the initialization functions and their kwargs for both initial state probabilities
         and transition probabilities. This dictionary can be set up using the `setup_hmm_initialization` function.
         If not provided, or if specific functions are missing, defaults will be used.
-    valid_funcs :
+    default_init_dict :
         Dictionary containing the valid initialization functions dictionary. This may be model specific.
 
     Returns
@@ -893,7 +902,7 @@ def generate_hmm_initial_params(
     init_funcs = (
         DEFAULT_INIT_FUNCTIONS.copy()
         if init_funcs is None
-        else _validate_init_funcs_keys(init_funcs, valid_funcs=valid_funcs)
+        else _validate_init_funcs_keys(init_funcs, default_init_dict=default_init_dict)
     )
 
     # grab initial probability initialization function

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -405,8 +405,8 @@ def dirichlet_initial_proba_init(
     >>> n_states = 3
     >>> alphas = jnp.array([5.0, 1.0, 1.0])  # favor first state
     >>> init_prob = dirichlet_initial_proba_init(n_states, alphas=alphas, random_key=jax.random.PRNGKey(0))
-    >>> print(init_prob)
-    [0.8081229 0.1293587 0.0625184]
+    >>> init_prob  # doctest: +ELLIPSIS
+    Array([...], dtype=float32)
     """
     if alphas is None:
         alphas = jnp.ones((n_states,))

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -718,7 +718,7 @@ def _validate_init_funcs_keys(
 
 def _resolve_init_funcs(
     key: str, value: str | Callable, kwargs: Optional[dict] = None
-) -> Tuple[InitFunctionHMM, dict]:
+) -> Tuple[InitFunctionHMM, dict, bool]:
     """
     Validate a provided initialization function.
 
@@ -793,7 +793,7 @@ def _validate_init_funcs_kwargs(func: InitFunctionHMM, kwargs: dict | None) -> d
 
 def _validate_custom_init_func(
     func: Callable, kwargs: Optional[dict] = None
-) -> Tuple[InitFunctionHMM, dict]:
+) -> Tuple[InitFunctionHMM, dict, bool]:
     """
     Validate a custom initialization function against the expected signature.
 

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -755,8 +755,11 @@ def generate_hmm_initial_params(
         Function to set up the initialization functions and their kwargs based on user input.
     """
     # check for unexpected/unknown keys in init_funcs if user provided dictionary not made by setup_hmm_initialization
-    init_funcs = {} if init_funcs is None else init_funcs
-    init_funcs = _validate_init_funcs_keys(init_funcs)
+    init_funcs = (
+        DEFAULT_INIT_FUNCTIONS.copy()
+        if init_funcs is None
+        else _validate_init_funcs_keys(init_funcs)
+    )
 
     if isinstance(random_key, int):
         random_key = jax.random.PRNGKey(random_key)

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -663,6 +663,8 @@ def setup_hmm_initialization(
 
     if init_funcs is None:
         init_funcs = default_init_dict
+    else:
+        init_funcs = init_funcs.copy()
 
     # update functions and kwargs for init prob and transition prob
     # if a function is passed but not kwargs, kwargs will be reset

--- a/src/nemos/hmm/params.py
+++ b/src/nemos/hmm/params.py
@@ -1,11 +1,16 @@
 """HMM parameter definitions and type aliases."""
 
-from typing import Tuple
+from typing import Tuple, TypeVar
 
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
 from ..params import ModelParams
+
+# HMM-type User provided init_params (e.g. for GLM-HMM Tuple[array, array, array, array, array]])
+HMMUserProvidedParamsT = TypeVar("HMMUserProvidedParamsT")
+# HMM-type Model internal representation (e.g. for GLM-s nemos.glm_hmm.glm_hmm.GLMHMMParams)
+HMMModelParamsT = TypeVar("HMMModelParamsT")
 
 
 class HMMParams(ModelParams):

--- a/src/nemos/hmm/utils.py
+++ b/src/nemos/hmm/utils.py
@@ -2,12 +2,20 @@
 
 import jax
 import jax.numpy as jnp
-from numpy.typing import NDArray
+import pynapple as nap
+from numpy.typing import ArrayLike, NDArray
+
+from ..type_casting import is_pynapple_tsd
+from ..typing import DESIGN_INPUT_TYPE
 
 Array = NDArray | jax.numpy.ndarray
 
 
-def initialize_new_session(n_samples, is_new_session):
+def initialize_is_new_session(
+    X: DESIGN_INPUT_TYPE,
+    y: ArrayLike,
+    is_new_session: ArrayLike | nap.IntervalSet | None = None,
+):
     """
     Initialize and validate session boundary indicators for HMM inference.
 
@@ -17,10 +25,19 @@ def initialize_new_session(n_samples, is_new_session):
 
     Parameters
     ----------
-    n_samples :
-        Total number of time bins in the data.
+    X :
+        Input data/design matrix, shape ``(n_samples, n_features)``. Used to infer
+        session boundaries if is_new_session is a pynapple.IntervalSet and y is not
+        a pynapple Tsd or TsdFrame.
+    y :
+        Output data/observations, shape ``(n_samples, n_observations)``. Used to get
+        n_samples and to infer session boundaries if is_new_session is a pynapple.IntervalSet.
     is_new_session :
-        Boolean array indicating session starts, shape ``(n_samples,)``.
+        Optional array indicating user-provided session boundaries. Can be:
+        - a boolean array indicating session starts, shape ``(n_samples,)``
+        - an integer array of indices marking session starts, shape ``(n_sessions,)``
+        - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+          pynapple Tsd or TsdFrame to get timestamps)
         If None, creates a default array treating all data as one session.
 
     Returns
@@ -35,17 +52,160 @@ def initialize_new_session(n_samples, is_new_session):
     the forward and backward message passing at session starts, preventing
     information leakage between independent experimental sessions or trials.
     """
-    # Revise if the data is one single session or multiple sessions.
+    n_samples = y.shape[0]
     # If new_sess is not provided, assume one session
     if is_new_session is None:
-        # default: all False, but first time bin must be True
-        is_new_session = jax.lax.dynamic_update_index_in_dim(
-            jnp.zeros(n_samples, dtype=bool), True, 0, axis=0
-        )
+        # default: all False, but first time bin must be True (set at end)
+        is_new_session = jnp.zeros(n_samples, dtype=bool)
+    elif isinstance(is_new_session, nap.IntervalSet):
+        is_new_session = compute_is_new_session_from_pynapple(X, y, is_new_session)
+    elif hasattr(is_new_session, "dtype"):
+        if jnp.issubdtype(is_new_session.dtype, jnp.bool_):
+            if is_new_session.shape != (n_samples,):
+                raise ValueError(
+                    f"Boolean is_new_session must have shape (n_samples,), but got shape {is_new_session.shape}."
+                )
+            # force jax boolean array
+            is_new_session = jnp.asarray(is_new_session, dtype=bool)
+
+        elif jnp.issubdtype(is_new_session.dtype, jnp.integer):
+            if (jnp.max(is_new_session) >= n_samples) or (jnp.min(is_new_session) < 0):
+                raise ValueError(
+                    "Integer is_new_session values must be between 0 and n_samples-1, "
+                    f"but got min {jnp.min(is_new_session)} and max {jnp.max(is_new_session)}."
+                )
+            elif len(is_new_session) > n_samples:
+                raise ValueError(
+                    f"Integer is_new_session array must have length <= n_samples, but got length {len(is_new_session)} "
+                    f"and n_samples {n_samples}."
+                )
+
+            if (
+                (is_new_session == 0) | (is_new_session == 1)
+            ).all() and is_new_session.shape == (n_samples,):
+                # should be treated as a boolean array
+                is_new_session = jnp.asarray(is_new_session, dtype=bool)
+            else:
+                is_new_session = (
+                    jnp.zeros(n_samples, dtype=bool)
+                    .at[jnp.asarray(is_new_session, dtype=int)]
+                    .set(True)
+                )
+        else:
+            raise TypeError(
+                "is_new_session must be a boolean or integer array, but got dtype "
+                f"{is_new_session.dtype}."
+            )
     else:
-        # use the user-provided tree, but force the first time bin to be True
-        is_new_session = jax.lax.dynamic_update_index_in_dim(
-            jnp.asarray(is_new_session, dtype=bool), True, 0, axis=0
+        raise TypeError(
+            "is_new_session must be a boolean or integer array, but got type "
+            f"{type(is_new_session)}."
         )
 
+    # force first time bin to be True
+    is_new_session = jax.lax.dynamic_update_index_in_dim(
+        jnp.asarray(is_new_session, dtype=bool), True, 0, axis=0
+    )
     return is_new_session
+
+
+def compute_is_new_session_from_pynapple(
+    X: nap.Tsd | nap.TsdFrame,
+    y: nap.Tsd | nap.TsdFrame,
+    is_new_session: nap.IntervalSet,
+) -> jnp.ndarray:
+    """Compute indicator vector marking the start of new sessions.
+
+    This function identifies session boundaries in Pynapple time-series data by marking
+    positions where new epochs begin.
+
+    Parameters
+    ----------
+    X :
+        Input data/design matrix, shape ``(n_samples, n_features)``. Used for sample time
+        stamps if y is not a pynapple Tsd or TsdFrame.
+    y :
+        Output data/observations, shape ``(n_samples, n_observations)``. Used primarily when
+        retrieving sample time stamps.
+    is_new_session :
+        pynapple.IntervalSet marking the start and end times of sessions, where start times
+        are used to identify session boundaries.
+
+    Returns
+    -------
+    is_new_session :
+        Binary indicator array of shape ``(n_time_points,)`` where 1 indicates the start
+        of a new session and 0 otherwise.
+    """
+    if not (is_pynapple_tsd(X) or is_pynapple_tsd(y)):
+        raise TypeError(
+            "Either X or y must be a pynapple Tsd or TsdFrame to compute session boundaries from "
+            "a pynapple.IntervalSet object."
+        )
+    time = y.t if is_pynapple_tsd(y) else X.t
+    start = is_new_session.start
+    is_new_session = (
+        jax.numpy.zeros_like(time, dtype=bool)
+        .at[jax.numpy.searchsorted(time, start)]
+        .set(True)
+    )
+    return is_new_session
+
+
+def shift_nan_is_new_session(
+    is_new_session: jnp.ndarray, is_nan: jnp.ndarray
+) -> jnp.ndarray:
+    """
+    Shift session-start markers off NaN samples to the next valid sample.
+
+    Any ``True`` in ``is_new_session`` that falls on an index marked by ``is_nan``
+    is moved forward to the first subsequent index where ``is_nan`` is ``False``.
+    Markers already on valid samples are preserved. If no valid sample follows a
+    misplaced marker, it is dropped. This ensures that after dropping NaN values,
+    session boundaries are preserved.
+
+    Parameters
+    ----------
+    is_new_session :
+        Boolean array of session-start indicators, shape ``(n_samples,)``.
+    is_nan :
+        Boolean mask of NaN samples, shape ``(n_samples,)``.
+
+    Returns
+    -------
+    :
+        Updated boolean session-start indicators, shape ``(n_samples,)``.
+    """
+    n_samples = is_new_session.shape[0]
+    indices = jnp.arange(n_samples)
+
+    def body(carry, x):
+        is_nan_i, idx = x
+        next_valid = jnp.where(is_nan_i, carry, idx)
+        return next_valid, next_valid
+
+    # next_valid will contain the index of the next valid sample for each position, or the position itself if it's valid
+    _, next_valid = jax.lax.scan(body, n_samples, (is_nan, indices), reverse=True)
+    new_idx = next_valid[is_new_session]
+    return jnp.zeros(n_samples, dtype=bool).at[new_idx].set(True, mode="drop")
+
+
+def _check_state_format(state_format: str) -> None:
+    """Validate state_format parameter.
+
+    Parameters
+    ----------
+    state_format :
+        Format for state output, must be "one-hot" or "index".
+
+    Raises
+    ------
+    ValueError
+        If state_format is not "one-hot" or "index".
+    """
+    valid_formats = ("one-hot", "index")
+    if state_format not in valid_formats:
+        raise ValueError(
+            f"Invalid state_format '{state_format}'. "
+            f"Must be one of {valid_formats}."
+        )

--- a/src/nemos/hmm/utils.py
+++ b/src/nemos/hmm/utils.py
@@ -186,18 +186,22 @@ def shift_nan_is_new_session(
     :
         Updated boolean session-start indicators, shape ``(n_samples,)``.
     """
-    n_samples = is_new_session.shape[0]
-    indices = jnp.arange(n_samples)
+    n = is_new_session.shape[0]
+    valid = jnp.arange(n)[~is_nan]  # non-NaN indices
+    invalid_session_idx = jnp.arange(n)[is_nan & is_new_session]  # misplaced markers
 
-    def body(carry, x):
-        is_nan_i, idx = x
-        next_valid = jnp.where(is_nan_i, carry, idx)
-        return next_valid, next_valid
+    # Append sentinel n: searchsorted returning len(valid) (no valid sample after
+    # the markebuwr) then maps to n, which mode="drop" discards. The append copies
+    # valid but avoids any clip/where logic and handles empty valid correctly.
+    pos = jnp.searchsorted(valid, invalid_session_idx, side="left")
+    shifted_idx = jnp.append(valid, n)[pos]
 
-    # next_valid will contain the index of the next valid sample for each position, or the position itself if it's valid
-    _, next_valid = jax.lax.scan(body, n_samples, (is_nan, indices), reverse=True)
-    new_idx = next_valid[is_new_session]
-    return jnp.zeros(n_samples, dtype=bool).at[new_idx].set(True, mode="drop")
+    return (
+        is_new_session.at[invalid_session_idx]
+        .set(False)
+        .at[shifted_idx]
+        .set(True, mode="drop")
+    )
 
 
 def _check_state_format(state_format: str) -> None:

--- a/src/nemos/hmm/utils.py
+++ b/src/nemos/hmm/utils.py
@@ -1,14 +1,21 @@
 """Utilities for HMM."""
 
+from typing import TYPE_CHECKING
+
 import jax
 import jax.numpy as jnp
-import pynapple as nap
+import lazy_loader as lazy
 from numpy.typing import ArrayLike, NDArray
 
 from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE
 
 Array = NDArray | jax.numpy.ndarray
+
+nap = lazy.load("pynapple")
+
+if TYPE_CHECKING:
+    import pynapple as nap
 
 
 def initialize_is_new_session(
@@ -60,7 +67,7 @@ def initialize_is_new_session(
     if is_new_session is None:
         # default: all False, but first time bin must be True (set at end)
         is_new_session = jnp.zeros(n_samples, dtype=bool)
-    elif isinstance(is_new_session, nap.IntervalSet):
+    elif hasattr(is_new_session, "start") and hasattr(is_new_session, "end"):
         is_new_session = compute_is_new_session_from_pynapple(X, y, is_new_session)
     elif hasattr(is_new_session, "dtype"):
         if jnp.issubdtype(is_new_session.dtype, jnp.bool_):

--- a/src/nemos/hmm/utils.py
+++ b/src/nemos/hmm/utils.py
@@ -13,7 +13,7 @@ Array = NDArray | jax.numpy.ndarray
 
 def initialize_is_new_session(
     X: DESIGN_INPUT_TYPE,
-    y: ArrayLike,
+    y: ArrayLike | None,
     is_new_session: ArrayLike | nap.IntervalSet | None = None,
 ):
     """
@@ -32,6 +32,7 @@ def initialize_is_new_session(
     y :
         Output data/observations, shape ``(n_samples, n_observations)``. Used to get
         n_samples and to infer session boundaries if is_new_session is a pynapple.IntervalSet.
+        If None (e.g. during simulation), n_samples is inferred from X.
     is_new_session :
         Optional array indicating user-provided session boundaries. Can be:
         - a boolean array or integer array of 1s and 0s indicating session starts, shape ``(n_samples,)``
@@ -52,7 +53,9 @@ def initialize_is_new_session(
     the forward and backward message passing at session starts, preventing
     information leakage between independent experimental sessions or trials.
     """
-    n_samples = y.shape[0]
+    n_samples = (
+        y.shape[0] if y is not None else jax.tree_util.tree_leaves(X)[0].shape[0]
+    )
     # If new_sess is not provided, assume one session
     if is_new_session is None:
         # default: all False, but first time bin must be True (set at end)

--- a/src/nemos/hmm/utils.py
+++ b/src/nemos/hmm/utils.py
@@ -191,7 +191,7 @@ def shift_nan_is_new_session(
     invalid_session_idx = jnp.arange(n)[is_nan & is_new_session]  # misplaced markers
 
     # Append sentinel n: searchsorted returning len(valid) (no valid sample after
-    # the markebuwr) then maps to n, which mode="drop" discards. The append copies
+    # the marker) then maps to n, which mode="drop" discards. The append copies
     # valid but avoids any clip/where logic and handles empty valid correctly.
     pos = jnp.searchsorted(valid, invalid_session_idx, side="left")
     shifted_idx = jnp.append(valid, n)[pos]

--- a/src/nemos/hmm/utils.py
+++ b/src/nemos/hmm/utils.py
@@ -34,7 +34,7 @@ def initialize_is_new_session(
         n_samples and to infer session boundaries if is_new_session is a pynapple.IntervalSet.
     is_new_session :
         Optional array indicating user-provided session boundaries. Can be:
-        - a boolean array indicating session starts, shape ``(n_samples,)``
+        - a boolean array or integer array of 1s and 0s indicating session starts, shape ``(n_samples,)``
         - an integer array of indices marking session starts, shape ``(n_sessions,)``
         - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
           pynapple Tsd or TsdFrame to get timestamps)

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -1,19 +1,43 @@
 """Validation mixin class for HMM-based models."""
 
 from dataclasses import dataclass, field
-from typing import Any, Optional, Tuple, TypeVar
+from typing import Any, Optional, Tuple
 
-import jax
 import jax.numpy as jnp
+import pynapple as nap
+from pynapple import Tsd, TsdFrame
 
 from .. import validation
 from ..base_validator import RegressorValidator
-from .params import HMMParams, HMMUserParams
+from ..type_casting import is_pynapple_tsd
+from ..typing import DESIGN_INPUT_TYPE, ArrayLike
+from .params import HMMModelParamsT, HMMParams, HMMUserParams, HMMUserProvidedParamsT
+from .utils import (
+    initialize_is_new_session,
+    shift_nan_is_new_session,
+)
 
-# HMM-type User provided init_params (e.g. for GLM-HMM Tuple[array, array, array, array, array]])
-HMMUserProvidedParamsT = TypeVar("HMMUserProvidedParamsT")
-# HMM-type Model internal representation (e.g. for GLM-s nemos.glm_hmm.glm_hmm.GLMHMMParams)
-HMMModelParamsT = TypeVar("HMMModelParamsT")
+
+def has_nans_only_at_border(arr):
+    """Check if NaNs appear only at the start and end along axis=0."""
+    # Check which rows have any NaN values
+    is_nan = jnp.any(jnp.isnan(arr.reshape(arr.shape[0], -1)), axis=1)
+
+    # If no NaNs, it's valid
+    if not jnp.any(is_nan):
+        return True
+
+    # If all NaNs, it's valid
+    if jnp.all(is_nan):
+        return True
+
+    # Find first and last non-NaN positions
+    non_nan_indices = jnp.where(~is_nan)[0]
+    first_valid = non_nan_indices[0]
+    last_valid = non_nan_indices[-1]
+
+    # Check if there are any NaNs between first and last valid values
+    return not jnp.any(is_nan[first_valid : last_valid + 1])
 
 
 def to_hmm_params(user_params: HMMUserParams) -> HMMParams:
@@ -47,58 +71,12 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
     """Validate HMM parameters. Meant to be used as a mixin class for models that use HMMs."""
 
     n_states: int = field(kw_only=True)  # keyword only and required.
-    expected_param_dims: Tuple[int] = (
-        1,
-        2,
-    )  # (init_prob.ndim, transition_prob.ndim)
-    initial_prob_ind: int = None  # index of initial probability in user params tuple
-    transition_prob_ind: int = (
-        None  # index of transition probability in user params tuple
-    )
     model_param_names: Tuple[str] = ("initial_prob", "transition_prob")
     model_class: str = "HMM"
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
         ("check_init_and_transition_prob_shape", None),
         ("check_init_and_transition_prob_sum_to_1", None),
     )
-
-    def check_array_dimensions(
-        self,
-        params: HMMUserProvidedParamsT,
-        err_msg: Optional[str] = None,
-        err_message_format: str = None,
-    ) -> HMMUserProvidedParamsT:
-        """
-        Check array dimensions with custom error formatting for HMM-based model parameters.
-
-        Overrides the base implementation to provide model-specific error messages
-        that include the actual shapes of the provided parameters. The expected shapes of
-        additional model parameters and error message should be set in the child class (e.g
-        see GLMHMMValidator for an example).
-
-        Parameters
-        ----------
-        params :
-            User-provided parameters as a tuple.
-        err_msg :
-            Custom error message (unused, overridden by err_message_format).
-        err_message_format :
-            Format string for error message that takes two shape arguments.
-
-        Returns
-        -------
-        :
-            The validated parameters.
-
-        Raises
-        ------
-        ValueError
-            If arrays have incorrect dimensionality.
-        """
-        wrapped = self.wrap_user_params(params)
-        shapes = tuple(jax.tree_util.tree_map(lambda x: x.shape, p) for p in wrapped)
-        err_msg = err_message_format.format(*shapes)
-        return super().check_array_dimensions(params, err_msg=err_msg)
 
     def check_user_params_structure(
         self, params: HMMUserProvidedParamsT, **kwargs
@@ -125,13 +103,13 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         """
         validation.check_length(
             params,
-            len(self.expected_param_dims),
-            f"Params must have length {len(self.expected_param_dims)}: "
+            len(self.model_param_names),
+            f"Params must have length {len(self.model_param_names)}: "
             f"({', '.join(self.model_param_names)}).",
         )
         if not isinstance(params, (tuple, list)):
             raise TypeError(
-                f"{self.model_class} params must be a tuple/list of length {len(self.expected_param_dims)}, "
+                f"{self.model_class} params must be a tuple/list of length {len(self.model_param_names)}, "
                 f"({', '.join(self.model_param_names)})."
             )
         return params
@@ -140,11 +118,7 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         self, params: HMMUserProvidedParamsT
     ) -> HMMUserProvidedParamsT:
         """Check initial and transition probabilities shape."""
-        wrapped = self.wrap_user_params(params)
-        initial_prob, transition_prob = (
-            wrapped[self.initial_prob_ind],
-            wrapped[self.transition_prob_ind],
-        )
+        initial_prob, transition_prob = self.wrap_user_params(params)[-2:]
         if initial_prob.shape != (self.n_states,):
             raise ValueError(
                 f"initial_prob must be a 1-dimensional array of shape ``({self.n_states},)``. "
@@ -161,11 +135,8 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         self, params: HMMUserProvidedParamsT
     ) -> HMMUserProvidedParamsT:
         """Check that initial and transition probability sum to 1."""
-        wrapped = self.wrap_user_params(params)
-        initial_prob, transition_prob = (
-            wrapped[self.initial_prob_ind],
-            wrapped[self.transition_prob_ind],
-        )
+        initial_prob, transition_prob = self.wrap_user_params(params)[-2:]
+
         if not jnp.allclose(initial_prob.sum(), 1):
             raise ValueError(
                 f"initial_prob must sum to 1, but got sum = {initial_prob.sum()}. "
@@ -178,3 +149,74 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
                 f"and must sum to 1. "
             )
         return params
+
+    def validate_inputs(
+        self,
+        X: Optional[DESIGN_INPUT_TYPE] = None,
+        y: Optional[jnp.ndarray | Tsd | TsdFrame] = None,
+    ):
+        """Validate inputs for HMM model."""
+        super().validate_inputs(X, y)
+
+        # Additional checks due to the time-series structure.
+        # (the forward-backward implementation assumes no nans in the inputs)
+        # Skip NaN border check if y is None (e.g., during simulation)
+        if y is None:
+            if X is not None and not has_nans_only_at_border(X):
+                raise ValueError(
+                    "HMM requires continuous time-series data. NaN values must only "
+                    "appear at the beginning or end of the data, not in the middle."
+                )
+            return
+
+        if is_pynapple_tsd(X):
+            # loop over epochs and check that nans are all at the border
+            epoch_slices = [
+                X.get_slice(ep.start[0], ep.end[0]) for ep in X.time_support
+            ]
+            y_array = jnp.asarray(y)
+            is_continuous = all(
+                has_nans_only_at_border(X.d[s]) and has_nans_only_at_border(y_array[s])
+                for s in epoch_slices
+            )
+        elif is_pynapple_tsd(y):
+            # loop over epochs and check that nans are all at the border
+            epoch_slices = [
+                y.get_slice(ep.start[0], ep.end[0]) for ep in y.time_support
+            ]
+            is_continuous = all(
+                has_nans_only_at_border(X[s]) and has_nans_only_at_border(y.d[s])
+                for s in epoch_slices
+            )
+        else:
+            # check nans at the border
+            is_continuous = has_nans_only_at_border(X) and has_nans_only_at_border(y)
+        if not is_continuous:
+            raise ValueError(
+                "HMM requires continuous time-series data. NaN values must only "
+                "appear at the beginning or end of the data, not in the middle. "
+                "Found NaN values within the time series, which would break the "
+                "forward-backward algorithm. Please ensure your data is continuous "
+                "or split it into separate epochs at the gaps."
+            )
+
+    def validate_and_cast_is_new_session(
+        self, X, y, is_new_session: Optional[ArrayLike | nap.IntervalSet] = None
+    ) -> jnp.ndarray:
+        """Validate and cast is_new_session to a binary array of shape (n_samples,)."""
+        if is_new_session is None:
+            if is_pynapple_tsd(y):
+                is_new_session = y.time_support
+            elif is_pynapple_tsd(X):
+                is_new_session = X.time_support
+
+        is_new_session = initialize_is_new_session(X, y, is_new_session)
+
+        # shift any True values that fall on NaN samples to the next valid sample
+        nan_x = jnp.any(jnp.isnan(jnp.asarray(X)).reshape(X.shape[0], -1), axis=1)
+        nan_y = jnp.any(jnp.isnan(jnp.asarray(y)).reshape(y.shape[0], -1), axis=1)
+        return shift_nan_is_new_session(is_new_session, nan_x | nan_y)
+
+    def get_empty_params(self, X, y) -> HMMModelParamsT:
+        """Return the param shape given the input data."""
+        pass

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -7,7 +7,6 @@ from typing import Any, Optional, Tuple
 
 import jax.numpy as jnp
 import lazy_loader as lazy
-from pynapple import Tsd, TsdFrame
 
 from .. import validation
 from ..base_validator import RegressorValidator
@@ -157,7 +156,7 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
     def validate_inputs(
         self,
         X: Optional[DESIGN_INPUT_TYPE] = None,
-        y: Optional[jnp.ndarray | Tsd | TsdFrame] = None,
+        y: Optional[jnp.ndarray | nap.Tsd | nap.TsdFrame] = None,
     ):
         """Validate inputs for HMM model."""
         super().validate_inputs(X, y)

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -221,5 +221,5 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         """Return the param shape given the input data."""
         return HMMParams(
             log_initial_prob=jnp.empty((self.n_states,)),
-            log_transition_prob=jnp.empty(self.n_states, self.n_states),
+            log_transition_prob=jnp.empty((self.n_states, self.n_states)),
         )

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -214,8 +214,12 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
 
         # shift any True values that fall on NaN samples to the next valid sample
         nan_x = jnp.any(jnp.isnan(jnp.asarray(X)).reshape(X.shape[0], -1), axis=1)
-        nan_y = jnp.any(jnp.isnan(jnp.asarray(y)).reshape(y.shape[0], -1), axis=1)
-        return shift_nan_is_new_session(is_new_session, nan_x | nan_y)
+        if y is not None:
+            nan_y = jnp.any(jnp.isnan(jnp.asarray(y)).reshape(y.shape[0], -1), axis=1)
+            combined_nans = nan_x | nan_y
+        else:
+            combined_nans = nan_x
+        return shift_nan_is_new_session(is_new_session, combined_nans)
 
     def get_empty_params(self, X, y) -> HMMModelParamsT:
         """Return the param shape given the input data."""

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -193,7 +193,7 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
             is_continuous = has_nans_only_at_border(X) and has_nans_only_at_border(y)
         if not is_continuous:
             raise ValueError(
-                "HMM requires continuous time-series data. NaN values must only "
+                f"{self.model_class} requires continuous time-series data. NaN values must only "
                 "appear at the beginning or end of the data, not in the middle. "
                 "Found NaN values within the time series, which would break the "
                 "forward-backward algorithm. Please ensure your data is continuous "

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -11,7 +11,6 @@ from .. import validation
 from ..base_validator import RegressorValidator
 from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE, ArrayLike
-from .initialize_parameters import INITIALIZATION_FN_DICT, _validate_init_funcs_keys
 from .params import HMMModelParamsT, HMMParams, HMMUserParams, HMMUserProvidedParamsT
 from .utils import (
     initialize_is_new_session,
@@ -221,8 +220,3 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
     def get_empty_params(self, X, y) -> HMMModelParamsT:
         """Return the param shape given the input data."""
         pass
-
-    @staticmethod
-    def validate_init_funcs(init_funcs: dict):
-        """Validate the keys of the initialization funcs provided."""
-        _validate_init_funcs_keys(init_funcs, INITIALIZATION_FN_DICT)

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -219,4 +219,7 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
 
     def get_empty_params(self, X, y) -> HMMModelParamsT:
         """Return the param shape given the input data."""
-        pass
+        return HMMParams(
+            log_initial_prob=jnp.empty((self.n_states,)),
+            log_transition_prob=jnp.empty(self.n_states, self.n_states),
+        )

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -11,6 +11,7 @@ from .. import validation
 from ..base_validator import RegressorValidator
 from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE, ArrayLike
+from .initialize_parameters import INITIALIZATION_FN_DICT, _validate_init_funcs_keys
 from .params import HMMModelParamsT, HMMParams, HMMUserParams, HMMUserProvidedParamsT
 from .utils import (
     initialize_is_new_session,
@@ -220,3 +221,8 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
     def get_empty_params(self, X, y) -> HMMModelParamsT:
         """Return the param shape given the input data."""
         pass
+
+    @staticmethod
+    def validate_init_funcs(init_funcs: dict):
+        """Validate the keys of the initialization funcs provided."""
+        _validate_init_funcs_keys(init_funcs, INITIALIZATION_FN_DICT)

--- a/src/nemos/tree_utils.py
+++ b/src/nemos/tree_utils.py
@@ -222,5 +222,8 @@ def has_matching_axis_pytree(*pytree: Any, axis: int = 0):
 
 def drop_nans(*trees):
     """Drop all NaNs from trees."""
-    is_valid = get_valid_multitree(*trees)
-    return [jax.tree_util.tree_map(lambda x: x[is_valid], par) for par in trees]
+    is_valid = get_valid_multitree(*[t for t in trees if t is not None])
+    return [
+        jax.tree_util.tree_map(lambda x: x[is_valid], par) if par is not None else None
+        for par in trees
+    ]

--- a/tests/test_glm_hmm_algorithms.py
+++ b/tests/test_glm_hmm_algorithms.py
@@ -1130,8 +1130,8 @@ class TestMStep:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=alphas_transition,
-            dirichlet_prior_alphas_init_prob=alphas_init,
+            dirichlet_transition_proba=alphas_transition,
+            dirichlet_initial_proba=alphas_init,
         )
 
         # Convert back to probability space for gradient checks
@@ -1229,8 +1229,8 @@ class TestMStep:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=alphas_transition,
-            dirichlet_prior_alphas_init_prob=alphas_init,
+            dirichlet_transition_proba=alphas_transition,
+            dirichlet_initial_proba=alphas_init,
         )
         # Convert back to probability space
         new_initial_prob = np.exp(new_params.hmm_params.log_initial_prob)
@@ -1293,8 +1293,8 @@ class TestMStep:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=alphas_transition,
-            dirichlet_prior_alphas_init_prob=alphas_init,
+            dirichlet_transition_proba=alphas_transition,
+            dirichlet_initial_proba=alphas_init,
         )
         # Convert back to probability space
         new_initial_prob = np.exp(new_params.hmm_params.log_initial_prob)
@@ -1353,8 +1353,8 @@ class TestMStep:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=alphas_transition,
-            dirichlet_prior_alphas_init_prob=alphas_init,
+            dirichlet_transition_proba=alphas_transition,
+            dirichlet_initial_proba=alphas_init,
         )
         (
             new_params_no_prior,
@@ -1367,8 +1367,8 @@ class TestMStep:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=alphas_transition,
-            dirichlet_prior_alphas_init_prob=None,
+            dirichlet_transition_proba=alphas_transition,
+            dirichlet_initial_proba=None,
         )
         np.testing.assert_array_almost_equal(
             new_params_no_prior.hmm_params.log_initial_prob,
@@ -1436,8 +1436,8 @@ class TestMStep:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=alphas_transition,
-            dirichlet_prior_alphas_init_prob=alphas_init,
+            dirichlet_transition_proba=alphas_transition,
+            dirichlet_initial_proba=alphas_init,
         )
         (
             new_params_no_prior,
@@ -1450,8 +1450,8 @@ class TestMStep:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=None,
-            dirichlet_prior_alphas_init_prob=alphas_init,
+            dirichlet_transition_proba=None,
+            dirichlet_initial_proba=alphas_init,
         )
         np.testing.assert_array_almost_equal(
             new_params_no_prior.hmm_params.log_initial_prob,
@@ -1542,8 +1542,8 @@ class TestMStep:
             np.log(xis),
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_init_prob=dirichlet_prior_initial_prob,
-            dirichlet_prior_alphas_transition=dirichlet_prior_transition_prob,
+            dirichlet_initial_proba=dirichlet_prior_initial_prob,
+            dirichlet_transition_proba=dirichlet_prior_transition_prob,
         )
 
         # Convert back to probability space for comparison with reference
@@ -1691,8 +1691,8 @@ class TestMStep:
                 None,
                 dummy_aux,
             ),
-            dirichlet_prior_alphas_init_prob=alphas_init,
-            dirichlet_prior_alphas_transition=alphas_trans,
+            dirichlet_initial_proba=alphas_init,
+            dirichlet_transition_proba=alphas_trans,
         )
 
         # Compare to reference
@@ -2209,8 +2209,8 @@ def test_e_and_m_step_for_population(generate_data_multi_state_population):
         log_xis,
         is_new_session=new_sess.astype(bool),
         m_step_fn_model_params=update_fn,
-        dirichlet_prior_alphas_transition=alphas_transition,
-        dirichlet_prior_alphas_init_prob=alphas_init,
+        dirichlet_transition_proba=alphas_transition,
+        dirichlet_initial_proba=alphas_init,
     )
 
 
@@ -2862,8 +2862,8 @@ class TestCompilation:
             log_xis,
             is_new_session,
             m_step_fn_model_params,
-            dirichlet_prior_alphas_init_prob=None,
-            dirichlet_prior_alphas_transition=None,
+            dirichlet_initial_proba=None,
+            dirichlet_transition_proba=None,
         ):
             # This increment only runs during tracing (compilation)
             compilation_counter["n_compilations"] += 1
@@ -2876,8 +2876,8 @@ class TestCompilation:
                 log_xis,
                 is_new_session=is_new_session,
                 m_step_fn_model_params=m_step_fn_model_params,
-                dirichlet_prior_alphas_transition=dirichlet_prior_alphas_transition,
-                dirichlet_prior_alphas_init_prob=dirichlet_prior_alphas_init_prob,
+                dirichlet_transition_proba=dirichlet_transition_proba,
+                dirichlet_initial_proba=dirichlet_initial_proba,
             )
 
             return new_params, new_state
@@ -2900,8 +2900,8 @@ class TestCompilation:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=None,
-            dirichlet_prior_alphas_init_prob=None,
+            dirichlet_transition_proba=None,
+            dirichlet_initial_proba=None,
         )
         assert compilation_counter["n_compilations"] == 1, "First call should compile"
 
@@ -2914,8 +2914,8 @@ class TestCompilation:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=None,
-            dirichlet_prior_alphas_init_prob=None,
+            dirichlet_transition_proba=None,
+            dirichlet_initial_proba=None,
         )
         assert compilation_counter["n_compilations"] == 1, "None prior not cached!"
 
@@ -2928,8 +2928,8 @@ class TestCompilation:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=np.ones(transition_prob.shape),
-            dirichlet_prior_alphas_init_prob=np.ones(initial_prob.shape),
+            dirichlet_transition_proba=np.ones(transition_prob.shape),
+            dirichlet_initial_proba=np.ones(initial_prob.shape),
         )
         assert (
             compilation_counter["n_compilations"] == 2
@@ -2944,8 +2944,8 @@ class TestCompilation:
             log_xis,
             is_new_session=new_sess.astype(bool),
             m_step_fn_model_params=solver.run,
-            dirichlet_prior_alphas_transition=2 * np.ones(transition_prob.shape),
-            dirichlet_prior_alphas_init_prob=2 * np.ones(initial_prob.shape),
+            dirichlet_transition_proba=2 * np.ones(transition_prob.shape),
+            dirichlet_initial_proba=2 * np.ones(initial_prob.shape),
         )
         assert compilation_counter["n_compilations"] == 2, "Array prior not cached!"
 

--- a/tests/test_glm_hmm_algorithms.py
+++ b/tests/test_glm_hmm_algorithms.py
@@ -1002,7 +1002,7 @@ class TestMStep:
             inverse_link_function=obs.default_inverse_link_function,
         )
         log_conditionals = log_likelihood(
-            X, y, GLMHMMModelParams(coef, jnp.ones(coef.shape[-1]))
+            GLMHMMModelParams(coef, jnp.ones(coef.shape[-1])), X, y
         )
         new_sess = np.zeros(10)
         new_sess[0] = 1
@@ -2237,7 +2237,7 @@ class TestViterbi:
         )
 
         # to be in the correct for for max_sum
-        def log_like_func_max_sum(X, y, params):
+        def log_like_func_max_sum(params, X, y):
             predicted_rate = inverse_link_function(X @ params.coef + params.intercept)
             return log_like_func(y, predicted_rate)
 
@@ -2285,7 +2285,7 @@ class TestViterbi:
         )
 
         # to be in the correct for for max_sum
-        def log_like_func_max_sum(X, y, params):
+        def log_like_func_max_sum(params, X, y):
             predicted_rate = inverse_link_function(X @ params.coef + params.intercept)
             return log_like_func(y, predicted_rate)
 

--- a/tests/test_glm_hmm_analytic_mstep.py
+++ b/tests/test_glm_hmm_analytic_mstep.py
@@ -236,8 +236,8 @@ class TestAnalyticMStepScale:
             log_xis,
             is_new_session=new_sess,
             m_step_fn_model_params=analytical_update_fn,
-            dirichlet_prior_alphas_transition=None,
-            dirichlet_prior_alphas_init_prob=None,
+            dirichlet_transition_proba=None,
+            dirichlet_initial_proba=None,
         )
 
         def numerical_update_fn(params, X, y, posteriors):
@@ -269,8 +269,8 @@ class TestAnalyticMStepScale:
             log_xis,
             is_new_session=new_sess,
             m_step_fn_model_params=numerical_update_fn,
-            dirichlet_prior_alphas_transition=None,
-            dirichlet_prior_alphas_init_prob=None,
+            dirichlet_transition_proba=None,
+            dirichlet_initial_proba=None,
         )
         np.testing.assert_allclose(
             numerical_update.model_params.log_scale,

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -1,0 +1,1087 @@
+from contextlib import nullcontext as does_not_raise
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pynapple as nap
+import pytest
+
+from nemos.base_validator import RegressorValidator
+from nemos.hmm.hmm import BaseHMM
+from nemos.hmm.initialize_parameters import (
+    DEFAULT_INIT_FUNCTIONS,
+    INITIALIZATION_FN_DICT,
+    kmeans_initial_proba_init,
+    kmeans_transition_proba_init,
+    random_initial_proba_init,
+    random_transition_proba_init,
+    sticky_transition_proba_init,
+    uniform_initial_proba_init,
+    uniform_transition_proba_init,
+)
+from nemos.hmm.params import HMMParams
+from nemos.hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
+from nemos.params import ModelParams
+
+
+class MockHMMModelParams(ModelParams):
+    param: jnp.ndarray
+
+
+class MockHMMParams(ModelParams):
+    model_params: MockHMMModelParams
+    hmm_params: HMMParams
+
+
+MockHMMUserParams = Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]
+
+
+def to_mock_params(user_params: MockHMMUserParams) -> MockHMMParams:
+    return MockHMMParams(
+        model_params=MockHMMModelParams(user_params[0]),
+        hmm_params=to_hmm_params(user_params[1:]),
+    )
+
+
+def from_mock_params(params: MockHMMParams) -> MockHMMUserParams:
+    initial_prob, transition_prob = from_hmm_params(params.hmm_params)
+    return (
+        params.model_params.param,
+        initial_prob,
+        transition_prob,
+    )
+
+
+@dataclass(frozen=True, repr=False)
+class MockHMMValidator(HMMValidator[MockHMMUserParams, MockHMMParams]):
+    model_param_names: Tuple[str] = (
+        "param",
+        *HMMValidator.model_param_names,
+    )
+    to_model_params: Callable[[MockHMMUserParams], MockHMMParams] = to_mock_params
+    from_model_params: Callable[[MockHMMParams], MockHMMUserParams] = from_mock_params
+    model_class: str = "MockHMM"
+    params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
+        *RegressorValidator.params_validation_sequence[:2],
+        *HMMValidator.params_validation_sequence,
+        *RegressorValidator.params_validation_sequence[3:],
+    )
+
+    def validate_consistency(self, params: MockHMMParams) -> None:
+        return True
+
+
+class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
+    _validator_class = MockHMMValidator
+
+    def __init__(
+        self,
+        n_states: int,
+        dirichlet_prior_alphas_init_prob: Union[
+            jnp.ndarray, None
+        ] = None,  # (n_state, )
+        dirichlet_prior_alphas_transition: Union[
+            jnp.ndarray | None
+        ] = None,  # (n_state, n_state):
+        maxiter: int = 1000,
+        tol: float = 1e-8,
+        seed=jax.random.PRNGKey(123),
+        hmm_initialization_funcs: INITIALIZATION_FN_DICT = {},
+        model_initialization_funcs: INITIALIZATION_FN_DICT = {},
+    ):
+        BaseHMM.__init__(
+            self,
+            n_states=n_states,
+            dirichlet_prior_alphas_init_prob=dirichlet_prior_alphas_init_prob,
+            dirichlet_prior_alphas_transition=dirichlet_prior_alphas_transition,
+            maxiter=maxiter,
+            tol=tol,
+            seed=seed,
+            hmm_initialization_funcs=hmm_initialization_funcs,
+        )
+        self.param_: jnp.ndarray | None = None
+        self.model_initialization_funcs = model_initialization_funcs
+
+    def setup(
+        self,
+        initial_proba_init: Optional[str | Callable] = None,
+        initial_proba_init_kwargs: Optional[dict] = None,
+        transition_proba_init: Optional[str | Callable] = None,
+        transition_proba_init_kwargs: Optional[dict] = None,
+        param_init: Optional[str | Callable] = None,
+        param_init_kwargs: Optional[dict] = None,
+    ):
+        BaseHMM.setup(
+            self,
+            initial_proba_init=initial_proba_init,
+            initial_proba_init_kwargs=initial_proba_init_kwargs,
+            transition_proba_init=transition_proba_init,
+            transition_proba_init_kwargs=transition_proba_init_kwargs,
+        )
+
+    def _check_model_is_fit(self):
+        BaseHMM._check_is_fit(self)
+        if self.param_ is None:
+            raise ValueError("Model is not fitted yet.")
+
+    def _get_model_params(self) -> MockHMMParams:
+        return self._validator.to_model_params(
+            self.param_,
+            self.log_initial_prob_,
+            self.log_transition_prob_,
+        )
+
+    def _set_model_params(self, params):
+        param, initial_prob, transition_prob = self._validator.from_model_params(params)
+        self.param_ = param
+        self.initial_prob_ = initial_prob
+        self.transition_prob_ = transition_prob
+
+    def _log_likelihood(self, params, X, y):
+        pass
+
+    def _model_params_initialization(self, X, y, is_new_session):
+        return (
+            jnp.zeros(self._n_states),
+            False,
+        )
+
+    def fit(self, X, y, is_new_session=None, init_params=None):
+        pass
+
+    def _initialize_optimizer_and_state(self, *args, **kwargs):
+        pass
+
+    def _compute_loss(self, *args, **kwargs):
+        pass
+
+    def _get_optimal_solver_params_config(self, *args, **kwargs):
+        pass
+
+    def predict(self, *args, **kwargs):
+        pass
+
+    def simulate(self, *args, **kwargs):
+        pass
+
+    def save_params(self, *args, **kwargs):
+        pass
+
+    def update(self, *args, **kwargs):
+        pass
+
+    def score(self, *args, **kwargs):
+        pass
+
+
+class TestHMMInit:
+
+    # -------------------------------------------------------------------------
+    # n_states setter tests
+    # -------------------------------------------------------------------------
+    def test_n_states_creates_validator(self):
+        """Test that setting n_states creates a GLMHMMValidator."""
+        model = MockHMM(n_states=3)
+        assert hasattr(model, "_validator")
+        assert model._validator.n_states == 3
+
+    @pytest.mark.parametrize(
+        "n_states, expectation",
+        [
+            (1, does_not_raise()),
+            (2, does_not_raise()),
+            (10, does_not_raise()),
+            (3.0, does_not_raise()),  # float with no decimals is allowed
+            (0, pytest.raises(ValueError, match="must be a positive integer")),
+            (-1, pytest.raises(ValueError, match="must be a positive integer")),
+            (2.5, pytest.raises(TypeError, match="must be a positive integer")),
+            ("3", pytest.raises(TypeError, match="must be a positive integer")),
+            (None, pytest.raises(TypeError, match="must be a positive integer")),
+            ([3], pytest.raises(TypeError, match="must be a positive integer")),
+        ],
+    )
+    def test_n_states_setter(self, n_states, expectation):
+        """Test n_states validation accepts positive integers only."""
+        with expectation:
+            model = MockHMM(n_states=n_states)
+            assert model.n_states == int(n_states)
+
+    # -------------------------------------------------------------------------
+    # maxiter setter tests
+    # -------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "maxiter, expectation",
+        [
+            (1, does_not_raise()),
+            (100, does_not_raise()),
+            (1000, does_not_raise()),
+            (10.0, does_not_raise()),  # float with no decimals is allowed
+            (0, pytest.raises(ValueError, match="must be a strictly positive integer")),
+            (
+                -1,
+                pytest.raises(ValueError, match="must be a strictly positive integer"),
+            ),
+            (
+                10.5,
+                pytest.raises(ValueError, match="must be a strictly positive integer"),
+            ),
+            (
+                "100",
+                pytest.raises(ValueError, match="must be a strictly positive integer"),
+            ),
+            (
+                None,
+                pytest.raises(ValueError, match="must be a strictly positive integer"),
+            ),
+        ],
+    )
+    def test_maxiter_setter(self, maxiter, expectation):
+        """Test maxiter validation accepts positive integers only."""
+        with expectation:
+            model = MockHMM(n_states=2, maxiter=maxiter)
+            assert model.maxiter == int(maxiter)
+
+    # -------------------------------------------------------------------------
+    # tol setter tests
+    # -------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "tol, expectation",
+        [
+            (1e-8, does_not_raise()),
+            (0.001, does_not_raise()),
+            (1.0, does_not_raise()),
+            (1, does_not_raise()),  # int is allowed (converted to float)
+            (0, pytest.raises(ValueError, match="must be a strictly positive float")),
+            (
+                -1e-8,
+                pytest.raises(ValueError, match="must be a strictly positive float"),
+            ),
+            (
+                "0.001",
+                pytest.raises(ValueError, match="must be a strictly positive float"),
+            ),
+            (
+                None,
+                pytest.raises(ValueError, match="must be a strictly positive float"),
+            ),
+        ],
+    )
+    def test_tol_setter(self, tol, expectation):
+        """Test tol validation accepts positive numbers only."""
+        with expectation:
+            model = MockHMM(n_states=2, tol=tol)
+            assert model.tol == float(tol)
+
+    # -------------------------------------------------------------------------
+    # seed setter tests
+    # -------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "seed, expectation",
+        [
+            (jax.random.PRNGKey(0), does_not_raise()),
+            (jax.random.PRNGKey(123), does_not_raise()),
+            (jax.random.PRNGKey(999999), does_not_raise()),
+        ],
+    )
+    def test_seed_setter_valid(self, seed, expectation):
+        """Test seed validation accepts valid JAX PRNG keys."""
+        with expectation:
+            model = MockHMM(n_states=2, seed=seed)
+            assert jnp.array_equal(model.seed, seed)
+
+    @pytest.mark.parametrize(
+        "seed",
+        [
+            123,  # plain int
+            np.array([1, 2, 3]),  # wrong shape
+            jnp.array([1.0, 2.0]),  # wrong dtype
+            "seed",  # string
+            None,  # None
+        ],
+    )
+    def test_seed_setter_invalid(self, seed):
+        """Test seed validation rejects invalid inputs."""
+        with pytest.raises(TypeError, match="seed must be a JAX PRNG key"):
+            MockHMM(n_states=2, seed=seed)
+
+    # -------------------------------------------------------------------------
+    # dirichlet_prior_alphas_init_prob setter tests
+    # -------------------------------------------------------------------------
+    def test_dirichlet_prior_init_prob_none(self):
+        """Test that None is accepted for dirichlet prior."""
+        model = MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=None)
+        assert model.dirichlet_prior_alphas_init_prob is None
+
+    def test_dirichlet_prior_init_prob_valid(self):
+        """Test valid dirichlet prior alphas."""
+        alphas = jnp.array([1.0, 2.0, 3.0])
+        model = MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=alphas)
+        assert jnp.array_equal(model.dirichlet_prior_alphas_init_prob, alphas)
+
+    def test_dirichlet_prior_init_prob_wrong_shape(self):
+        """Test that wrong shape raises ValueError."""
+        alphas = jnp.array([1.0, 2.0])  # n_states=3 but only 2 elements
+        with pytest.raises(ValueError, match="must have shape"):
+            MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=alphas)
+
+    def test_dirichlet_prior_init_prob_values_less_than_one(self):
+        """Test that alpha values < 1 raise ValueError."""
+        alphas = jnp.array([1.0, 0.5, 2.0])
+        with pytest.raises(ValueError, match="must be >= 1"):
+            MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=alphas)
+
+    # -------------------------------------------------------------------------
+    # dirichlet_prior_alphas_transition setter tests
+    # -------------------------------------------------------------------------
+    def test_dirichlet_prior_transition_none(self):
+        """Test that None is accepted for dirichlet prior."""
+        model = MockHMM(n_states=3, dirichlet_prior_alphas_transition=None)
+        assert model.dirichlet_prior_alphas_transition is None
+
+    def test_dirichlet_prior_transition_valid(self):
+        """Test valid dirichlet prior alphas for transitions."""
+        alphas = jnp.ones((3, 3))
+        model = MockHMM(n_states=3, dirichlet_prior_alphas_transition=alphas)
+        assert jnp.array_equal(model.dirichlet_prior_alphas_transition, alphas)
+
+    def test_dirichlet_prior_transition_wrong_shape(self):
+        """Test that wrong shape raises ValueError."""
+        alphas = jnp.ones((2, 3))  # n_states=3 but wrong shape
+        with pytest.raises(ValueError, match="must have shape"):
+            MockHMM(n_states=3, dirichlet_prior_alphas_transition=alphas)
+
+    # -------------------------------------------------------------------------
+    # hmm_initialization_funcs setter tests
+    # -------------------------------------------------------------------------
+    def test_initialization_funcs_none_uses_defaults(self):
+        """Test that no setting uses default initialization functions."""
+        model = MockHMM(n_states=2)
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
+
+    def test_initialization_funcs_modified(self):
+        """Test that modified initialization funcs are preserved."""
+
+        def custom_func(n_states, X, y, random_key, extra_arg):
+            return jnp.full((n_states,), 1.0) / n_states
+
+        init_funcs = {
+            "initial_proba_init": custom_func,
+            "initial_proba_init_kwargs": {"extra_arg": "value"},
+        }
+        model = MockHMM(n_states=2, hmm_initialization_funcs=init_funcs)
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS | init_funcs
+
+    def test_initialization_funcs_invalid_key(self):
+        """Test that invalid registry keys raise KeyError."""
+        with pytest.raises(KeyError, match="unknown key"):
+            MockHMM(n_states=2, hmm_initialization_funcs={"invalid_key": lambda: None})
+
+    # -------------------------------------------------------------------------
+    # Default values tests
+    # -------------------------------------------------------------------------
+    def test_default_values(self):
+        """Test that default values are set correctly."""
+        model = MockHMM(n_states=3)
+
+        assert model.n_states == 3
+        assert model.maxiter == 1000
+        assert model.tol == 1e-8
+        assert model.dirichlet_prior_alphas_init_prob is None
+        assert model.dirichlet_prior_alphas_transition is None
+
+    def test_fit_attributes_initialized_to_none(self):
+        """Test that fit attributes are initialized to None."""
+        model = MockHMM(n_states=3)
+
+        assert model.initial_prob_ is None
+        assert model.transition_prob_ is None
+
+
+class TestHMMSetup:
+
+    def test_setup_with_no_input(self):
+        """Test that setup leaves everything as default."""
+        model = MockHMM(n_states=3)
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
+        model.setup()
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
+
+    @pytest.mark.parametrize(
+        "func_name, func, kwargs, expectation",
+        [
+            ("uniform", uniform_initial_proba_init, None, does_not_raise()),
+            ("random", random_initial_proba_init, None, does_not_raise()),
+            (
+                "kmeans",
+                kmeans_initial_proba_init,
+                {"is_new_session": jnp.zeros(10)},
+                does_not_raise(),
+            ),
+            (
+                "random",
+                None,
+                {"extra_arg": "value"},
+                pytest.raises(ValueError, match="Invalid keyword argument"),
+            ),
+            (
+                "invalid",
+                None,
+                None,
+                pytest.raises(ValueError, match="Invalid initialization"),
+            ),
+            (
+                "custom",
+                lambda n_states, X, y, random_key, extra_arg: jnp.full((n_states,), 1.0)
+                / n_states,
+                {"extra_arg": "value"},
+                does_not_raise(),
+            ),
+            (
+                "custom",
+                lambda n_states, X, y, random_key: jnp.full((n_states,), 1.0)
+                / n_states,
+                {"extra_arg": "value"},
+                pytest.raises(ValueError, match="Invalid keyword argument"),
+            ),
+        ],
+    )
+    def test_setup_initial_proba_init(self, func_name, func, kwargs, expectation):
+        """Test setup arguments for initial_proba_init and kwargs."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            if func_name == "custom":
+                model.setup(initial_proba_init=func, initial_proba_init_kwargs=kwargs)
+                assert (
+                    model.hmm_initialization_funcs["initial_proba_init_custom"] is True
+                )
+            else:
+                model.setup(
+                    initial_proba_init=func_name, initial_proba_init_kwargs=kwargs
+                )
+                assert (
+                    model.hmm_initialization_funcs["initial_proba_init_custom"] is False
+                )
+
+            assert model.hmm_initialization_funcs["initial_proba_init"] == func
+
+            if kwargs is None:
+                assert model.hmm_initialization_funcs["initial_proba_init_kwargs"] == {}
+            else:
+                assert (
+                    model.hmm_initialization_funcs["initial_proba_init_kwargs"]
+                    == kwargs
+                )
+
+    @pytest.mark.parametrize(
+        "func_name, func, kwargs, expectation",
+        [
+            ("sticky", sticky_transition_proba_init, None, does_not_raise()),
+            ("uniform", uniform_transition_proba_init, None, does_not_raise()),
+            ("random", random_transition_proba_init, None, does_not_raise()),
+            (
+                "kmeans",
+                kmeans_transition_proba_init,
+                {"is_new_session": jnp.zeros(10)},
+                does_not_raise(),
+            ),
+            (
+                "random",
+                None,
+                {"extra_arg": "value"},
+                pytest.raises(ValueError, match="Invalid keyword argument"),
+            ),
+            (
+                "invalid",
+                None,
+                None,
+                pytest.raises(ValueError, match="Invalid initialization"),
+            ),
+            (
+                "custom",
+                lambda n_states, X, y, random_key, extra_arg: jnp.full(
+                    (n_states, n_states), 1.0
+                )
+                / n_states,
+                {"extra_arg": "value"},
+                does_not_raise(),
+            ),
+            (
+                "custom",
+                lambda n_states, X, y, random_key: jnp.full((n_states, n_states), 1.0)
+                / n_states,
+                {"extra_arg": "value"},
+                pytest.raises(ValueError, match="Invalid keyword argument"),
+            ),
+        ],
+    )
+    def test_setup_transition_proba_init(self, func_name, func, kwargs, expectation):
+        """Test setup arguments for transition_proba_init and kwargs."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            if func_name == "custom":
+                model.setup(
+                    transition_proba_init=func, transition_proba_init_kwargs=kwargs
+                )
+                assert (
+                    model.hmm_initialization_funcs["transition_proba_init_custom"]
+                    is True
+                )
+            else:
+                model.setup(
+                    transition_proba_init=func_name, transition_proba_init_kwargs=kwargs
+                )
+                assert (
+                    model.hmm_initialization_funcs["transition_proba_init_custom"]
+                    is False
+                )
+
+            assert model.hmm_initialization_funcs["transition_proba_init"] == func
+
+            if kwargs is None:
+                assert (
+                    model.hmm_initialization_funcs["transition_proba_init_kwargs"] == {}
+                )
+            else:
+                assert (
+                    model.hmm_initialization_funcs["transition_proba_init_kwargs"]
+                    == kwargs
+                )
+
+    def test_setup_set_all(self):
+        init_funcs = {
+            "initial_proba_init": kmeans_initial_proba_init,
+            "initial_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+            "transition_proba_init": kmeans_transition_proba_init,
+            "transition_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+        }
+
+        model = MockHMM(n_states=3)
+        model.setup(
+            initial_proba_init="kmeans",
+            initial_proba_init_kwargs={"is_new_session": jnp.zeros(10)},
+            transition_proba_init="kmeans",
+            transition_proba_init_kwargs={"is_new_session": jnp.zeros(10)},
+        )
+        expected_funcs = DEFAULT_INIT_FUNCTIONS | init_funcs
+        assert (
+            model.hmm_initialization_funcs[key] == expected_funcs[key]
+            for key in expected_funcs
+        )
+
+    def test_setup_consecutive_calls(self):
+        init_funcs = {
+            "initial_proba_init": kmeans_initial_proba_init,
+            "initial_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+            "transition_proba_init": kmeans_transition_proba_init,
+            "transition_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+        }
+
+        model = MockHMM(n_states=3)
+        model.setup(initial_proba_init="kmeans")
+        # updated
+        assert (
+            model.hmm_initialization_funcs["initial_proba_init"]
+            == init_funcs["initial_proba_init"]
+        )
+        # default
+        assert (
+            model.hmm_initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
+            for key in [
+                "initial_proba_init_kwargs",
+                "transition_proba_init",
+                "transition_proba_init_kwargs",
+            ]
+        )
+
+        model.setup(initial_proba_init_kwargs={"is_new_session": jnp.ones(10)})
+        # updated
+        assert (
+            model.hmm_initialization_funcs[key] == init_funcs[key]
+            for key in [
+                "initial_proba_init",
+                "initial_proba_init_kwargs",
+            ]
+        )
+        # default
+        assert (
+            model.hmm_initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
+            for key in [
+                "transition_proba_init",
+                "transition_proba_init_kwargs",
+            ]
+        )
+
+        model.setup(transition_proba_init="kmeans")
+        # updated
+        assert (
+            model.hmm_initialization_funcs[key] == init_funcs[key]
+            for key in [
+                "initial_proba_init",
+                "initial_proba_init_kwargs",
+                "transition_proba_init",
+            ]
+        )
+        # default
+        assert (
+            model.hmm_initialization_funcs["transition_proba_init_kwargs"]
+            == DEFAULT_INIT_FUNCTIONS["transition_proba_init_kwargs"]
+        )
+
+        model.setup(transition_proba_init_kwargs={"is_new_session": jnp.zeros(10)})
+        # updated
+        assert (
+            model.hmm_initialization_funcs[key] == init_funcs[key]
+            for key in [
+                "initial_proba_init",
+                "initial_proba_init_kwargs",
+                "transition_proba_init",
+                "transition_proba_init_kwargs",
+            ]
+        )
+
+    @pytest.mark.parametrize("key", ["initial_proba_init", "transition_proba_init"])
+    def test_setup_reset_kwargs(self, key):
+        """Test that kwargs are reset if method is set to something else."""
+        model = MockHMM(n_states=3)
+        model.setup(**{key: "kmeans", key + "_kwargs": {"is_new_session": 1.0}})
+        assert model.hmm_initialization_funcs[key + "_kwargs"] == {
+            "is_new_session": 1.0
+        }
+        model.setup(**{key: "random"})
+        assert model.hmm_initialization_funcs[key + "_kwargs"] == {}
+
+
+class TestHMMInitialParams:
+
+    def test__hmm_params_initialization_defaults(self):
+        """Test that _hmm_params_initialization returns expected default parameters and validation flag."""
+        model = MockHMM(n_states=3)
+
+        (initial_prob, transition_prob), validate_params = (
+            model._hmm_params_initialization(None, None, None)
+        )
+
+        assert jnp.allclose(
+            initial_prob, DEFAULT_INIT_FUNCTIONS["initial_proba_init"](3)
+        )
+        assert jnp.allclose(
+            transition_prob, DEFAULT_INIT_FUNCTIONS["transition_proba_init"](3)
+        )
+        assert validate_params is False
+
+    def test__hmm_params_initialization_custom_validation(self):
+        model = MockHMM(n_states=3)
+        model.setup(
+            initial_proba_init=lambda n_states, X, y, random_key: jnp.full(
+                (n_states,), 1.0
+            )
+            / n_states
+        )
+        (initial_prob, _), validate_params = model._hmm_params_initialization(
+            None, None, None
+        )
+        assert jnp.allclose(initial_prob, jnp.full((3,), 1.0) / 3)
+        assert validate_params is True
+
+        model = MockHMM(n_states=3)
+        model.setup(
+            transition_proba_init=lambda n_states, X, y, random_key: jnp.full(
+                (n_states, n_states), 1.0
+            )
+            / n_states
+        )
+        (_, transition_prob), validate_params = model._hmm_params_initialization(
+            None, None, None
+        )
+        assert jnp.allclose(transition_prob, jnp.full((3, 3), 1.0) / 3)
+        assert validate_params is True
+
+    def test__model_specific_initialization_defaults(self):
+        model = MockHMM(n_states=3)
+        model_params = model._model_specific_initialization(None, None, None)
+        assert jnp.allclose(
+            model_params.hmm_params.log_initial_prob,
+            jnp.log(DEFAULT_INIT_FUNCTIONS["initial_proba_init"](3)),
+        )
+        assert jnp.allclose(
+            model_params.hmm_params.log_transition_prob,
+            jnp.log(DEFAULT_INIT_FUNCTIONS["transition_proba_init"](3)),
+        )
+
+
+class TestHMMNewSession:
+
+    @pytest.mark.parametrize(
+        "X, y, is_new_session, expected_new_session",
+        [
+            # No is_new_session provided
+            (np.ones((3, 1)), np.ones((3,)), None, jnp.array([1, 0, 0])),
+            # NaN at start in y
+            (np.ones((3, 1)), np.array([np.nan, 0, 0]), None, jnp.array([0, 1, 0])),
+            # X and y both have NaNs at different positions
+            (
+                np.array([[np.nan], [2], [3], [4]]),
+                np.array([0, np.nan, 3, 4]),
+                None,
+                jnp.array([0, 0, 1, 0]),
+            ),
+            # X and y both have NaNs at same position
+            (
+                np.array([[np.nan], [1], [2], [3]]),
+                np.array([np.nan, 1, 2, 3]),
+                None,
+                jnp.array([0, 1, 0, 0]),
+            ),
+            # NaN at the very end of data
+            (
+                np.ones((4, 1)),
+                np.array([0, 1, 2, np.nan]),
+                None,
+                jnp.array([1, 0, 0, 0]),
+            ),
+            # Multiple NaNs at the start
+            (
+                np.ones((5, 1)),
+                np.array([np.nan, np.nan, 1, 2, 3]),
+                None,
+                jnp.array([0, 0, 1, 0, 0]),
+            ),
+            # Multiple NaNs spaced
+            (
+                np.ones((5, 1)),
+                np.array([np.nan, 1, np.nan, 2, 3]),
+                None,
+                jnp.array([0, 1, 0, 0, 0]),
+            ),
+            # Explicit is_new_session provided by user
+            # boolean array or integer array with 1s and 0s
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([1, 0, 0]),
+                jnp.array([1, 0, 0]),
+            ),
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([True, False, False]),
+                jnp.array([1, 0, 0]),
+            ),
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([0, 1, 0]),
+                jnp.array([1, 1, 0]),
+            ),
+            # new session added at beginning
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([0, 1, 0], dtype=bool),
+                jnp.array([1, 1, 0]),
+            ),
+            (
+                np.ones((3, 1)),
+                np.array([np.nan, 0, 0]),
+                jnp.array([1, 0, 1]),
+                jnp.array([0, 1, 1]),
+            ),
+            # beginning new session dropped
+            (
+                np.array([[np.nan], [2], [3], [4]]),
+                np.array([0, np.nan, 3, 4]),
+                jnp.array([1, 0, 1, 0]),
+                jnp.array([0, 0, 1, 0]),
+            ),
+            # middle new session moved
+            (
+                np.ones((5, 1)),
+                np.array([0, 1, np.nan, np.nan, 3]),
+                jnp.array([1, 0, 1, 0, 0]),
+                jnp.array([1, 0, 0, 0, 1]),
+            ),
+            # integer array with indices of new sessions
+            (
+                np.ones((5, 1)),
+                np.array([0, 1, 2, 3, 4]),
+                jnp.array([0]),
+                jnp.array([1, 0, 0, 0, 0]),
+            ),
+            (
+                np.ones((5, 1)),
+                np.array([0, 1, 2, 3, 4]),
+                jnp.array([0, 1]),
+                jnp.array([1, 1, 0, 0, 0]),
+            ),
+            (
+                np.ones((5, 1)),
+                np.array([0, 1, 2, 3, 4]),
+                jnp.array([2, 4]),
+                jnp.array([1, 0, 1, 0, 1]),
+            ),
+            # nan moving is independent of input type so I won't add more cases
+        ],
+    )
+    def test_initialize_new_session(self, X, y, is_new_session, expected_new_session):
+        """Test that session boundaries are correctly initialized and moved when there are NaN values."""
+        model = MockHMM(n_states=3)
+        is_new_session = model._validator.validate_and_cast_is_new_session(
+            X, y, is_new_session
+        )
+        assert jnp.all(is_new_session == expected_new_session)
+
+    @pytest.mark.parametrize(
+        "X, y, is_new_session, expected_new_session",
+        [
+            # no is_new_session provided
+            # inferred time support should only find one new session at start
+            (
+                nap.TsdFrame(
+                    t=np.arange(3),
+                    d=np.zeros((3, 3)),
+                ),
+                nap.Tsd(
+                    t=np.arange(3),
+                    d=np.zeros((3,)),
+                ),
+                None,
+                jnp.array([1, 0, 0]),
+            ),
+            # inferred time support finds 2 new sessions
+            (
+                nap.TsdFrame(
+                    t=np.arange(3),
+                    d=np.zeros((3, 3)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 2.0]),
+                ),
+                nap.Tsd(
+                    t=np.arange(3),
+                    d=np.zeros((3,)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 2.0]),
+                ),
+                None,
+                jnp.array([1, 0, 1]),
+            ),
+            # two new sessions where second is moved from nans
+            (
+                nap.TsdFrame(
+                    t=np.arange(5),
+                    d=np.zeros((5, 3)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 5.0]),
+                ),
+                nap.Tsd(
+                    t=np.arange(5),
+                    d=np.array([0, 0, np.nan, np.nan, 0]),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 5.0]),
+                ),
+                None,
+                jnp.array([1, 0, 0, 0, 1]),
+            ),
+            # time support prioritized from y
+            (
+                nap.TsdFrame(
+                    t=np.arange(6),
+                    d=np.zeros((6, 3)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 5.0]),
+                ),
+                nap.Tsd(
+                    t=np.arange(6),
+                    d=np.array([0, 0, np.nan, np.nan, 0, 0]),
+                ),
+                None,
+                jnp.array([1, 0, 0, 0, 0, 0]),
+            ),
+            # time support taken from x
+            (
+                nap.TsdFrame(
+                    t=np.arange(6),
+                    d=np.zeros((6, 3)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 5.0]),
+                ),
+                np.array([0, 0, np.nan, np.nan, 0, 0]),
+                None,
+                jnp.array([1, 0, 0, 0, 1, 0]),
+            ),
+            # x not required for pynnaple support
+            (
+                np.array([[np.nan], [0], [np.nan], [0], [0]]),
+                nap.Tsd(
+                    t=np.arange(5),
+                    d=np.zeros(5),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 5.0]),
+                ),
+                None,
+                jnp.array([0, 1, 0, 1, 0]),
+            ),
+            # Entire epoch is NaN (with pynapple)
+            (
+                nap.TsdFrame(
+                    t=np.arange(6),
+                    d=np.zeros((6, 1)),
+                    time_support=nap.IntervalSet([0, 2, 4], [1, 3, 5]),
+                ),
+                nap.Tsd(
+                    t=np.arange(6),
+                    d=np.array([0, 0, np.nan, np.nan, 3, 4]),
+                    time_support=nap.IntervalSet([0, 2, 4], [1, 3, 5]),
+                ),
+                None,
+                jnp.array([1, 0, 0, 0, 1, 0]),
+            ),
+            # intervalset passed as is_new_session
+            (
+                nap.TsdFrame(
+                    t=np.arange(3),
+                    d=np.zeros((3, 3)),
+                ),
+                nap.Tsd(
+                    t=np.arange(3),
+                    d=np.zeros((3,)),
+                ),
+                nap.IntervalSet([0, 3]),
+                jnp.array([1, 0, 0]),
+            ),
+            # forces first time point to be new session
+            (
+                nap.TsdFrame(
+                    t=np.arange(3),
+                    d=np.zeros((3, 3)),
+                ),
+                nap.Tsd(
+                    t=np.arange(3),
+                    d=np.zeros((3,)),
+                ),
+                nap.IntervalSet([2, 3]),
+                jnp.array([1, 0, 1]),
+            ),
+            # time support finds 2 new sessions
+            (
+                nap.TsdFrame(
+                    t=np.arange(3),
+                    d=np.zeros((3, 3)),
+                ),
+                nap.Tsd(
+                    t=np.arange(3),
+                    d=np.zeros((3,)),
+                ),
+                nap.IntervalSet([0, 1.5], [1.0, 2.0]),
+                jnp.array([1, 0, 1]),
+            ),
+            # ignore time support when intervalset is provided
+            (
+                nap.TsdFrame(
+                    t=np.arange(3),
+                    d=np.zeros((3, 3)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 2.0]),
+                ),
+                nap.Tsd(
+                    t=np.arange(3),
+                    d=np.zeros((3,)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 2.0]),
+                ),
+                nap.IntervalSet([0, 3]),
+                jnp.array([1, 0, 0]),
+            ),
+            # ignore time support when intervalset is provided
+            (
+                nap.TsdFrame(
+                    t=np.arange(3),
+                    d=np.zeros((3, 3)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 2.0]),
+                ),
+                nap.Tsd(
+                    t=np.arange(3),
+                    d=np.zeros((3,)),
+                    time_support=nap.IntervalSet([0, 1.5], [1.0, 2.0]),
+                ),
+                jnp.array([1]),
+                jnp.array([1, 1, 0]),
+            ),
+        ],
+    )
+    def test_compute_is_new_session_from_pynapple(
+        self, X, y, is_new_session, expected_new_session
+    ):
+        """Test that is_new_session is correctly computed from pynapple time support and interval sets"""
+        model = MockHMM(n_states=3)
+        is_new_session = model._validator.validate_and_cast_is_new_session(
+            X, y, is_new_session
+        )
+        assert jnp.all(is_new_session == expected_new_session)
+
+    @pytest.mark.parametrize(
+        "X, y, is_new_session, expectation",
+        [
+            # wrong shape for boolean array
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([True, False, False, False]),
+                pytest.raises(ValueError, match="is_new_session must have shape"),
+            ),
+            # wrong length for integer array
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([1, 0, 0, 0]),
+                pytest.raises(
+                    ValueError, match="is_new_session array must have length"
+                ),
+            ),
+            # integer out of bounds
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([0, 3]),
+                pytest.raises(ValueError, match="is_new_session values must be"),
+            ),
+            # negative integer
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([-1]),
+                pytest.raises(ValueError, match="is_new_session values must be"),
+            ),
+            # wrong dtype
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                jnp.array([0.0, 3.0]),
+                pytest.raises(
+                    TypeError,
+                    match="is_new_session must be a boolean or integer array",
+                ),
+            ),
+            # wrong dtype
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                "is_new_session",
+                pytest.raises(
+                    TypeError,
+                    match="is_new_session must be a boolean or integer array",
+                ),
+            ),
+            # interval set when no pynapple objects are used
+            (
+                np.ones((3, 1)),
+                np.ones((3,)),
+                nap.IntervalSet([0, 3]),
+                pytest.raises(
+                    TypeError,
+                    match="X or y must be a pynapple",
+                ),
+            ),
+        ],
+    )
+    def test_initialize_and_compute_new_session_errors(
+        self, X, y, is_new_session, expectation
+    ):
+        """Test that session boundaries are correctly initialized and moved when there are NaN values."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            is_new_session = model._validator.validate_and_cast_is_new_session(
+                X, y, is_new_session
+            )

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -22,6 +22,7 @@ from nemos.hmm.initialize_parameters import (
     uniform_transition_proba_init,
 )
 from nemos.hmm.params import HMMParams
+from nemos.hmm.utils import initialize_is_new_session
 from nemos.hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
 from nemos.params import ModelParams
 
@@ -63,13 +64,15 @@ class MockHMMValidator(HMMValidator[MockHMMUserParams, MockHMMParams]):
     to_model_params: Callable[[MockHMMUserParams], MockHMMParams] = to_mock_params
     from_model_params: Callable[[MockHMMParams], MockHMMUserParams] = from_mock_params
     model_class: str = "MockHMM"
+    X_dimensionality: int = 2
+    y_dimensionality: int = 1
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
         *RegressorValidator.params_validation_sequence[:2],
         *HMMValidator.params_validation_sequence,
         *RegressorValidator.params_validation_sequence[3:],
     )
 
-    def validate_consistency(self, params: MockHMMParams) -> None:
+    def validate_consistency(self, *args, **kwargs) -> None:
         return True
 
 
@@ -122,15 +125,16 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
         )
 
     def _check_model_is_fit(self):
-        BaseHMM._check_is_fit(self)
         if self.param_ is None:
             raise ValueError("Model is not fitted yet.")
 
     def _get_model_params(self) -> MockHMMParams:
         return self._validator.to_model_params(
-            self.param_,
-            self.log_initial_prob_,
-            self.log_transition_prob_,
+            (
+                self.param_,
+                self.initial_prob_,
+                self.transition_prob_,
+            )
         )
 
     def _set_model_params(self, params):
@@ -139,17 +143,19 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
         self.initial_prob_ = initial_prob
         self.transition_prob_ = transition_prob
 
-    def _log_likelihood(self, params, X, y):
-        pass
+    def _log_likelihood(self, X, y, params):
+        return jnp.zeros((y.shape[0], self.n_states))
 
     def _model_params_initialization(self, X, y, is_new_session):
         return (
-            jnp.zeros(self._n_states),
+            jnp.arange(self._n_states),
             False,
         )
 
     def fit(self, X, y, is_new_session=None, init_params=None):
-        pass
+        is_new_session = initialize_is_new_session(X, y, is_new_session)
+        fit_params = self._model_specific_initialization(X, y, is_new_session)
+        self._set_model_params(fit_params)
 
     def _initialize_optimizer_and_state(self, *args, **kwargs):
         pass
@@ -1085,3 +1091,408 @@ class TestHMMNewSession:
             is_new_session = model._validator.validate_and_cast_is_new_session(
                 X, y, is_new_session
             )
+
+
+class TestHMMInference:
+    """Test suite for inference methods (smooth_proba, filter_proba, decode_state)."""
+
+    @staticmethod
+    def _get_expected_shape(method_name, kwargs, n_samples, n_states):
+        """Helper to compute expected output shape based on method and kwargs."""
+        if method_name in ["smooth_proba", "filter_proba"]:
+            return (n_samples, n_states)
+        elif method_name == "decode_state":
+            if kwargs.get("state_format") == "index":
+                return (n_samples,)
+            else:  # one-hot (default)
+                return (n_samples, n_states)
+        else:
+            raise ValueError(f"Unknown method: {method_name}")
+
+    @pytest.mark.parametrize(
+        "drop_attr",
+        ["initial_prob_", "transition_prob_"],
+    )
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_not_fitted_raises_error(self, drop_attr, method_config):
+        """Test that inference methods raise an error when model is not fitted."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        model.fit(np.random.rand(10, 2), np.random.rand(10))
+        setattr(model, drop_attr, None)
+        with pytest.raises(
+            ValueError,
+            match=rf"This MockHMM instance is not fitted yet. .+ \['{drop_attr}'\]",
+        ):
+            getattr(model, method_name)(None, None, **kwargs)
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_returns_correct_shape(self, method_config):
+        """Test that inference methods return arrays with correct shapes."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+
+        # Get output
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+        out = getattr(model, method_name)(X, y, **kwargs)
+
+        # Check shape
+        n_samples = (~np.isnan(np.sum(y, axis=tuple(range(1, y.ndim))))).sum()
+        n_states = model.n_states
+        expected_shape = self._get_expected_shape(
+            method_name, kwargs, n_samples, n_states
+        )
+        assert (
+            out.shape == expected_shape
+        ), f"Expected shape {expected_shape}, got {out.shape}"
+
+    @pytest.mark.parametrize("method_name", ["smooth_proba", "filter_proba"])
+    def test_posterior_proba_returns_valid_probabilities(self, method_name):
+        """Test that smooth_proba returns valid probabilities (between 0 and 1, summing to 1)."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Get posteriors
+        posteriors = getattr(model, method_name)(X, y)
+
+        # Check all values are between 0 and 1
+        assert jnp.all(posteriors >= 0), "Some posteriors are negative"
+        assert jnp.all(posteriors <= 1), "Some posteriors are greater than 1"
+
+        # Check sum across states
+        row_sums = jnp.sum(posteriors, axis=1)
+        assert jnp.allclose(
+            row_sums, 1.0, rtol=1e-5
+        ), f"Probabilities don't sum to 1. Min: {row_sums.min()}, Max: {row_sums.max()}"
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_with_arrays(self, method_config):
+        """Test inference methods with numpy/jax arrays return jax array."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Test with numpy array
+        out = getattr(model, method_name)(X, y, **kwargs)
+        assert isinstance(out, jnp.ndarray), f"Expected jnp.ndarray, got {type(out)}"
+
+    @pytest.mark.parametrize("input_type", ["X", "y", "both"])
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_with_pynapple_returns_tsdframe(self, input_type, method_config):
+        """Test that inference methods return TsdFrame/Tsd when input is pynapple."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Convert to pynapple
+        n_samples = X.shape[0]
+        time = np.linspace(0, n_samples / 100, n_samples)
+
+        if input_type in ["X", "both"]:
+            X = nap.TsdFrame(t=time, d=X)
+        if input_type in ["y", "both"]:
+            y = nap.Tsd(t=time, d=y)
+
+        # Get output
+        out = getattr(model, method_name)(X, y, **kwargs)
+
+        # Check return type - decode_state with index format returns Tsd, others return TsdFrame
+        if method_name == "decode_state" and kwargs.get("state_format") == "index":
+            assert isinstance(out, nap.Tsd), f"Expected nap.Tsd, got {type(out)}"
+            assert out.shape == (n_samples,)
+        else:
+            assert isinstance(
+                out, nap.TsdFrame
+            ), f"Expected nap.TsdFrame, got {type(out)}"
+            assert out.shape == (n_samples, model.n_states)
+        assert jnp.allclose(out.t, time)
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_with_multiple_sessions(self, method_config):
+        """Test inference methods with multiple sessions (pynapple epochs)."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Create multi-session data
+        n_samples = X.shape[0]
+        session_1_end = n_samples // 2
+
+        time = np.linspace(0, n_samples / 100, n_samples)
+        epochs = nap.IntervalSet(
+            start=[time[0], time[session_1_end]],
+            end=[time[session_1_end - 1], time[-1]],
+        )
+
+        X_tsd = nap.TsdFrame(t=time, d=X, time_support=epochs)
+        y_tsd = nap.Tsd(t=time, d=y, time_support=epochs)
+
+        # Get output
+        out = getattr(model, method_name)(X_tsd, y_tsd, **kwargs)
+
+        # Check shape and type
+        if method_name == "decode_state" and kwargs.get("state_format") == "index":
+            assert isinstance(out, nap.Tsd)
+            assert out.shape == (n_samples,)
+        else:
+            assert isinstance(out, nap.TsdFrame)
+            assert out.shape == (n_samples, model.n_states)
+
+        # Check probabilities are valid for proba methods
+        if method_name in ["smooth_proba", "filter_proba"]:
+            assert jnp.all(out.values >= 0)
+            assert jnp.all(out.values <= 1)
+            row_sums = jnp.sum(out.values, axis=1)
+            assert jnp.allclose(row_sums, 1.0, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_consistency_across_calls(self, method_config):
+        """Test that inference methods return consistent results across multiple calls."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Get output twice
+        out_1 = getattr(model, method_name)(X, y, **kwargs)
+        out_2 = getattr(model, method_name)(X, y, **kwargs)
+
+        # Check consistency
+        assert jnp.allclose(
+            out_1, out_2
+        ), f"{method_name} returns different results on consecutive calls"
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_single_sample(self, method_name):
+        """Test smooth_proba with a single sample."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(1, 2)
+        y = np.random.rand(1)
+        model.fit(X, y)
+
+        # Get posteriors for single sample
+        out = getattr(model, method_name)(X, y)
+
+        # Check shape
+        assert out.shape == (1, model.n_states)
+
+        if method_name != "decode_state":
+            # Check probabilities are valid
+            assert jnp.all(out >= 0)
+            assert jnp.all(out <= 1)
+            assert jnp.allclose(jnp.sum(out), 1.0, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_with_nans_filtered(self, method_name):
+        """Test that smooth_proba handles NaNs properly by filtering them."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Create data with NaNs
+        X_with_nan = X.copy()
+        y_with_nan = y.copy()
+
+        # Add NaNs at specific indices
+        nan_indices = [0, 1, 2]
+        X_with_nan[nan_indices] = np.nan
+
+        # This should work - NaNs get filtered internally
+        posteriors = getattr(model, method_name)(X_with_nan, y_with_nan)
+
+        # Check that we get valid output (NaN rows filtered)
+        assert posteriors.shape[1] == model.n_states
+        # After filtering NaNs, shape[0] should be reduced
+        assert posteriors.shape[0] == X.shape[0]
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    @pytest.mark.parametrize("nan_location", [[], [0, 1, 10, 11, 12]])
+    def test_pynapple_in_pynapple_out_X(self, method_name, nan_location):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        X[nan_location] = np.nan
+        ep = nap.IntervalSet([0, 10], [9, 500])
+        X = nap.TsdFrame(t=np.arange(X.shape[0]), d=X, time_support=ep)
+        out = getattr(model, method_name)(X, y)
+        assert isinstance(out, nap.TsdFrame), "Did not return pynapple!"
+        assert np.all(
+            np.isnan(out[nan_location])
+        ), "Not returning NaNs in the expected location!"
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    @pytest.mark.parametrize("nan_location", [[], [0, 1, 10, 11, 12]])
+    def test_pynapple_in_pynapple_out_y(self, method_name, nan_location):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        y[nan_location] = np.nan
+        ep = nap.IntervalSet([0, 10], [9, 500])
+        y = nap.Tsd(t=np.arange(y.shape[0]), d=y, time_support=ep)
+        posteriors = getattr(model, method_name)(X, y)
+        assert isinstance(posteriors, nap.TsdFrame), "Did not return pynapple!"
+        assert np.all(
+            np.isnan(posteriors[nan_location])
+        ), "Not returning NaNs in the expected location!"
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_int_vs_float_y(self, method_name):
+        """Test that integer and float y with same values give same posteriors.
+
+        This is a regression test for a bug where y.dtype was used to cast params
+        before preprocessing, causing integer y to round float params to integers.
+        """
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        y = np.round(y)
+        y_float = y.astype(float)
+        y_int = y.astype(int)
+
+        # Get posteriors with float y
+        out_float = getattr(model, method_name)(X, y_float)
+
+        # Get posteriors with int y (same values)
+        out_int = getattr(model, method_name)(X, y_int)
+
+        # Posteriors should be identical regardless of y dtype
+        np.testing.assert_allclose(
+            out_float,
+            out_int,
+            rtol=1e-10,
+            err_msg=f"{method_name} gives different results for int vs float y with same values",
+        )
+
+    def test_onehot_vs_index_decode(self):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        out_onehot = model.decode_state(X, y, state_format="one-hot")
+        out_index = model.decode_state(X, y, state_format="index")
+        assert jnp.all(
+            jnp.where(out_onehot == 1)[1] == out_index
+        ), "index and one-hot do not match!"
+        assert jnp.all(
+            out_onehot.sum(axis=1) == 1
+        ), "more than one hot value in one-hot array!"
+
+    def test_decode_state_invalid_state_format(self):
+        """Test that decode_state raises ValueError for invalid state_format."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        with pytest.raises(ValueError, match="Invalid state_format"):
+            model.decode_state(X, y, state_format="invalid")
+
+    @pytest.mark.parametrize("n_states", [2, 3, 5])
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_different_n_states(self, n_states, method_name):
+        """Test smooth_proba with different numbers of states."""
+        model = MockHMM(n_states=n_states)
+        n_samples, n_features = 100, 2
+        X = np.random.rand(n_samples, n_features)
+        y = np.random.rand(n_samples)
+        model.fit(X, y)
+
+        out = getattr(model, method_name)(X, y)
+
+        # Check shape
+        assert out.shape == (
+            n_samples,
+            n_states,
+        ), f"Expected shape ({n_samples}, {n_states}), got {out.shape}"
+
+        # Check probabilities are valid
+        assert jnp.all(out >= 0)
+        assert jnp.all(out <= 1)
+        row_sums = jnp.sum(out, axis=1)
+        assert jnp.allclose(row_sums, 1.0)

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -89,7 +89,7 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
         maxiter: int = 1000,
         tol: float = 1e-8,
         seed=jax.random.PRNGKey(123),
-        hmm_initialization_funcs: INITIALIZATION_FN_DICT = None,
+        initialization_funcs: INITIALIZATION_FN_DICT = None,
         model_initialization_funcs: INITIALIZATION_FN_DICT = None,
     ):
         BaseHMM.__init__(
@@ -100,7 +100,7 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
             maxiter=maxiter,
             tol=tol,
             seed=seed,
-            hmm_initialization_funcs=hmm_initialization_funcs,
+            initialization_funcs=initialization_funcs,
         )
         self.param_: jnp.ndarray | None = None
         self.model_initialization_funcs = {}
@@ -374,13 +374,13 @@ class TestHMMInit:
             "initial_proba_init": custom_func,
             "initial_proba_init_kwargs": {"extra_arg": "value"},
         }
-        model = MockHMM(n_states=2, hmm_initialization_funcs=init_funcs)
+        model = MockHMM(n_states=2, initialization_funcs=init_funcs)
         assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS | init_funcs
 
     def test_initialization_funcs_invalid_key(self):
         """Test that invalid registry keys raise KeyError."""
         with pytest.raises(KeyError, match="unknown key"):
-            MockHMM(n_states=2, hmm_initialization_funcs={"invalid_key": lambda: None})
+            MockHMM(n_states=2, initialization_funcs={"invalid_key": lambda: None})
 
     # -------------------------------------------------------------------------
     # Default values tests
@@ -767,7 +767,7 @@ class TestHMMInitialParams:
         model = MockHMM(n_states=3)
         model.setup(**{key: value})
         with expectation:
-            model_params = model._model_specific_initialization(None, None, None)
+            model._model_specific_initialization(None, None, None)
 
 
 class TestHMMNewSession:

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -437,14 +437,18 @@ class TestHMMSetup:
             ),
             (
                 "custom",
-                lambda n_states, X, y, is_new_session, random_key, extra_arg: jnp.full((n_states,), 1.0)
+                lambda n_states, X, y, is_new_session, random_key, extra_arg: jnp.full(
+                    (n_states,), 1.0
+                )
                 / n_states,
                 {"extra_arg": "value"},
                 does_not_raise(),
             ),
             (
                 "custom",
-                lambda n_states, X, y, is_new_session, random_key: jnp.full((n_states,), 1.0)
+                lambda n_states, X, y, is_new_session, random_key: jnp.full(
+                    (n_states,), 1.0
+                )
                 / n_states,
                 {"extra_arg": "value"},
                 pytest.raises(ValueError, match="Invalid keyword argument"),
@@ -457,26 +461,19 @@ class TestHMMSetup:
         with expectation:
             if func_name == "custom":
                 model.setup(initial_proba_init=func, initial_proba_init_kwargs=kwargs)
-                assert (
-                    model.initialization_funcs["initial_proba_init_custom"] is True
-                )
+                assert model.initialization_funcs["initial_proba_init_custom"] is True
             else:
                 model.setup(
                     initial_proba_init=func_name, initial_proba_init_kwargs=kwargs
                 )
-                assert (
-                    model.initialization_funcs["initial_proba_init_custom"] is False
-                )
+                assert model.initialization_funcs["initial_proba_init_custom"] is False
 
             assert model.initialization_funcs["initial_proba_init"] == func
 
             if kwargs is None:
                 assert model.initialization_funcs["initial_proba_init_kwargs"] == {}
             else:
-                assert (
-                    model.initialization_funcs["initial_proba_init_kwargs"]
-                    == kwargs
-                )
+                assert model.initialization_funcs["initial_proba_init_kwargs"] == kwargs
 
     @pytest.mark.parametrize(
         "func_name, func, kwargs, expectation",
@@ -513,7 +510,9 @@ class TestHMMSetup:
             ),
             (
                 "custom",
-                lambda n_states, X, y, is_new_session, random_key: jnp.full((n_states, n_states), 1.0)
+                lambda n_states, X, y, is_new_session, random_key: jnp.full(
+                    (n_states, n_states), 1.0
+                )
                 / n_states,
                 {"extra_arg": "value"},
                 pytest.raises(ValueError, match="Invalid keyword argument"),
@@ -529,28 +528,23 @@ class TestHMMSetup:
                     transition_proba_init=func, transition_proba_init_kwargs=kwargs
                 )
                 assert (
-                    model.initialization_funcs["transition_proba_init_custom"]
-                    is True
+                    model.initialization_funcs["transition_proba_init_custom"] is True
                 )
             else:
                 model.setup(
                     transition_proba_init=func_name, transition_proba_init_kwargs=kwargs
                 )
                 assert (
-                    model.initialization_funcs["transition_proba_init_custom"]
-                    is False
+                    model.initialization_funcs["transition_proba_init_custom"] is False
                 )
 
             assert model.initialization_funcs["transition_proba_init"] == func
 
             if kwargs is None:
-                assert (
-                    model.initialization_funcs["transition_proba_init_kwargs"] == {}
-                )
+                assert model.initialization_funcs["transition_proba_init_kwargs"] == {}
             else:
                 assert (
-                    model.initialization_funcs["transition_proba_init_kwargs"]
-                    == kwargs
+                    model.initialization_funcs["transition_proba_init_kwargs"] == kwargs
                 )
 
     def test_setup_set_all(self):
@@ -650,9 +644,7 @@ class TestHMMSetup:
         """Test that kwargs are reset if method is set to something else."""
         model = MockHMM(n_states=3)
         model.setup(**{key: "kmeans", key + "_kwargs": {"minimum_prob": 0.01}})
-        assert model.initialization_funcs[key + "_kwargs"] == {
-            "minimum_prob": 0.01
-        }
+        assert model.initialization_funcs[key + "_kwargs"] == {"minimum_prob": 0.01}
         model.setup(**{key: "random"})
         assert model.initialization_funcs[key + "_kwargs"] == {}
 

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -76,7 +76,7 @@ class MockHMMValidator(HMMValidator[MockHMMUserParams, MockHMMParams]):
         return True
 
 
-class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
+class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams, INITIALIZATION_FN_DICT]):
     _validator_class = MockHMMValidator
 
     def __init__(
@@ -357,12 +357,12 @@ class TestHMMInit:
             MockHMM(n_states=3, dirichlet_transition_proba=alphas)
 
     # -------------------------------------------------------------------------
-    # hmm_initialization_funcs setter tests
+    # initialization_funcs setter tests
     # -------------------------------------------------------------------------
     def test_initialization_funcs_none_uses_defaults(self):
         """Test that no setting uses default initialization functions."""
         model = MockHMM(n_states=2)
-        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
+        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS
 
     def test_initialization_funcs_modified(self):
         """Test that modified initialization funcs are preserved."""
@@ -375,7 +375,7 @@ class TestHMMInit:
             "initial_proba_init_kwargs": {"extra_arg": "value"},
         }
         model = MockHMM(n_states=2, initialization_funcs=init_funcs)
-        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS | init_funcs
+        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS | init_funcs
 
     def test_initialization_funcs_invalid_key(self):
         """Test that invalid registry keys raise KeyError."""
@@ -408,9 +408,9 @@ class TestHMMSetup:
     def test_setup_with_no_input(self):
         """Test that setup leaves everything as default."""
         model = MockHMM(n_states=3)
-        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
+        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS
         model.setup()
-        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
+        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS
 
     @pytest.mark.parametrize(
         "func_name, func, kwargs, expectation",
@@ -420,7 +420,7 @@ class TestHMMSetup:
             (
                 "kmeans",
                 kmeans_initial_proba_init,
-                {"is_new_session": jnp.zeros(10)},
+                None,
                 does_not_raise(),
             ),
             (
@@ -437,14 +437,14 @@ class TestHMMSetup:
             ),
             (
                 "custom",
-                lambda n_states, X, y, random_key, extra_arg: jnp.full((n_states,), 1.0)
+                lambda n_states, X, y, is_new_session, random_key, extra_arg: jnp.full((n_states,), 1.0)
                 / n_states,
                 {"extra_arg": "value"},
                 does_not_raise(),
             ),
             (
                 "custom",
-                lambda n_states, X, y, random_key: jnp.full((n_states,), 1.0)
+                lambda n_states, X, y, is_new_session, random_key: jnp.full((n_states,), 1.0)
                 / n_states,
                 {"extra_arg": "value"},
                 pytest.raises(ValueError, match="Invalid keyword argument"),
@@ -458,23 +458,23 @@ class TestHMMSetup:
             if func_name == "custom":
                 model.setup(initial_proba_init=func, initial_proba_init_kwargs=kwargs)
                 assert (
-                    model.hmm_initialization_funcs["initial_proba_init_custom"] is True
+                    model.initialization_funcs["initial_proba_init_custom"] is True
                 )
             else:
                 model.setup(
                     initial_proba_init=func_name, initial_proba_init_kwargs=kwargs
                 )
                 assert (
-                    model.hmm_initialization_funcs["initial_proba_init_custom"] is False
+                    model.initialization_funcs["initial_proba_init_custom"] is False
                 )
 
-            assert model.hmm_initialization_funcs["initial_proba_init"] == func
+            assert model.initialization_funcs["initial_proba_init"] == func
 
             if kwargs is None:
-                assert model.hmm_initialization_funcs["initial_proba_init_kwargs"] == {}
+                assert model.initialization_funcs["initial_proba_init_kwargs"] == {}
             else:
                 assert (
-                    model.hmm_initialization_funcs["initial_proba_init_kwargs"]
+                    model.initialization_funcs["initial_proba_init_kwargs"]
                     == kwargs
                 )
 
@@ -487,7 +487,7 @@ class TestHMMSetup:
             (
                 "kmeans",
                 kmeans_transition_proba_init,
-                {"is_new_session": jnp.zeros(10)},
+                None,
                 does_not_raise(),
             ),
             (
@@ -504,7 +504,7 @@ class TestHMMSetup:
             ),
             (
                 "custom",
-                lambda n_states, X, y, random_key, extra_arg: jnp.full(
+                lambda n_states, X, y, is_new_session, random_key, extra_arg: jnp.full(
                     (n_states, n_states), 1.0
                 )
                 / n_states,
@@ -513,7 +513,7 @@ class TestHMMSetup:
             ),
             (
                 "custom",
-                lambda n_states, X, y, random_key: jnp.full((n_states, n_states), 1.0)
+                lambda n_states, X, y, is_new_session, random_key: jnp.full((n_states, n_states), 1.0)
                 / n_states,
                 {"extra_arg": "value"},
                 pytest.raises(ValueError, match="Invalid keyword argument"),
@@ -529,7 +529,7 @@ class TestHMMSetup:
                     transition_proba_init=func, transition_proba_init_kwargs=kwargs
                 )
                 assert (
-                    model.hmm_initialization_funcs["transition_proba_init_custom"]
+                    model.initialization_funcs["transition_proba_init_custom"]
                     is True
                 )
             else:
@@ -537,61 +537,61 @@ class TestHMMSetup:
                     transition_proba_init=func_name, transition_proba_init_kwargs=kwargs
                 )
                 assert (
-                    model.hmm_initialization_funcs["transition_proba_init_custom"]
+                    model.initialization_funcs["transition_proba_init_custom"]
                     is False
                 )
 
-            assert model.hmm_initialization_funcs["transition_proba_init"] == func
+            assert model.initialization_funcs["transition_proba_init"] == func
 
             if kwargs is None:
                 assert (
-                    model.hmm_initialization_funcs["transition_proba_init_kwargs"] == {}
+                    model.initialization_funcs["transition_proba_init_kwargs"] == {}
                 )
             else:
                 assert (
-                    model.hmm_initialization_funcs["transition_proba_init_kwargs"]
+                    model.initialization_funcs["transition_proba_init_kwargs"]
                     == kwargs
                 )
 
     def test_setup_set_all(self):
         init_funcs = {
             "initial_proba_init": kmeans_initial_proba_init,
-            "initial_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+            "initial_proba_init_kwargs": {"minimum_prob": 0.01},
             "transition_proba_init": kmeans_transition_proba_init,
-            "transition_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+            "transition_proba_init_kwargs": {"minimum_prob": 0.01},
         }
 
         model = MockHMM(n_states=3)
         model.setup(
             initial_proba_init="kmeans",
-            initial_proba_init_kwargs={"is_new_session": jnp.zeros(10)},
+            initial_proba_init_kwargs={"minimum_prob": 0.01},
             transition_proba_init="kmeans",
-            transition_proba_init_kwargs={"is_new_session": jnp.zeros(10)},
+            transition_proba_init_kwargs={"minimum_prob": 0.01},
         )
         expected_funcs = DEFAULT_INIT_FUNCTIONS | init_funcs
         assert (
-            model.hmm_initialization_funcs[key] == expected_funcs[key]
+            model.initialization_funcs[key] == expected_funcs[key]
             for key in expected_funcs
         )
 
     def test_setup_consecutive_calls(self):
         init_funcs = {
             "initial_proba_init": kmeans_initial_proba_init,
-            "initial_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+            "initial_proba_init_kwargs": {"minimum_prob": 0.01},
             "transition_proba_init": kmeans_transition_proba_init,
-            "transition_proba_init_kwargs": {"is_new_session": jnp.zeros(10)},
+            "transition_proba_init_kwargs": {"minimum_prob": 0.01},
         }
 
         model = MockHMM(n_states=3)
         model.setup(initial_proba_init="kmeans")
         # updated
         assert (
-            model.hmm_initialization_funcs["initial_proba_init"]
+            model.initialization_funcs["initial_proba_init"]
             == init_funcs["initial_proba_init"]
         )
         # default
         assert (
-            model.hmm_initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
+            model.initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
             for key in [
                 "initial_proba_init_kwargs",
                 "transition_proba_init",
@@ -599,10 +599,10 @@ class TestHMMSetup:
             ]
         )
 
-        model.setup(initial_proba_init_kwargs={"is_new_session": jnp.ones(10)})
+        model.setup(initial_proba_init_kwargs={"minimum_prob": 0.01})
         # updated
         assert (
-            model.hmm_initialization_funcs[key] == init_funcs[key]
+            model.initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
                 "initial_proba_init_kwargs",
@@ -610,7 +610,7 @@ class TestHMMSetup:
         )
         # default
         assert (
-            model.hmm_initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
+            model.initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
             for key in [
                 "transition_proba_init",
                 "transition_proba_init_kwargs",
@@ -620,7 +620,7 @@ class TestHMMSetup:
         model.setup(transition_proba_init="kmeans")
         # updated
         assert (
-            model.hmm_initialization_funcs[key] == init_funcs[key]
+            model.initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
                 "initial_proba_init_kwargs",
@@ -629,14 +629,14 @@ class TestHMMSetup:
         )
         # default
         assert (
-            model.hmm_initialization_funcs["transition_proba_init_kwargs"]
+            model.initialization_funcs["transition_proba_init_kwargs"]
             == DEFAULT_INIT_FUNCTIONS["transition_proba_init_kwargs"]
         )
 
-        model.setup(transition_proba_init_kwargs={"is_new_session": jnp.zeros(10)})
+        model.setup(transition_proba_init_kwargs={"minimum_prob": 0.01})
         # updated
         assert (
-            model.hmm_initialization_funcs[key] == init_funcs[key]
+            model.initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
                 "initial_proba_init_kwargs",
@@ -649,12 +649,12 @@ class TestHMMSetup:
     def test_setup_reset_kwargs(self, key):
         """Test that kwargs are reset if method is set to something else."""
         model = MockHMM(n_states=3)
-        model.setup(**{key: "kmeans", key + "_kwargs": {"is_new_session": 1.0}})
-        assert model.hmm_initialization_funcs[key + "_kwargs"] == {
-            "is_new_session": 1.0
+        model.setup(**{key: "kmeans", key + "_kwargs": {"minimum_prob": 0.01}})
+        assert model.initialization_funcs[key + "_kwargs"] == {
+            "minimum_prob": 0.01
         }
         model.setup(**{key: "random"})
-        assert model.hmm_initialization_funcs[key + "_kwargs"] == {}
+        assert model.initialization_funcs[key + "_kwargs"] == {}
 
 
 class TestHMMInitialParams:
@@ -678,7 +678,7 @@ class TestHMMInitialParams:
     def test__hmm_params_initialization_custom_validation(self):
         model = MockHMM(n_states=3)
         model.setup(
-            initial_proba_init=lambda n_states, X, y, random_key: jnp.full(
+            initial_proba_init=lambda n_states, X, y, is_new_session, random_key: jnp.full(
                 (n_states,), 1.0
             )
             / n_states
@@ -691,7 +691,7 @@ class TestHMMInitialParams:
 
         model = MockHMM(n_states=3)
         model.setup(
-            transition_proba_init=lambda n_states, X, y, random_key: jnp.full(
+            transition_proba_init=lambda n_states, X, y, is_new_session, random_key: jnp.full(
                 (n_states, n_states), 1.0
             )
             / n_states

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -829,7 +829,82 @@ class TestHMMNewSession:
         ],
     )
     def test_initialize_new_session(self, X, y, is_new_session, expected_new_session):
-        """Test that session boundaries are correctly initialized and moved when there are NaN values."""
+        """Test that session boundaries are correctly initialized."""
+        model = MockHMM(n_states=3)
+        is_new_session = model._validator.validate_and_cast_is_new_session(
+            X, y, is_new_session
+        )
+        assert jnp.all(is_new_session == expected_new_session)
+
+    @pytest.mark.parametrize(
+        "X, y, is_new_session, expected_new_session",
+        [
+            # NaN at start in y
+            (np.ones((3, 1)), np.array([np.nan, 0, 0]), None, jnp.array([0, 1, 0])),
+            # X and y both have NaNs at different positions
+            (
+                np.array([[np.nan], [2], [3], [4]]),
+                np.array([0, np.nan, 3, 4]),
+                None,
+                jnp.array([0, 0, 1, 0]),
+            ),
+            # X and y both have NaNs at same position
+            (
+                np.array([[np.nan], [1], [2], [3]]),
+                np.array([np.nan, 1, 2, 3]),
+                None,
+                jnp.array([0, 1, 0, 0]),
+            ),
+            # NaN at the very end of data
+            (
+                np.ones((4, 1)),
+                np.array([0, 1, 2, np.nan]),
+                None,
+                jnp.array([1, 0, 0, 0]),
+            ),
+            # Multiple NaNs at the start
+            (
+                np.ones((5, 1)),
+                np.array([np.nan, np.nan, 1, 2, 3]),
+                None,
+                jnp.array([0, 0, 1, 0, 0]),
+            ),
+            # Multiple NaNs spaced
+            (
+                np.ones((5, 1)),
+                np.array([np.nan, 1, np.nan, 2, 3]),
+                None,
+                jnp.array([0, 1, 0, 0, 0]),
+            ),
+            # Explicit is_new_session provided by user
+            # beginning session shifted
+            (
+                np.ones((3, 1)),
+                np.array([np.nan, 0, 0]),
+                jnp.array([1, 0, 1]),
+                jnp.array([0, 1, 1]),
+            ),
+            # beginning new session dropped
+            (
+                np.array([[np.nan], [2], [3], [4]]),
+                np.array([0, np.nan, 3, 4]),
+                jnp.array([1, 0, 1, 0]),
+                jnp.array([0, 0, 1, 0]),
+            ),
+            # middle session moved
+            (
+                np.ones((5, 1)),
+                np.array([0, 1, np.nan, np.nan, 3]),
+                jnp.array([1, 0, 1, 0, 0]),
+                jnp.array([1, 0, 0, 0, 1]),
+            ),
+            # nan moving is independent of input type so I won't add casses with different types
+        ],
+    )
+    def test_initialize_new_session_with_nan_shift(
+        self, X, y, is_new_session, expected_new_session
+    ):
+        """Test that session boundaries are correctly moved when there are NaN values."""
         model = MockHMM(n_states=3)
         is_new_session = model._validator.validate_and_cast_is_new_session(
             X, y, is_new_session

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -1274,6 +1274,41 @@ class TestHMMValidator:
         with expectation:
             model._validator.validate_inputs(X, y)
 
+    @pytest.mark.parametrize(
+        "X, y, expectation",
+        [
+            # nan border y
+            (
+                np.ones((5, 1)),
+                np.array([np.nan, 1, 2, 3, np.nan]),
+                does_not_raise(),
+            ),
+            # nan border x
+            (
+                np.array([[np.nan], [2], [3], [np.nan]]),
+                np.array([0, 1, 3, 4]),
+                does_not_raise(),
+            ),
+            # nan middle y
+            (
+                np.ones((5, 1)),
+                np.array([np.nan, 1, np.nan, 2, 3]),
+                pytest.raises(ValueError, match="HMM requires continuous"),
+            ),
+            # nan middle x
+            (
+                np.array([[np.nan], [2], [np.nan], [3]]),
+                np.array([0, 1, 3, 4]),
+                pytest.raises(ValueError, match="HMM requires continuous"),
+            ),
+        ],
+    )
+    def test_nans_only_at_border(self, X, y, expectation):
+        """Test that validate_inputs allows NaNs only at the borders of the data."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            model._validator.validate_inputs(X, y)
+
 
 class TestHMMInference:
     """Test suite for inference methods (smooth_proba, filter_proba, decode_state)."""

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -26,6 +26,8 @@ from nemos.hmm.utils import initialize_is_new_session
 from nemos.hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
 from nemos.params import ModelParams
 
+import inspect
+
 
 class MockHMMModelParams(ModelParams):
     param: jnp.ndarray
@@ -1202,7 +1204,43 @@ class TestHMMNewSession:
             )
 
 
+def all_subclasses(cls):
+    seen = set()
+    stack = list(cls.__subclasses__())
+    while stack:
+        sub = stack.pop()
+        if sub in seen:
+            continue
+        seen.add(sub)
+        stack.extend(sub.__subclasses__())
+    return seen
+
+
 class TestHMMValidator:
+    """Test suite for input validation logic in HMMValidator."""
+
+    def test_user_param_order(self) -> None:
+        """Meta-test.
+
+        Tests that any subclasses of HMMValidator have the correct user parameter order
+        """
+        import importlib
+        import pkgutil
+        import nemos
+
+        # Import every submodule so all HMMValidator subclasses get registered.
+        for _, modname, _ in pkgutil.walk_packages(nemos.__path__, prefix="nemos."):
+            importlib.import_module(modname)
+
+        # Filter the classes that are subclasses of 'SuperClass'.
+        subclasses = all_subclasses(HMMValidator)
+
+        for validator in subclasses:
+            n_params = len(validator.model_param_names)
+            user_par = [0.0] * (n_params - 2) + [1.0, 1.0]
+            params = validator.to_model_params(user_par)
+            assert np.all(params.hmm_params.log_initial_prob == 0.0)
+            assert np.all(params.hmm_params.log_transition_prob == 0.0)
 
     @pytest.mark.parametrize(
         "X, y, expectation",

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -144,7 +144,7 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams, INITIALIZATION_FN_DICT])
     def _log_likelihood(self, params, X, y):
         return jnp.zeros((y.shape[0], self.n_states))
 
-    def _model_params_initialization(self, X, y, is_new_session):
+    def _model_params_initialization(self, X, y, is_new_session, random_key=None):
         return (
             jnp.arange(self._n_states),
             False,
@@ -377,10 +377,42 @@ class TestHMMInit:
         model = MockHMM(n_states=2, initialization_funcs=init_funcs)
         assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS | init_funcs
 
-    def test_initialization_funcs_invalid_key(self):
-        """Test that invalid registry keys raise KeyError."""
-        with pytest.raises(KeyError, match="unknown key"):
-            MockHMM(n_states=2, initialization_funcs={"invalid_key": lambda: None})
+    @pytest.mark.parametrize(
+        "init_funcs, expectation",
+        [
+            (
+                {"invalid_key": None},
+                pytest.raises(KeyError, match="[Uu]nknown key"),
+            ),
+            (
+                {"initial_prob_init": None},
+                pytest.raises(KeyError, match="Did you mean"),
+            ),
+        ],
+    )
+    def test_initialization_funcs_invalid_key_via_init(self, init_funcs, expectation):
+        """Test that invalid/misspelled keys raise KeyError when passed via constructor."""
+        with expectation:
+            MockHMM(n_states=2, initialization_funcs=init_funcs)
+
+    @pytest.mark.parametrize(
+        "init_funcs, expectation",
+        [
+            (
+                {"invalid_key": None},
+                pytest.raises(KeyError, match="[Uu]nknown key"),
+            ),
+            (
+                {"initial_prob_init": None},
+                pytest.raises(KeyError, match="Did you mean"),
+            ),
+        ],
+    )
+    def test_initialization_funcs_invalid_key_via_setter(self, init_funcs, expectation):
+        """Test that invalid/misspelled keys raise KeyError when assigned via setter."""
+        model = MockHMM(n_states=2)
+        with expectation:
+            model.initialization_funcs = init_funcs
 
     # -------------------------------------------------------------------------
     # Default values tests
@@ -656,7 +688,12 @@ class TestHMMInitialParams:
         model = MockHMM(n_states=3)
 
         (initial_prob, transition_prob), validate_params = (
-            model._hmm_params_initialization(None, None, None)
+            model._hmm_params_initialization(
+                None,
+                None,
+                None,
+                random_key_pair=jax.random.split(jax.random.PRNGKey(0), 2),
+            )
         )
 
         assert jnp.allclose(
@@ -676,7 +713,7 @@ class TestHMMInitialParams:
             / n_states
         )
         (initial_prob, _), validate_params = model._hmm_params_initialization(
-            None, None, None
+            None, None, None, random_key_pair=jax.random.split(jax.random.PRNGKey(0), 2)
         )
         assert jnp.allclose(initial_prob, jnp.full((3,), 1.0) / 3)
         assert validate_params is True
@@ -689,7 +726,7 @@ class TestHMMInitialParams:
             / n_states
         )
         (_, transition_prob), validate_params = model._hmm_params_initialization(
-            None, None, None
+            None, None, None, random_key_pair=jax.random.split(jax.random.PRNGKey(0), 2)
         )
         assert jnp.allclose(transition_prob, jnp.full((3, 3), 1.0) / 3)
         assert validate_params is True

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -595,7 +595,7 @@ class TestHMMSetup:
             transition_proba_init_kwargs={"minimum_prob": 0.01},
         )
         expected_funcs = DEFAULT_INIT_FUNCTIONS | init_funcs
-        assert (
+        assert all(
             model.initialization_funcs[key] == expected_funcs[key]
             for key in expected_funcs
         )
@@ -616,7 +616,7 @@ class TestHMMSetup:
             == init_funcs["initial_proba_init"]
         )
         # default
-        assert (
+        assert all(
             model.initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
             for key in [
                 "initial_proba_init_kwargs",
@@ -627,7 +627,7 @@ class TestHMMSetup:
 
         model.setup(initial_proba_init_kwargs={"minimum_prob": 0.01})
         # updated
-        assert (
+        assert all(
             model.initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
@@ -635,7 +635,7 @@ class TestHMMSetup:
             ]
         )
         # default
-        assert (
+        assert all(
             model.initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
             for key in [
                 "transition_proba_init",
@@ -645,7 +645,7 @@ class TestHMMSetup:
 
         model.setup(transition_proba_init="kmeans")
         # updated
-        assert (
+        assert all(
             model.initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
@@ -661,7 +661,7 @@ class TestHMMSetup:
 
         model.setup(transition_proba_init_kwargs={"minimum_prob": 0.01})
         # updated
-        assert (
+        assert all(
             model.initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -714,6 +714,61 @@ class TestHMMInitialParams:
             jnp.log(DEFAULT_INIT_FUNCTIONS["transition_proba_init"](3)),
         )
 
+    @pytest.mark.parametrize(
+        "key, value, expectation",
+        [
+            (
+                "initial_proba_init",
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones((n_states,))
+                / n_states,
+                does_not_raise(),
+            ),
+            (
+                "transition_proba_init",
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones(
+                    (n_states, n_states)
+                )
+                / n_states,
+                does_not_raise(),
+            ),
+            (
+                "initial_proba_init",
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones(
+                    (n_states - 1,)
+                ),
+                pytest.raises(ValueError, match="initial_prob must be"),
+            ),
+            (
+                "transition_proba_init",
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones(
+                    (n_states - 1, n_states - 1)
+                ),
+                pytest.raises(ValueError, match="transition_prob must be"),
+            ),
+            (
+                "initial_proba_init",
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones(
+                    (n_states,)
+                ),
+                pytest.raises(ValueError, match="must sum to 1"),
+            ),
+            (
+                "transition_proba_init",
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones(
+                    (n_states, n_states)
+                ),
+                pytest.raises(ValueError, match="rows must sum to 1"),
+            ),
+        ],
+    )
+    def test_custom_init_and_transition_prob_sum_and_shape(
+        self, key, value, expectation
+    ):
+        model = MockHMM(n_states=3)
+        model.setup(**{key: value})
+        with expectation:
+            model_params = model._model_specific_initialization(None, None, None)
+
 
 class TestHMMNewSession:
 
@@ -1116,6 +1171,41 @@ class TestHMMNewSession:
             is_new_session = model._validator.validate_and_cast_is_new_session(
                 X, y, is_new_session
             )
+
+
+class TestHMMValidator:
+
+    @pytest.mark.parametrize(
+        "X, y, expectation",
+        [
+            (
+                np.random.rand(10, 2),
+                np.random.rand(10),
+                does_not_raise(),
+            ),
+            (
+                np.random.rand(10, 2),
+                np.random.rand(9),
+                pytest.raises(ValueError, match="X and y must have"),
+            ),
+            (
+                nap.TsdFrame(
+                    t=np.arange(10),
+                    d=np.random.rand(10, 2),
+                ),
+                nap.Tsd(
+                    t=np.arange(10) + 1,
+                    d=np.random.rand(10),
+                ),
+                pytest.raises(ValueError, match="Time axis mismatch"),
+            ),
+        ],
+    )
+    def test_validate_inputs(self, X, y, expectation):
+        """Test that validate_inputs correctly validates X and y."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            model._validator.validate_inputs(X, y)
 
 
 class TestHMMInference:

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -722,43 +722,6 @@ class TestHMMNewSession:
         [
             # No is_new_session provided
             (np.ones((3, 1)), np.ones((3,)), None, jnp.array([1, 0, 0])),
-            # NaN at start in y
-            (np.ones((3, 1)), np.array([np.nan, 0, 0]), None, jnp.array([0, 1, 0])),
-            # X and y both have NaNs at different positions
-            (
-                np.array([[np.nan], [2], [3], [4]]),
-                np.array([0, np.nan, 3, 4]),
-                None,
-                jnp.array([0, 0, 1, 0]),
-            ),
-            # X and y both have NaNs at same position
-            (
-                np.array([[np.nan], [1], [2], [3]]),
-                np.array([np.nan, 1, 2, 3]),
-                None,
-                jnp.array([0, 1, 0, 0]),
-            ),
-            # NaN at the very end of data
-            (
-                np.ones((4, 1)),
-                np.array([0, 1, 2, np.nan]),
-                None,
-                jnp.array([1, 0, 0, 0]),
-            ),
-            # Multiple NaNs at the start
-            (
-                np.ones((5, 1)),
-                np.array([np.nan, np.nan, 1, 2, 3]),
-                None,
-                jnp.array([0, 0, 1, 0, 0]),
-            ),
-            # Multiple NaNs spaced
-            (
-                np.ones((5, 1)),
-                np.array([np.nan, 1, np.nan, 2, 3]),
-                None,
-                jnp.array([0, 1, 0, 0, 0]),
-            ),
             # Explicit is_new_session provided by user
             # boolean array or integer array with 1s and 0s
             (
@@ -786,46 +749,35 @@ class TestHMMNewSession:
                 jnp.array([0, 1, 0], dtype=bool),
                 jnp.array([1, 1, 0]),
             ),
-            (
-                np.ones((3, 1)),
-                np.array([np.nan, 0, 0]),
-                jnp.array([1, 0, 1]),
-                jnp.array([0, 1, 1]),
-            ),
-            # beginning new session dropped
-            (
-                np.array([[np.nan], [2], [3], [4]]),
-                np.array([0, np.nan, 3, 4]),
-                jnp.array([1, 0, 1, 0]),
-                jnp.array([0, 0, 1, 0]),
-            ),
-            # middle new session moved
-            (
-                np.ones((5, 1)),
-                np.array([0, 1, np.nan, np.nan, 3]),
-                jnp.array([1, 0, 1, 0, 0]),
-                jnp.array([1, 0, 0, 0, 1]),
-            ),
             # integer array with indices of new sessions
+            # 1 session
             (
                 np.ones((5, 1)),
                 np.array([0, 1, 2, 3, 4]),
                 jnp.array([0]),
                 jnp.array([1, 0, 0, 0, 0]),
             ),
+            # repeated values
+            (
+                np.ones((5, 1)),
+                np.array([0, 1, 2, 3, 4]),
+                jnp.array([0, 0]),
+                jnp.array([1, 0, 0, 0, 0]),
+            ),
+            # all 0s and 1s with length < n_samples
             (
                 np.ones((5, 1)),
                 np.array([0, 1, 2, 3, 4]),
                 jnp.array([0, 1]),
                 jnp.array([1, 1, 0, 0, 0]),
             ),
+            # higher int values, adding first session
             (
                 np.ones((5, 1)),
                 np.array([0, 1, 2, 3, 4]),
                 jnp.array([2, 4]),
                 jnp.array([1, 0, 1, 0, 1]),
             ),
-            # nan moving is independent of input type so I won't add more cases
         ],
     )
     def test_initialize_new_session(self, X, y, is_new_session, expected_new_session):

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -82,30 +82,28 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
     def __init__(
         self,
         n_states: int,
-        dirichlet_prior_alphas_init_prob: Union[
-            jnp.ndarray, None
-        ] = None,  # (n_state, )
-        dirichlet_prior_alphas_transition: Union[
+        dirichlet_initial_proba: Union[jnp.ndarray, None] = None,  # (n_state, )
+        dirichlet_transition_proba: Union[
             jnp.ndarray | None
         ] = None,  # (n_state, n_state):
         maxiter: int = 1000,
         tol: float = 1e-8,
         seed=jax.random.PRNGKey(123),
-        hmm_initialization_funcs: INITIALIZATION_FN_DICT = {},
-        model_initialization_funcs: INITIALIZATION_FN_DICT = {},
+        hmm_initialization_funcs: INITIALIZATION_FN_DICT = None,
+        model_initialization_funcs: INITIALIZATION_FN_DICT = None,
     ):
         BaseHMM.__init__(
             self,
             n_states=n_states,
-            dirichlet_prior_alphas_init_prob=dirichlet_prior_alphas_init_prob,
-            dirichlet_prior_alphas_transition=dirichlet_prior_alphas_transition,
+            dirichlet_initial_proba=dirichlet_initial_proba,
+            dirichlet_transition_proba=dirichlet_transition_proba,
             maxiter=maxiter,
             tol=tol,
             seed=seed,
             hmm_initialization_funcs=hmm_initialization_funcs,
         )
         self.param_: jnp.ndarray | None = None
-        self.model_initialization_funcs = model_initialization_funcs
+        self.model_initialization_funcs = {}
 
     def setup(
         self,
@@ -313,50 +311,50 @@ class TestHMMInit:
             MockHMM(n_states=2, seed=seed)
 
     # -------------------------------------------------------------------------
-    # dirichlet_prior_alphas_init_prob setter tests
+    # dirichlet_initial_proba setter tests
     # -------------------------------------------------------------------------
     def test_dirichlet_prior_init_prob_none(self):
         """Test that None is accepted for dirichlet prior."""
-        model = MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=None)
-        assert model.dirichlet_prior_alphas_init_prob is None
+        model = MockHMM(n_states=3, dirichlet_initial_proba=None)
+        assert model.dirichlet_initial_proba is None
 
     def test_dirichlet_prior_init_prob_valid(self):
         """Test valid dirichlet prior alphas."""
         alphas = jnp.array([1.0, 2.0, 3.0])
-        model = MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=alphas)
-        assert jnp.array_equal(model.dirichlet_prior_alphas_init_prob, alphas)
+        model = MockHMM(n_states=3, dirichlet_initial_proba=alphas)
+        assert jnp.array_equal(model.dirichlet_initial_proba, alphas)
 
     def test_dirichlet_prior_init_prob_wrong_shape(self):
         """Test that wrong shape raises ValueError."""
         alphas = jnp.array([1.0, 2.0])  # n_states=3 but only 2 elements
         with pytest.raises(ValueError, match="must have shape"):
-            MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=alphas)
+            MockHMM(n_states=3, dirichlet_initial_proba=alphas)
 
     def test_dirichlet_prior_init_prob_values_less_than_one(self):
         """Test that alpha values < 1 raise ValueError."""
         alphas = jnp.array([1.0, 0.5, 2.0])
         with pytest.raises(ValueError, match="must be >= 1"):
-            MockHMM(n_states=3, dirichlet_prior_alphas_init_prob=alphas)
+            MockHMM(n_states=3, dirichlet_initial_proba=alphas)
 
     # -------------------------------------------------------------------------
-    # dirichlet_prior_alphas_transition setter tests
+    # dirichlet_transition_proba setter tests
     # -------------------------------------------------------------------------
     def test_dirichlet_prior_transition_none(self):
         """Test that None is accepted for dirichlet prior."""
-        model = MockHMM(n_states=3, dirichlet_prior_alphas_transition=None)
-        assert model.dirichlet_prior_alphas_transition is None
+        model = MockHMM(n_states=3, dirichlet_transition_proba=None)
+        assert model.dirichlet_transition_proba is None
 
     def test_dirichlet_prior_transition_valid(self):
         """Test valid dirichlet prior alphas for transitions."""
         alphas = jnp.ones((3, 3))
-        model = MockHMM(n_states=3, dirichlet_prior_alphas_transition=alphas)
-        assert jnp.array_equal(model.dirichlet_prior_alphas_transition, alphas)
+        model = MockHMM(n_states=3, dirichlet_transition_proba=alphas)
+        assert jnp.array_equal(model.dirichlet_transition_proba, alphas)
 
     def test_dirichlet_prior_transition_wrong_shape(self):
         """Test that wrong shape raises ValueError."""
         alphas = jnp.ones((2, 3))  # n_states=3 but wrong shape
         with pytest.raises(ValueError, match="must have shape"):
-            MockHMM(n_states=3, dirichlet_prior_alphas_transition=alphas)
+            MockHMM(n_states=3, dirichlet_transition_proba=alphas)
 
     # -------------------------------------------------------------------------
     # hmm_initialization_funcs setter tests
@@ -394,8 +392,8 @@ class TestHMMInit:
         assert model.n_states == 3
         assert model.maxiter == 1000
         assert model.tol == 1e-8
-        assert model.dirichlet_prior_alphas_init_prob is None
-        assert model.dirichlet_prior_alphas_transition is None
+        assert model.dirichlet_initial_proba is None
+        assert model.dirichlet_transition_proba is None
 
     def test_fit_attributes_initialized_to_none(self):
         """Test that fit attributes are initialized to None."""

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -143,7 +143,7 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
         self.initial_prob_ = initial_prob
         self.transition_prob_ = transition_prob
 
-    def _log_likelihood(self, X, y, params):
+    def _log_likelihood(self, params, X, y):
         return jnp.zeros((y.shape[0], self.n_states))
 
     def _model_params_initialization(self, X, y, is_new_session):
@@ -1378,7 +1378,6 @@ class TestHMMInference:
 
         # Check that we get valid output (NaN rows filtered)
         assert posteriors.shape[1] == model.n_states
-        # After filtering NaNs, shape[0] should be reduced
         assert posteriors.shape[0] == X.shape[0]
 
     @pytest.mark.parametrize(
@@ -1496,3 +1495,32 @@ class TestHMMInference:
         assert jnp.all(out <= 1)
         row_sums = jnp.sum(out, axis=1)
         assert jnp.allclose(row_sums, 1.0)
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_is_new_session_is_used(self, method_name):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.param_ = jnp.ones((3,))
+        model.initial_prob_ = jnp.array([0.8, 0.1, 0.1])
+        model.transition_prob_ = jnp.array(
+            [[0.1, 0.8, 0.1], [0.1, 0.1, 0.8], [0.8, 0.1, 0.1]]
+        )
+        out_all_new_sess = getattr(model, method_name)(
+            X, y, is_new_session=np.ones(10, dtype=bool)
+        )
+        assert np.all(
+            out_all_new_sess == out_all_new_sess[0]
+        ), "Output should be the same for all time points"
+        out_default = getattr(model, method_name)(X, y)
+        assert not np.allclose(
+            out_all_new_sess, out_default
+        ), "Output with all new sessions should not match default output"
+        out_no_new_sess = getattr(model, method_name)(
+            X, y, is_new_session=np.zeros(10, dtype=bool)
+        )
+        assert jnp.allclose(
+            out_no_new_sess, out_default
+        ), "Output with no new sessions should match default output"

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -599,11 +599,11 @@ class TestGenerateHMMInitParams:
             ({"initial_proba_init": random_initial_proba_init}, does_not_raise()),
             (
                 {"invalid_key": None},
-                pytest.raises(ValueError, match="Unexpected or unknown keys"),
+                pytest.raises(KeyError, match="Unexpected or unknown keys"),
             ),
             (
                 {"initial_prob_init": random_initial_proba_init},
-                pytest.raises(ValueError, match="Did you mean"),
+                pytest.raises(KeyError, match="Did you mean"),
             ),
         ],
     )

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -632,6 +632,42 @@ class TestSetupHMMInitialization:
         init_funcs = setup_hmm_initialization()
         assert init_funcs == DEFAULT_INIT_FUNCTIONS
 
+    @pytest.mark.parametrize("n_states", [2, 3, 5])
+    @pytest.mark.parametrize(
+        "init_key, kwargs_key, wrong_alphas_factory",
+        [
+            # initial proba expects (n_states,); pass 2D → wrong
+            ("initial_proba_init", "initial_proba_init_kwargs", lambda n: jnp.ones((n, n))),
+            # transition proba expects (n_states, n_states); pass 1D → wrong
+            ("transition_proba_init", "transition_proba_init_kwargs", lambda n: jnp.ones(n)),
+        ],
+    )
+    def test_alphas_wrong_shape_via_setup(
+        self, n_states, init_key, kwargs_key, wrong_alphas_factory
+    ):
+        """Wrong alphas shape in init_kwargs raises ValueError through setup_hmm_initialization."""
+        with pytest.raises(ValueError, match="must have shape"):
+            setup_hmm_initialization(
+                **{init_key: "dirichlet", kwargs_key: {"alphas": wrong_alphas_factory(n_states)}},
+                n_states=n_states,
+            )
+
+    @pytest.mark.parametrize("n_states", [2, 3])
+    def test_alphas_correct_shape_via_setup(self, n_states):
+        """Correctly shaped alphas accepted without error through setup_hmm_initialization."""
+        init_funcs = setup_hmm_initialization(
+            initial_proba_init="dirichlet",
+            initial_proba_init_kwargs={"alphas": jnp.ones(n_states)},
+            transition_proba_init="dirichlet",
+            transition_proba_init_kwargs={"alphas": jnp.ones((n_states, n_states))},
+            n_states=n_states,
+        )
+        assert init_funcs["initial_proba_init_kwargs"]["alphas"].shape == (n_states,)
+        assert init_funcs["transition_proba_init_kwargs"]["alphas"].shape == (
+            n_states,
+            n_states,
+        )
+
 
 class TestGenerateHMMInitParams:
     """Test generate_hmm_initial_params function"""

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -637,9 +637,17 @@ class TestSetupHMMInitialization:
         "init_key, kwargs_key, wrong_alphas_factory",
         [
             # initial proba expects (n_states,); pass 2D → wrong
-            ("initial_proba_init", "initial_proba_init_kwargs", lambda n: jnp.ones((n, n))),
+            (
+                "initial_proba_init",
+                "initial_proba_init_kwargs",
+                lambda n: jnp.ones((n, n)),
+            ),
             # transition proba expects (n_states, n_states); pass 1D → wrong
-            ("transition_proba_init", "transition_proba_init_kwargs", lambda n: jnp.ones(n)),
+            (
+                "transition_proba_init",
+                "transition_proba_init_kwargs",
+                lambda n: jnp.ones(n),
+            ),
         ],
     )
     def test_alphas_wrong_shape_via_setup(
@@ -648,7 +656,10 @@ class TestSetupHMMInitialization:
         """Wrong alphas shape in init_kwargs raises ValueError through setup_hmm_initialization."""
         with pytest.raises(ValueError, match="must have shape"):
             setup_hmm_initialization(
-                **{init_key: "dirichlet", kwargs_key: {"alphas": wrong_alphas_factory(n_states)}},
+                **{
+                    init_key: "dirichlet",
+                    kwargs_key: {"alphas": wrong_alphas_factory(n_states)},
+                },
                 n_states=n_states,
             )
 

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -664,53 +664,6 @@ class TestGenerateHMMInitParams:
         assert isinstance(initial_prob, jnp.ndarray)
         assert isinstance(transition_prob, jnp.ndarray)
 
-    # @pytest.mark.parametrize(
-    #     "key, value, expectation",
-    #     [
-    #         (
-    #             "initial_proba_init",
-    #             lambda n_states, X, y, random_key: jnp.ones((n_states,)) / n_states,
-    #             does_not_raise(),
-    #         ),
-    #         (
-    #             "transition_proba_init",
-    #             lambda n_states, X, y, random_key: jnp.ones((n_states, n_states))
-    #             / n_states,
-    #             does_not_raise(),
-    #         ),
-    #         (
-    #             "initial_proba_init",
-    #             lambda n_states, X, y, random_key: jnp.ones((n_states - 1,)),
-    #             pytest.raises(ValueError, match="must return an array of shape"),
-    #         ),
-    #         (
-    #             "transition_proba_init",
-    #             lambda n_states, X, y, random_key: jnp.ones(
-    #                 (n_states - 1, n_states - 1)
-    #             ),
-    #             pytest.raises(ValueError, match="must return an array of shape"),
-    #         ),
-    #         (
-    #             "initial_proba_init",
-    #             lambda n_states, X, y, random_key: jnp.ones((n_states,)),
-    #             pytest.raises(ValueError, match="must sum to 1"),
-    #         ),
-    #         (
-    #             "transition_proba_init",
-    #             lambda n_states, X, y, random_key: jnp.ones((n_states, n_states)),
-    #             pytest.raises(ValueError, match="rows that sum to 1"),
-    #         ),
-    #     ],
-    # )
-    # def test_validate_custom_func_output(self, key, value, expectation):
-    #     with expectation:
-    #         generate_hmm_initial_params(
-    #             n_states=3,
-    #             X=None,
-    #             y=None,
-    #             init_funcs={key: value, key + "_custom": True},
-    #         )
-
 
 class TestResolveDirichletPriors:
     """Test _resolve_dirichlet_priors validation function."""

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -12,6 +12,8 @@ from nemos.hmm.initialize_parameters import (
     DEFAULT_INIT_FUNCTIONS,
     KMeansInitializer,
     _resolve_dirichlet_priors,
+    dirichlet_initial_proba_init,
+    dirichlet_transition_proba_init,
     generate_hmm_initial_params,
     kmeans_initial_proba_init,
     kmeans_transition_proba_init,
@@ -21,8 +23,6 @@ from nemos.hmm.initialize_parameters import (
     sticky_transition_proba_init,
     uniform_initial_proba_init,
     uniform_transition_proba_init,
-    dirichlet_initial_proba_init,
-    dirichlet_transition_proba_init,
 )
 
 

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -636,27 +636,6 @@ class TestSetupHMMInitialization:
 class TestGenerateHMMInitParams:
     """Test generate_hmm_initial_params function"""
 
-    @pytest.mark.parametrize(
-        "init_funcs, expectation",
-        [
-            ({}, does_not_raise()),
-            ({"initial_proba_init": random_initial_proba_init}, does_not_raise()),
-            (
-                {"invalid_key": None},
-                pytest.raises(KeyError, match="Unexpected or unknown keys"),
-            ),
-            (
-                {"initial_prob_init": random_initial_proba_init},
-                pytest.raises(KeyError, match="Did you mean"),
-            ),
-        ],
-    )
-    def test_init_funcs_keys(self, init_funcs, expectation):
-        with expectation:
-            generate_hmm_initial_params(
-                n_states=3, X=None, y=None, is_new_session=None, init_funcs=init_funcs
-            )
-
     def test_init_funcs_none_values(self):
         """Test that None values in init_funcs are replaced by defaults."""
         init_funcs = {

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -639,52 +639,52 @@ class TestGenerateHMMInitParams:
         assert isinstance(initial_prob, jnp.ndarray)
         assert isinstance(transition_prob, jnp.ndarray)
 
-    @pytest.mark.parametrize(
-        "key, value, expectation",
-        [
-            (
-                "initial_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones((n_states,)) / n_states,
-                does_not_raise(),
-            ),
-            (
-                "transition_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones((n_states, n_states))
-                / n_states,
-                does_not_raise(),
-            ),
-            (
-                "initial_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones((n_states - 1,)),
-                pytest.raises(ValueError, match="must return an array of shape"),
-            ),
-            (
-                "transition_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones(
-                    (n_states - 1, n_states - 1)
-                ),
-                pytest.raises(ValueError, match="must return an array of shape"),
-            ),
-            (
-                "initial_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones((n_states,)),
-                pytest.raises(ValueError, match="must sum to 1"),
-            ),
-            (
-                "transition_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones((n_states, n_states)),
-                pytest.raises(ValueError, match="rows that sum to 1"),
-            ),
-        ],
-    )
-    def test_validate_custom_func_output(self, key, value, expectation):
-        with expectation:
-            generate_hmm_initial_params(
-                n_states=3,
-                X=None,
-                y=None,
-                init_funcs={key: value, key + "_custom": True},
-            )
+    # @pytest.mark.parametrize(
+    #     "key, value, expectation",
+    #     [
+    #         (
+    #             "initial_proba_init",
+    #             lambda n_states, X, y, random_key: jnp.ones((n_states,)) / n_states,
+    #             does_not_raise(),
+    #         ),
+    #         (
+    #             "transition_proba_init",
+    #             lambda n_states, X, y, random_key: jnp.ones((n_states, n_states))
+    #             / n_states,
+    #             does_not_raise(),
+    #         ),
+    #         (
+    #             "initial_proba_init",
+    #             lambda n_states, X, y, random_key: jnp.ones((n_states - 1,)),
+    #             pytest.raises(ValueError, match="must return an array of shape"),
+    #         ),
+    #         (
+    #             "transition_proba_init",
+    #             lambda n_states, X, y, random_key: jnp.ones(
+    #                 (n_states - 1, n_states - 1)
+    #             ),
+    #             pytest.raises(ValueError, match="must return an array of shape"),
+    #         ),
+    #         (
+    #             "initial_proba_init",
+    #             lambda n_states, X, y, random_key: jnp.ones((n_states,)),
+    #             pytest.raises(ValueError, match="must sum to 1"),
+    #         ),
+    #         (
+    #             "transition_proba_init",
+    #             lambda n_states, X, y, random_key: jnp.ones((n_states, n_states)),
+    #             pytest.raises(ValueError, match="rows that sum to 1"),
+    #         ),
+    #     ],
+    # )
+    # def test_validate_custom_func_output(self, key, value, expectation):
+    #     with expectation:
+    #         generate_hmm_initial_params(
+    #             n_states=3,
+    #             X=None,
+    #             y=None,
+    #             init_funcs={key: value, key + "_custom": True},
+    #         )
 
 
 class TestResolveDirichletPriors:

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -104,6 +104,18 @@ class TestInitialProbaInitialization:
 
         assert not jnp.allclose(initial_prob1, initial_prob2)
 
+    @pytest.mark.parametrize("method_subset", [[dirichlet_initial_proba_init]])
+    @pytest.mark.parametrize("n_states", [2, 3, 5])
+    def test_dirichlet_alphas_is_used(
+        self, method, method_subset, use_method_for_test, n_states
+    ):
+        """Test that dirichlet_initial_proba_init uses the provided alphas."""
+        alphas = jnp.ones(n_states)
+        alphas = alphas.at[n_states - 1].set(100.0)  # Make the last state most likely
+
+        initial_prob = method(n_states, random_key=jax.random.PRNGKey(0), alphas=alphas)
+        assert jnp.argmax(initial_prob) == n_states - 1
+
 
 @pytest.mark.parametrize(
     "method",
@@ -215,6 +227,24 @@ class TestTransitionProbaInitialization:
         transition_prob2 = method(n_states, random_key=jax.random.PRNGKey(999))
 
         assert not jnp.allclose(transition_prob1, transition_prob2)
+
+    @pytest.mark.parametrize("method_subset", [[dirichlet_transition_proba_init]])
+    @pytest.mark.parametrize("n_states", [2, 3, 5])
+    def test_dirichlet_alphas_is_used(
+        self, method, method_subset, use_method_for_test, n_states
+    ):
+        """Test that dirichlet_initial_proba_init uses the provided alphas."""
+        alphas = jnp.ones((n_states, n_states))
+        for i in range(n_states):
+            alphas = alphas.at[i, n_states - 1].set(
+                100.0
+            )  # Make the last state most likely
+
+        transition_prob = method(
+            n_states, random_key=jax.random.PRNGKey(0), alphas=alphas
+        )
+        for i in range(n_states):
+            assert jnp.argmax(transition_prob[i]) == n_states - 1
 
 
 def generate_kmeans_data(n_states=3, min_prob=0.02):

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -21,6 +21,8 @@ from nemos.hmm.initialize_parameters import (
     sticky_transition_proba_init,
     uniform_initial_proba_init,
     uniform_transition_proba_init,
+    dirichlet_initial_proba_init,
+    dirichlet_transition_proba_init,
 )
 
 
@@ -35,6 +37,7 @@ def use_method_for_test(method, method_subset):
     [
         uniform_initial_proba_init,
         random_initial_proba_init,
+        dirichlet_initial_proba_init,
     ],
 )
 class TestInitialProbaInitialization:
@@ -89,7 +92,9 @@ class TestInitialProbaInitialization:
         # Should be identical regardless of random key
         assert jnp.allclose(initial_prob1, initial_prob2)
 
-    @pytest.mark.parametrize("method_subset", [[random_initial_proba_init]])
+    @pytest.mark.parametrize(
+        "method_subset", [[random_initial_proba_init, dirichlet_initial_proba_init]]
+    )
     def test_non_deterministic(self, method, method_subset, use_method_for_test):
         """Test that output is non-deterministic (different across different calls)."""
         n_states = 3
@@ -106,6 +111,7 @@ class TestInitialProbaInitialization:
         sticky_transition_proba_init,
         uniform_transition_proba_init,
         random_transition_proba_init,
+        dirichlet_transition_proba_init,
     ],
 )
 class TestTransitionProbaInitialization:
@@ -385,7 +391,8 @@ class TestSetupHMMInitialization:
         "init_func, expectation",
         [
             (
-                lambda n_states, X, y, random_key: jnp.ones((n_states,)) / n_states,
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones((n_states,))
+                / n_states,
                 does_not_raise(),
             ),
             (
@@ -425,7 +432,9 @@ class TestSetupHMMInitialization:
         "init_func, expectation",
         [
             (
-                lambda n_states, X, y, random_key: jnp.ones((n_states, n_states))
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones(
+                    (n_states, n_states)
+                )
                 / n_states,
                 does_not_raise(),
             ),
@@ -455,7 +464,7 @@ class TestSetupHMMInitialization:
     def custom_init_func(self, init_func, key):
         if init_func:
             return (
-                lambda n_states, X, y, random_key, extra_key=2: jnp.ones(
+                lambda n_states, X, y, is_new_session, random_key, extra_key=2: jnp.ones(
                     shape=((n_states, n_states) if "transition" in key else (n_states,))
                 )
                 / n_states
@@ -514,7 +523,7 @@ class TestSetupHMMInitialization:
                 "initial_proba_init",
                 "kmeans",
                 "initial_proba_init_kwargs",
-                {"is_new_session": None},
+                {"minimum_prob": 0.1},
             ),
             (
                 "transition_proba_init",
@@ -524,14 +533,16 @@ class TestSetupHMMInitialization:
             ),
             (
                 "initial_proba_init",
-                lambda n_states, X, y, random_key, extra_kwarg=1: jnp.ones((n_states,))
+                lambda n_states, X, y, is_new_session, random_key, extra_kwarg=1: jnp.ones(
+                    (n_states,)
+                )
                 / n_states,
                 "initial_proba_init_kwargs",
                 {"extra_kwarg": 2},
             ),
             (
                 "transition_proba_init",
-                lambda n_states, X, y, random_key, extra_kwarg=1: jnp.ones(
+                lambda n_states, X, y, is_new_session, random_key, extra_kwarg=1: jnp.ones(
                     (n_states, n_states)
                 )
                 / n_states,
@@ -565,21 +576,24 @@ class TestSetupHMMInitialization:
             ),
             (
                 "initial_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones((n_states,)) / n_states,
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones((n_states,))
+                / n_states,
             ),
             (
                 "transition_proba_init",
-                lambda n_states, X, y, random_key: jnp.ones((n_states, n_states))
+                lambda n_states, X, y, is_new_session, random_key: jnp.ones(
+                    (n_states, n_states)
+                )
                 / n_states,
             ),
         ],
     )
     def test_reset_init_kwargs(self, key, value):
         first_dict = setup_hmm_initialization(
-            **{key: "kmeans", key + "_kwargs": {"is_new_session": None}}
+            **{key: "kmeans", key + "_kwargs": {"minimum_prob": 0.1}}
         )
         second_dict = setup_hmm_initialization(**{key: value}, init_funcs=first_dict)
-        assert first_dict[key + "_kwargs"] == {"is_new_session": None}
+        assert first_dict[key + "_kwargs"] == {"minimum_prob": 0.1}
         assert second_dict[key + "_kwargs"] == {}
 
     def test_default_initialization(self):
@@ -610,7 +624,7 @@ class TestGenerateHMMInitParams:
     def test_init_funcs_keys(self, init_funcs, expectation):
         with expectation:
             generate_hmm_initial_params(
-                n_states=3, X=None, y=None, init_funcs=init_funcs
+                n_states=3, X=None, y=None, is_new_session=None, init_funcs=init_funcs
             )
 
     def test_init_funcs_none_values(self):
@@ -622,16 +636,18 @@ class TestGenerateHMMInitParams:
             "transition_proba_init_kwargs": None,
         }
         result1 = generate_hmm_initial_params(
-            n_states=3, X=None, y=None, init_funcs=init_funcs
+            n_states=3, X=None, y=None, is_new_session=None, init_funcs=init_funcs
         )
-        result2 = generate_hmm_initial_params(n_states=3, X=None, y=None)
+        result2 = generate_hmm_initial_params(
+            n_states=3, X=None, y=None, is_new_session=None
+        )
         assert jnp.allclose(jnp.vstack(result1), jnp.vstack(result2))
 
     @pytest.mark.parametrize("n_states", [1, 2, 3, 5])
     def test_output_shapes_and_types(self, n_states):
         """Test that output shapes and types are correct."""
         initial_prob, transition_prob = generate_hmm_initial_params(
-            n_states=n_states, X=None, y=None
+            n_states=n_states, X=None, y=None, is_new_session=None
         )
 
         assert initial_prob.shape == (n_states,)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -259,6 +259,7 @@ PYNAPPLE_FREE_MODULES = [
     "nemos.solvers",
     "nemos.regularizer",
     "nemos.glm",
+    "nemos.hmm",
 ]
 
 

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -264,7 +264,7 @@ PYNAPPLE_FREE_IMPORTS = [
     "from nemos.solvers import OptimistixFISTA, SVRG, OptimistixOptaxLBFGS",
     "import nemos.regularizer",
     "from nemos.glm import GLM, PopulationGLM, ClassifierGLM, ClassifierPopulationGLM",
-    "from nemos.hmm.utils import *",
+    "from nemos.hmm.hmm import *",  # this eagerly import the hmm module
     "from nemos.type_casting import *",
     "import nemos.hmm",
 ]


### PR DESCRIPTION
## Summary
This PR adds the base components of the `BaseHMM` abstract class and tests initialization and validation using a mock class. This class inherits `BaseRegressor` using HMM-generic parameter types `HMMModelParamsT` and `HMMUserProvidedParamsT` (introduced in #540). In this way, classes that inherit `BaseHMM` do not also need to inherit `BaseRegressor`, and will specify typing through `BaseHMM`, e.g. `MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams])`

## Changes overview

### New class attributes:
- **`hmm_initialization_funcs`**: This is included in the init signature to have a sklearn compatible way of copying or cross validating over initialization methods. However, the user should not be defining the functions here, and instead should be going through the new `setup` method (detailed below).
- **`_validator_class`**: similar to `GLM` and `PopulationGLM`, this attribute is defined outside of `__init__` in the inheriting class so that the validator can be initialized correctly when setting `n_states`

### New/modified class methods:
- **`setup`**: An optional method to run after model instantiation if the user wants to update what initialization method is used for initial probabilities and transition probabilities (with initialization methods introduced in #542). This is essentially a wrapper around `setup_hmm_initialization`, which updates the internal `_hmm_initialization_funcs` dictionary. 
- **`_check_hmm_is_fit`**: called by `_check_is_fit`, checks HMM-specific parameters (initial prob and transition prob)
- **`_check_model_is_fit`**: a new _abstract_ method, also called by `_check_is_fit`. to be implemented by inheriting class to check model-specific parameters.
- **`_check_is_fit`**: in an attempt to generalize core functions, this function is being handled by the base class. it calls the two functions listed above.
- **`_hmm_params_initialization`**: private function for calling `generate_hmm_initial_params` and indicating whether or not the output needs to be validated (i.e. it was generated from a custom function). called by `_model_specific_initialization` (see below)
- **`_model_params_initialization`**: a new _abstract_ method to mirror `_hmm_params_initialization` except for model parameters. needs to be implemented by inheriting class. called by `_model_specific_initialization` (see below)
- **`_model_specific_initialization`**: similar to `_check_is_fit`, this function is being handled by the base class. it calls the two previously mentioned functions to separately initialize hmm and model params. it will validate all parameters if at least one is being generated by a custom function. _This called for new assumptions/restrictions on the validator class for this to work simply (see below)_
- **`_validate_and_prepare_inputs`**: this function was pulled and modified from GLM-HMM and adds the option to pass a user-defined `is_new_session`. this parameter is validated and recast to a jax boolean array (if it isn't already), and allow some flexibility on what `is_new_session` can be passed as. _This called for updates to the validator class and utility functions (detailed below)_

### Class attributes pulled from GLM-HMM:
- `n_states`, `dirichlet_prior_alphas_init_prob`, `dirichlet_prior_alphas_transition`, `regularizer`, `regularizer_strength`, `solver_name`, `solver_kwargs`, `maxiter`, `tol`, `seed`
- Validation of these parameters, initialization of `BaseRegressor`, and initialization of the validator were all moved to `BaseHMM`.

### Changes to `HMMValidator`
1. In order to easily concatenate generated HMM and model parameters in `_validate_and_prepare_inputs`, I went back to the assumption that model parameters come first, and HMM parameters are always the last two. This removed the `initial_prob_ind` and `transition_prob_ind` properties of the validator.
2. I removed the field `expected_param_dims` from and moved `check_array_dimensions` back to the `GLMHMMValidator`. This is because checking the array dimensions is redundant with shape checking, and I believe we should remove this step altogether. However, to limit updates to `GLMHMMValidator` for now, I moved this function instead of removing this step. 
3. `validate_and_cast_is_new_session` is a new validation check specifically for `is_new_session`. It calls the utils function **`initialize_is_new_session`**, which allows `is_new_session` to be `None`, a boolean array, an integer array, or an interval set. Error checking in handled inside this function. Before returning the validated `is_new_session`, it calls the utils function **`shift_nan_is_new_session`** to make sure all new-session markers are moved off of NaN values in X and/or y.

## Outstanding questions / concerns
- is it OK that we reintroduce the requirement that HMM params must always come last in the inheriting model's user params? it's the only way to generically and simply concatenate all user params in `_model_specific_initialization` to pass through the parameter validation sequence. we can't use the indices of the HMM params, because for jax compatibility, we can't insert them in-place, and recreating the array also assumes knowledge of the index (and number) of the model params, which is model dependent. if we want to avoid this assumption, we can remove `_model_specific_initialization` from `BaseHMM` and have the inheriting class handle model-specific initialization. However, I don't find the assumption to be too limiting in general.
- Similar to how it was implemented in `GLMHMM`, `_model_specific_initialization` will validate the generated parameters if they were created by custom functions. However, this is redundant with checks I had in place in `generate_hmm_initial_params`. Should I remove the shape and output sum checks from `generate_hmm_initial_params`?
- I think we should rename and/or combine the dirichlet prior parameters. Should we do that in this PR or make a small one after?
- The way NaN's in the middle of sessions are handled now is different than before. Before, you were adding new session indicators after any NaN break, where now session indicators are only _moved_ if they fall during a NaN, not added. This is negligible if we don't allow NaN's to fall in the middle of the session. But if we want to allow that behavior in the future, we will want to think about how to handle it. Some thoughts:
    - I don't know if we can make any judgements on whether to treat a trial with a NaN value as if it never happened, or as a new session. If this occurs for some reason other than convolution, i.e. an animal has a violation trial, it's up to the experimenter on how they want to deal with this, not us. They should be the ones responsible for dropping those trials or updating a new session boundary as they see fit.
    - If the NaNs are occurring at session edges from convolution: if this is being done using pynapple time supports to segment the data, then theoretically the current approach should be sufficient to handle it IF the user doesn't pass anything for `is_new_session`. ideally, the time support used for the convolution will be the same that is used to identify session boundaries. they will each get shifted off any NaN values at the start of the sessions, and any NaN values at the ends of sessions can be dropped without worry. But if they do pass another value for `is_new_session`? I don't know
- the checks inside `initialize_is_new_session` makes it no longer jittable. Therefore, I had to remove calls to this function in the EM functions. This makes it such that `is_new_session` will still default to a single session if `None`, but no checks are performed (i.e. the first index is no longer ensured to be 1) if the user passes something. I think this is OK because this will be enforced within the model when validating `is_new_session`, and anyone using the EM algorithms outside of the model already does so at their own risk
