### PR TITLE
Add common inference methods into `BaseHMM`

### DIFF
--- a/src/nemos/glm_hmm/algorithm_configs.py
+++ b/src/nemos/glm_hmm/algorithm_configs.py
@@ -224,7 +224,7 @@ def prepare_estep_log_likelihood(
             out_axes=state_axes,
         )
 
-    def log_likelihood(X, y, params):
+    def log_likelihood(params, X, y):
         rate = compute_rate_per_state(X, params, inverse_link_function)
         scale = jnp.exp(params.log_scale) if params.log_scale is not None else None
         log_like = log_likelihood_per_sample(y, rate, scale)

--- a/src/nemos/hmm/expectation_maximization.py
+++ b/src/nemos/hmm/expectation_maximization.py
@@ -264,7 +264,7 @@ def forward_pass(
     )
 
     # Compute log-likelihoods
-    log_conditionals = log_likelihood_func(X, y, model_params)
+    log_conditionals = log_likelihood_func(model_params, X, y)
 
     # Compute forward pass
     log_alphas, log_normalizers = _forward_pass(
@@ -455,7 +455,7 @@ def forward_backward(
     )
 
     # Compute log-likelihoods
-    log_conditionals = log_likelihood_func(X, y, model_params)
+    log_conditionals = log_likelihood_func(model_params, X, y)
 
     # Compute forward pass
     log_alphas, log_normalization = _forward_pass(
@@ -915,7 +915,7 @@ def max_sum(
         else jnp.zeros(y.shape[0], dtype=bool).at[0].set(1)
     )
 
-    log_emission = log_likelihood_func(X, y, model_params)
+    log_emission = log_likelihood_func(model_params, X, y)
 
     # Forward pass: similar to forward-backward, scan over all time points
     def forward_max_sum(omega_prev, xs):

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import abc
+import warnings
 from numbers import Number
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Literal, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
+import pynapple as nap
+from numpy.typing import ArrayLike, NDArray
 
+from .. import tree_utils
 from ..base_regressor import BaseRegressor
+from ..hmm.expectation_maximization import (
+    forward_backward,
+    forward_pass,
+    max_sum,
+)
 from ..regularizer import Regularizer
+from ..type_casting import support_pynapple
 from ..typing import (
     DESIGN_INPUT_TYPE,
 )
@@ -22,6 +32,7 @@ from .initialize_parameters import (
     setup_hmm_initialization,
 )
 from .params import HMMModelParamsT, HMMUserParams, HMMUserProvidedParamsT
+from .utils import _check_state_format
 from .validation import HMMValidator
 
 
@@ -384,3 +395,347 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
             X=X, y=y, is_new_session=is_new_session
         )
         return params, X, y, is_new_session
+
+    @abc.abstractmethod
+    def _log_likelihood(self, params: HMMModelParamsT, X, y):
+        """Compute the log-likelihood of the data given the model parameters."""
+        pass
+
+    def _score(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Private score compute."""
+        # filter for non-nans, grab data if needed
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+
+        # smooth with forward backward
+        _, log_norm = forward_pass(
+            params=params,
+            X=data,
+            y=y,
+            is_new_session=is_new_session,
+            # do we store this in the model during initialization?
+            log_likelihood_func=self._log_likelihood,
+        )
+        return jnp.sum(log_norm)
+
+    def score(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: ArrayLike,
+        is_new_session: Optional[ArrayLike] = None,
+        score_type: Literal[
+            "log-likelihood", "pseudo-r2-McFadden", "pseudo-r2-Cohen"
+        ] = "log-likelihood",
+        null_model: Optional[Literal["constant", "glm"]] = None,
+    ) -> jnp.ndarray:
+        """Compute the model score."""
+        if score_type == "log-likelihood" and null_model is not None:
+            warnings.warn(
+                "The null model is not used for the log-likelihood computation.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if score_type != "log-likelihood":
+            raise NotImplementedError(
+                f"score of type {score_type} not implemented yet!"
+            )
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        return self._score(params, X, y, is_new_session)
+
+    @support_pynapple(conv_type="jax")
+    def _smooth_proba(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Private smooth_proba compute."""
+        # filter for non-nans, grab data if needed
+        valid = tree_utils.get_valid_multitree(X, y)
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+
+        # smooth with forward backward
+        log_posteriors, _, _, _, _, _ = forward_backward(
+            params=params,
+            X=data,
+            y=y,
+            is_new_session=is_new_session,
+            log_likelihood_func=self._log_likelihood,
+        )
+        proba = jnp.exp(log_posteriors)
+        # renormalize (numerical precision due to exponentiation)
+        proba /= proba.sum(axis=1, keepdims=True)
+        # re-attach nans
+        proba = jnp.full((valid.shape[0], proba.shape[1]), jnp.nan).at[valid].set(proba)
+        return proba
+
+    def smooth_proba(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: Optional[ArrayLike] = None,
+    ) -> jnp.ndarray | nap.TsdFrame:
+        """Compute smoothing posterior probabilities over hidden states.
+
+        Computes the probability of being in each hidden state at each time point,
+        conditioned on the entire observed sequence. This method uses the forward-backward
+        algorithm to incorporate information from both past and future observations,
+        providing optimal state estimates given all available data.
+
+        The smoothing posteriors answer: "Given all observations, what is the probability
+        that the system was in state k at time t?"
+
+        Parameters
+        ----------
+        X
+            Predictors, shape ``(n_time_points, n_features)``.
+        y
+            Observations, shape ``(n_time_points,)`` for single observation or
+            ``(n_time_points, n_observations)`` for population.
+
+        Returns
+        -------
+        posteriors
+            Smoothing posterior probabilities, shape ``(n_time_points, n_states)``.
+            Each row sums to 1 and represents the probability distribution over states
+            at that time point.
+
+        Raises
+        ------
+        ValueError
+            If the model has not been fit (``fit()`` must be called first).
+        ValueError
+            If inputs contain NaN values in the middle of epochs (only boundary NaNs allowed).
+        ValueError
+            If X and y have inconsistent shapes or features.
+
+        See Also
+        --------
+        filter_proba : Compute filtering posteriors (conditioned on past observations only).
+        decode_state : Compute most likely state sequence (Viterbi decoding).
+
+        Notes
+        -----
+        - Smoothing provides better state estimates than filtering because it uses all data
+        - The algorithm properly handles session boundaries and NaN values at epoch borders
+        """
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        return self._smooth_proba(params, X, y, is_new_session)
+
+    @support_pynapple(conv_type="jax")
+    def _filter_proba(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Compute filtering probabilities without validation (internal method)."""
+        # filter for non-nans, grab data if needed
+        valid = tree_utils.get_valid_multitree(X, y)
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+        log_proba, _ = forward_pass(
+            params,
+            data,
+            y,
+            is_new_session=is_new_session,
+            log_likelihood_func=self._log_likelihood,
+        )
+        proba = jnp.exp(log_proba)
+        # renormalize (numerical errors due to exponentiating)
+        proba /= proba.sum(axis=1, keepdims=True)
+        # re-attach nans
+        proba = jnp.full((valid.shape[0], proba.shape[1]), jnp.nan).at[valid].set(proba)
+        return proba
+
+    def filter_proba(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: Optional[ArrayLike] = None,
+    ) -> jnp.ndarray | nap.TsdFrame:
+        """Compute filtering posterior probabilities over hidden states.
+
+        Computes the probability of being in each hidden state at each time point,
+        conditioned only on observations up to that time point. This method uses the
+        forward pass of the forward-backward algorithm, providing causal (online) state
+        estimates that only use past and current observations.
+
+        The filtering posteriors answer: "Given observations up to time t, what is the
+        probability that the system is in state k at time t?"
+
+        Parameters
+        ----------
+        X
+            Predictors, shape ``(n_time_points, n_features)``.
+        y
+            Observations, shape ``(n_time_points,)`` for single observation or
+            ``(n_time_points, n_observations)`` for population.
+
+        Returns
+        -------
+        posteriors
+            Filtering posterior probabilities, shape ``(n_time_points, n_states)``.
+            Each row sums to 1 and represents the probability distribution over states
+            at that time point conditioned on past observations.
+
+        Raises
+        ------
+        ValueError
+            If the model has not been fit (``fit()`` must be called first).
+        ValueError
+            If inputs contain NaN values in the middle of epochs (only boundary NaNs allowed).
+        ValueError
+            If X and y have inconsistent shapes or features.
+
+        See Also
+        --------
+        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
+        decode_state : Compute most likely state sequence (Viterbi decoding).
+
+        Notes
+        -----
+        - Filtering provides causal state estimates suitable for online/real-time applications
+        - Smoothing provides better estimates but requires all data (non-causal)
+        - The algorithm properly handles session boundaries and NaN values at epoch borders
+        - NaN values are removed before inference, but session markers are preserved
+        - For pynapple inputs, the output TsdFrame has columns named "state_0", "state_1", etc.
+        """
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        return self._filter_proba(params, X, y, is_new_session)
+
+    @support_pynapple(conv_type="jax")
+    def _decode_state(
+        self,
+        params: HMMModelParamsT,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: Union[NDArray, jnp.ndarray, nap.Tsd],
+        is_new_session: jnp.ndarray,
+        return_index: bool,
+    ) -> jnp.ndarray:
+        """Decode most likely state sequence without validation (internal method)."""
+        # filter for non-nans, grab data if needed
+        valid = tree_utils.get_valid_multitree(X, y)
+        data, y, is_new_session = self._preprocess_inputs(X, y, is_new_session)
+
+        # safe conversion to jax arrays of float
+        params = jax.tree_util.tree_map(lambda x: jnp.asarray(x, y.dtype), params)
+
+        # make sure is_new_session starts with a 1
+        is_new_session = is_new_session.at[0].set(True)
+
+        decoded_states = max_sum(
+            params,
+            data,
+            y,
+            is_new_session=is_new_session,
+            log_likelihood_func=self._log_likelihood,
+            return_index=return_index,
+        )
+
+        # reattach nans
+        decoded_states = (
+            jnp.full((valid.shape[0], *decoded_states.shape[1:]), jnp.nan)
+            .at[valid]
+            .set(decoded_states)
+        )
+        return decoded_states
+
+    def decode_state(
+        self,
+        X: Union[DESIGN_INPUT_TYPE, ArrayLike],
+        y: ArrayLike,
+        is_new_session: Optional[ArrayLike] = None,
+        state_format: Literal["one-hot", "index"] = "one-hot",
+    ) -> jnp.ndarray | nap.TsdFrame:
+        """Compute the most likely hidden state sequence (Viterbi decoding).
+
+        Finds the single most likely sequence of hidden states that best explains
+        the observed data. This method uses the Viterbi (max-sum) algorithm to
+        compute the state sequence that maximizes the joint probability of states
+        and observations.
+
+        Unlike ``smooth_proba()`` and ``filter_proba()`` which return probability
+        distributions over states at each time point, this method makes a deterministic
+        choice of the single best state sequence.
+
+        The decoded states answer: "What is the most likely sequence of states that
+        generated the observed data?"
+
+        Parameters
+        ----------
+        X
+            Predictors, shape ``(n_time_points, n_features)``.
+        y
+            Observations, shape ``(n_time_points,)`` for single observation or
+            ``(n_time_points, n_observations)`` for population.
+        state_format
+            Format of the returned states:
+
+            - ``"one-hot"``: Binary matrix of shape ``(n_time_points, n_states)`` where
+              each row has a single 1 indicating the decoded state.
+            - ``"index"``: Integer array of shape ``(n_time_points,)`` with values
+              in ``[0, n_states-1]`` indicating the decoded state.
+
+        Returns
+        -------
+        decoded_states
+            Most likely state sequence:
+
+            - If ``state_format="one-hot"``: shape ``(n_time_points, n_states)``.
+              Each row is a one-hot vector with 1 in the position of the decoded state.
+            - If ``state_format="index"``: shape ``(n_time_points,)``.
+              Integer indices of the decoded states.
+
+        Raises
+        ------
+        ValueError
+            If the model has not been fit (``fit()`` must be called first).
+        ValueError
+            If inputs contain NaN values in the middle of epochs (only boundary NaNs allowed).
+        ValueError
+            If X and y have inconsistent shapes or features.
+
+        See Also
+        --------
+        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
+        filter_proba : Compute filtering posteriors (conditioned on past observations only).
+
+        Notes
+        -----
+        - Viterbi decoding finds the globally optimal state sequence, not the sequence
+          of individually most likely states from ``smooth_proba()``
+        - This is a hard assignment (single best path) unlike probabilistic posteriors
+        - The algorithm properly handles session boundaries and NaN values at epoch borders
+        - Decoding is useful for segmenting continuous data into discrete behavioral states
+        - For uncertainty estimates about states, use ``smooth_proba()`` instead
+        """
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        # validate state_format
+        _check_state_format(state_format)
+        # define the return type for the max-sum
+        return_index = False if state_format == "one-hot" else True
+        return self._decode_state(params, X, y, is_new_session, return_index)

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -397,7 +397,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         return params, X, y, is_new_session
 
     @abc.abstractmethod
-    def _log_likelihood(self, params: HMMModelParamsT, X, y):
+    def _log_likelihood(
+        self, params: HMMModelParamsT, X: DESIGN_INPUT_TYPE, y: ArrayLike
+    ) -> jnp.ndarray:
         """Compute the log-likelihood of the data given the model parameters."""
         pass
 

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -440,7 +440,36 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         ] = "log-likelihood",
         null_model: Optional[Literal["constant", "glm"]] = None,
     ) -> jnp.ndarray:
-        """Compute the model score."""
+        """
+        Compute the model score.
+
+        Scores the model by computing the log-likelihood of the data given the model parameters.
+        Other score metrics are currently not implemented.
+
+        Parameters
+        ----------
+        X :
+            Input data/design matrix, shape ``(n_samples, n_features)``.
+        y :
+            Output data/observations, shape ``(n_samples, n_observations)``.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_samples,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
+        score_type :
+            The type of score to compute. Currently, only "log-likelihood" is implemented.
+        null_model :
+            Used for scoring metrics that require a null model (e.g., pseudo-R2).
+            Currently not used as only log-likelihood is implemented.
+
+        Returns
+        -------
+        :
+            The computed model score.
+        """
         if score_type == "log-likelihood" and null_model is not None:
             warnings.warn(
                 "The null model is not used for the log-likelihood computation.",
@@ -539,8 +568,10 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         See Also
         --------
-        filter_proba : Compute filtering posteriors (conditioned on past observations only).
-        decode_state : Compute most likely state sequence (Viterbi decoding).
+        :meth:`~nemos.hmm.BaseHMM.filter_proba`
+            Compute filtering posteriors (conditioned on past observations only).
+        :meth:`~nemos.hmm.BaseHMM.decode_state`
+            Compute most likely state sequence (Viterbi decoding).
 
         Notes
         -----
@@ -633,8 +664,10 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         See Also
         --------
-        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
-        decode_state : Compute most likely state sequence (Viterbi decoding).
+        :meth:`~nemos.hmm.BaseHMM.smooth_proba`
+            Compute smoothing posteriors (conditioned on all observations).
+        :meth:`~nemos.hmm.BaseHMM.decode_state`
+            Compute most likely state sequence (Viterbi decoding).
 
         Notes
         -----
@@ -750,8 +783,10 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         See Also
         --------
-        smooth_proba : Compute smoothing posteriors (conditioned on all observations).
-        filter_proba : Compute filtering posteriors (conditioned on past observations only).
+        :meth:`~nemos.hmm.BaseHMM.smooth_proba`
+            Compute smoothing posteriors (conditioned on all observations).
+        :meth:`~nemos.hmm.BaseHMM.filter_proba`
+            Compute filtering posteriors (conditioned on past observations only).
 
         Notes
         -----

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -451,7 +451,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
             raise NotImplementedError(
                 f"score of type {score_type} not implemented yet!"
             )
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         return self._score(params, X, y, is_new_session)
 
     @support_pynapple(conv_type="jax")
@@ -506,15 +508,22 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
 
         Parameters
         ----------
-        X
+        X :
             Predictors, shape ``(n_time_points, n_features)``.
-        y
+        y :
             Observations, shape ``(n_time_points,)`` for single observation or
             ``(n_time_points, n_observations)`` for population.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_time_points,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
 
         Returns
         -------
-        posteriors
+        posteriors :
             Smoothing posterior probabilities, shape ``(n_time_points, n_states)``.
             Each row sums to 1 and represents the probability distribution over states
             at that time point.
@@ -538,7 +547,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         - Smoothing provides better state estimates than filtering because it uses all data
         - The algorithm properly handles session boundaries and NaN values at epoch borders
         """
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         return self._smooth_proba(params, X, y, is_new_session)
 
     @support_pynapple(conv_type="jax")
@@ -596,6 +607,13 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         y
             Observations, shape ``(n_time_points,)`` for single observation or
             ``(n_time_points, n_observations)`` for population.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_time_points,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
 
         Returns
         -------
@@ -626,7 +644,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         - NaN values are removed before inference, but session markers are preserved
         - For pynapple inputs, the output TsdFrame has columns named "state_0", "state_1", etc.
         """
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         return self._filter_proba(params, X, y, is_new_session)
 
     @support_pynapple(conv_type="jax")
@@ -694,6 +714,13 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         y
             Observations, shape ``(n_time_points,)`` for single observation or
             ``(n_time_points, n_observations)`` for population.
+        is_new_session :
+            Optional array indicating user-provided session boundaries. Can be:
+            - a boolean array indicating session starts, shape ``(n_time_points,)``
+            - an integer array of indices marking session starts, shape ``(n_sessions,)``
+            - a pynapple.IntervalSet marking session epochs (requires either X or y to be a
+            pynapple Tsd or TsdFrame to get timestamps)
+            If None, creates a default array treating all data as one session.
         state_format
             Format of the returned states:
 
@@ -735,7 +762,9 @@ class BaseHMM(BaseRegressor[HMMModelParamsT, HMMUserProvidedParamsT]):
         - Decoding is useful for segmenting continuous data into discrete behavioral states
         - For uncertainty estimates about states, use ``smooth_proba()`` instead
         """
-        params, X, y, is_new_session = self._validate_and_prepare_inputs(X, y)
+        params, X, y, is_new_session = self._validate_and_prepare_inputs(
+            X, y, is_new_session
+        )
         # validate state_format
         _check_state_format(state_format)
         # define the return type for the max-sum

--- a/tests/test_glm_hmm_algorithms.py
+++ b/tests/test_glm_hmm_algorithms.py
@@ -1002,7 +1002,7 @@ class TestMStep:
             inverse_link_function=obs.default_inverse_link_function,
         )
         log_conditionals = log_likelihood(
-            X, y, GLMHMMModelParams(coef, jnp.ones(coef.shape[-1]))
+            GLMHMMModelParams(coef, jnp.ones(coef.shape[-1])), X, y
         )
         new_sess = np.zeros(10)
         new_sess[0] = 1
@@ -2237,7 +2237,7 @@ class TestViterbi:
         )
 
         # to be in the correct for for max_sum
-        def log_like_func_max_sum(X, y, params):
+        def log_like_func_max_sum(params, X, y):
             predicted_rate = inverse_link_function(X @ params.coef + params.intercept)
             return log_like_func(y, predicted_rate)
 
@@ -2285,7 +2285,7 @@ class TestViterbi:
         )
 
         # to be in the correct for for max_sum
-        def log_like_func_max_sum(X, y, params):
+        def log_like_func_max_sum(params, X, y):
             predicted_rate = inverse_link_function(X @ params.coef + params.intercept)
             return log_like_func(y, predicted_rate)
 

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -22,6 +22,7 @@ from nemos.hmm.initialize_parameters import (
     uniform_transition_proba_init,
 )
 from nemos.hmm.params import HMMParams
+from nemos.hmm.utils import initialize_is_new_session
 from nemos.hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
 from nemos.params import ModelParams
 
@@ -63,13 +64,15 @@ class MockHMMValidator(HMMValidator[MockHMMUserParams, MockHMMParams]):
     to_model_params: Callable[[MockHMMUserParams], MockHMMParams] = to_mock_params
     from_model_params: Callable[[MockHMMParams], MockHMMUserParams] = from_mock_params
     model_class: str = "MockHMM"
+    X_dimensionality: int = 2
+    y_dimensionality: int = 1
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
         *RegressorValidator.params_validation_sequence[:2],
         *HMMValidator.params_validation_sequence,
         *RegressorValidator.params_validation_sequence[3:],
     )
 
-    def validate_consistency(self, params: MockHMMParams) -> None:
+    def validate_consistency(self, *args, **kwargs) -> None:
         return True
 
 
@@ -122,15 +125,16 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
         )
 
     def _check_model_is_fit(self):
-        BaseHMM._check_is_fit(self)
         if self.param_ is None:
             raise ValueError("Model is not fitted yet.")
 
     def _get_model_params(self) -> MockHMMParams:
         return self._validator.to_model_params(
-            self.param_,
-            self.log_initial_prob_,
-            self.log_transition_prob_,
+            (
+                self.param_,
+                self.initial_prob_,
+                self.transition_prob_,
+            )
         )
 
     def _set_model_params(self, params):
@@ -139,17 +143,19 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
         self.initial_prob_ = initial_prob
         self.transition_prob_ = transition_prob
 
-    def _log_likelihood(self, params, X, y):
-        pass
+    def _log_likelihood(self, X, y, params):
+        return jnp.zeros((y.shape[0], self.n_states))
 
     def _model_params_initialization(self, X, y, is_new_session):
         return (
-            jnp.zeros(self._n_states),
+            jnp.arange(self._n_states),
             False,
         )
 
     def fit(self, X, y, is_new_session=None, init_params=None):
-        pass
+        is_new_session = initialize_is_new_session(X, y, is_new_session)
+        fit_params = self._model_specific_initialization(X, y, is_new_session)
+        self._set_model_params(fit_params)
 
     def _initialize_optimizer_and_state(self, *args, **kwargs):
         pass
@@ -1085,3 +1091,408 @@ class TestHMMNewSession:
             is_new_session = model._validator.validate_and_cast_is_new_session(
                 X, y, is_new_session
             )
+
+
+class TestHMMInference:
+    """Test suite for inference methods (smooth_proba, filter_proba, decode_state)."""
+
+    @staticmethod
+    def _get_expected_shape(method_name, kwargs, n_samples, n_states):
+        """Helper to compute expected output shape based on method and kwargs."""
+        if method_name in ["smooth_proba", "filter_proba"]:
+            return (n_samples, n_states)
+        elif method_name == "decode_state":
+            if kwargs.get("state_format") == "index":
+                return (n_samples,)
+            else:  # one-hot (default)
+                return (n_samples, n_states)
+        else:
+            raise ValueError(f"Unknown method: {method_name}")
+
+    @pytest.mark.parametrize(
+        "drop_attr",
+        ["initial_prob_", "transition_prob_"],
+    )
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_not_fitted_raises_error(self, drop_attr, method_config):
+        """Test that inference methods raise an error when model is not fitted."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        model.fit(np.random.rand(10, 2), np.random.rand(10))
+        setattr(model, drop_attr, None)
+        with pytest.raises(
+            ValueError,
+            match=rf"This MockHMM instance is not fitted yet. .+ \['{drop_attr}'\]",
+        ):
+            getattr(model, method_name)(None, None, **kwargs)
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_returns_correct_shape(self, method_config):
+        """Test that inference methods return arrays with correct shapes."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+
+        # Get output
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+        out = getattr(model, method_name)(X, y, **kwargs)
+
+        # Check shape
+        n_samples = (~np.isnan(np.sum(y, axis=tuple(range(1, y.ndim))))).sum()
+        n_states = model.n_states
+        expected_shape = self._get_expected_shape(
+            method_name, kwargs, n_samples, n_states
+        )
+        assert (
+            out.shape == expected_shape
+        ), f"Expected shape {expected_shape}, got {out.shape}"
+
+    @pytest.mark.parametrize("method_name", ["smooth_proba", "filter_proba"])
+    def test_posterior_proba_returns_valid_probabilities(self, method_name):
+        """Test that smooth_proba returns valid probabilities (between 0 and 1, summing to 1)."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Get posteriors
+        posteriors = getattr(model, method_name)(X, y)
+
+        # Check all values are between 0 and 1
+        assert jnp.all(posteriors >= 0), "Some posteriors are negative"
+        assert jnp.all(posteriors <= 1), "Some posteriors are greater than 1"
+
+        # Check sum across states
+        row_sums = jnp.sum(posteriors, axis=1)
+        assert jnp.allclose(
+            row_sums, 1.0, rtol=1e-5
+        ), f"Probabilities don't sum to 1. Min: {row_sums.min()}, Max: {row_sums.max()}"
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_with_arrays(self, method_config):
+        """Test inference methods with numpy/jax arrays return jax array."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Test with numpy array
+        out = getattr(model, method_name)(X, y, **kwargs)
+        assert isinstance(out, jnp.ndarray), f"Expected jnp.ndarray, got {type(out)}"
+
+    @pytest.mark.parametrize("input_type", ["X", "y", "both"])
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_with_pynapple_returns_tsdframe(self, input_type, method_config):
+        """Test that inference methods return TsdFrame/Tsd when input is pynapple."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Convert to pynapple
+        n_samples = X.shape[0]
+        time = np.linspace(0, n_samples / 100, n_samples)
+
+        if input_type in ["X", "both"]:
+            X = nap.TsdFrame(t=time, d=X)
+        if input_type in ["y", "both"]:
+            y = nap.Tsd(t=time, d=y)
+
+        # Get output
+        out = getattr(model, method_name)(X, y, **kwargs)
+
+        # Check return type - decode_state with index format returns Tsd, others return TsdFrame
+        if method_name == "decode_state" and kwargs.get("state_format") == "index":
+            assert isinstance(out, nap.Tsd), f"Expected nap.Tsd, got {type(out)}"
+            assert out.shape == (n_samples,)
+        else:
+            assert isinstance(
+                out, nap.TsdFrame
+            ), f"Expected nap.TsdFrame, got {type(out)}"
+            assert out.shape == (n_samples, model.n_states)
+        assert jnp.allclose(out.t, time)
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_with_multiple_sessions(self, method_config):
+        """Test inference methods with multiple sessions (pynapple epochs)."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Create multi-session data
+        n_samples = X.shape[0]
+        session_1_end = n_samples // 2
+
+        time = np.linspace(0, n_samples / 100, n_samples)
+        epochs = nap.IntervalSet(
+            start=[time[0], time[session_1_end]],
+            end=[time[session_1_end - 1], time[-1]],
+        )
+
+        X_tsd = nap.TsdFrame(t=time, d=X, time_support=epochs)
+        y_tsd = nap.Tsd(t=time, d=y, time_support=epochs)
+
+        # Get output
+        out = getattr(model, method_name)(X_tsd, y_tsd, **kwargs)
+
+        # Check shape and type
+        if method_name == "decode_state" and kwargs.get("state_format") == "index":
+            assert isinstance(out, nap.Tsd)
+            assert out.shape == (n_samples,)
+        else:
+            assert isinstance(out, nap.TsdFrame)
+            assert out.shape == (n_samples, model.n_states)
+
+        # Check probabilities are valid for proba methods
+        if method_name in ["smooth_proba", "filter_proba"]:
+            assert jnp.all(out.values >= 0)
+            assert jnp.all(out.values <= 1)
+            row_sums = jnp.sum(out.values, axis=1)
+            assert jnp.allclose(row_sums, 1.0, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "method_config",
+        [
+            pytest.param(("smooth_proba", {}), id="smooth_proba"),
+            pytest.param(("filter_proba", {}), id="filter_proba"),
+            pytest.param(("decode_state", {}), id="decode_state-onehot"),
+            pytest.param(
+                ("decode_state", {"state_format": "index"}), id="decode_state-index"
+            ),
+        ],
+    )
+    def test_consistency_across_calls(self, method_config):
+        """Test that inference methods return consistent results across multiple calls."""
+        method_name, kwargs = method_config
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Get output twice
+        out_1 = getattr(model, method_name)(X, y, **kwargs)
+        out_2 = getattr(model, method_name)(X, y, **kwargs)
+
+        # Check consistency
+        assert jnp.allclose(
+            out_1, out_2
+        ), f"{method_name} returns different results on consecutive calls"
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_single_sample(self, method_name):
+        """Test smooth_proba with a single sample."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(1, 2)
+        y = np.random.rand(1)
+        model.fit(X, y)
+
+        # Get posteriors for single sample
+        out = getattr(model, method_name)(X, y)
+
+        # Check shape
+        assert out.shape == (1, model.n_states)
+
+        if method_name != "decode_state":
+            # Check probabilities are valid
+            assert jnp.all(out >= 0)
+            assert jnp.all(out <= 1)
+            assert jnp.allclose(jnp.sum(out), 1.0, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_with_nans_filtered(self, method_name):
+        """Test that smooth_proba handles NaNs properly by filtering them."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.fit(X, y)
+
+        # Create data with NaNs
+        X_with_nan = X.copy()
+        y_with_nan = y.copy()
+
+        # Add NaNs at specific indices
+        nan_indices = [0, 1, 2]
+        X_with_nan[nan_indices] = np.nan
+
+        # This should work - NaNs get filtered internally
+        posteriors = getattr(model, method_name)(X_with_nan, y_with_nan)
+
+        # Check that we get valid output (NaN rows filtered)
+        assert posteriors.shape[1] == model.n_states
+        # After filtering NaNs, shape[0] should be reduced
+        assert posteriors.shape[0] == X.shape[0]
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    @pytest.mark.parametrize("nan_location", [[], [0, 1, 10, 11, 12]])
+    def test_pynapple_in_pynapple_out_X(self, method_name, nan_location):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        X[nan_location] = np.nan
+        ep = nap.IntervalSet([0, 10], [9, 500])
+        X = nap.TsdFrame(t=np.arange(X.shape[0]), d=X, time_support=ep)
+        out = getattr(model, method_name)(X, y)
+        assert isinstance(out, nap.TsdFrame), "Did not return pynapple!"
+        assert np.all(
+            np.isnan(out[nan_location])
+        ), "Not returning NaNs in the expected location!"
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    @pytest.mark.parametrize("nan_location", [[], [0, 1, 10, 11, 12]])
+    def test_pynapple_in_pynapple_out_y(self, method_name, nan_location):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        y[nan_location] = np.nan
+        ep = nap.IntervalSet([0, 10], [9, 500])
+        y = nap.Tsd(t=np.arange(y.shape[0]), d=y, time_support=ep)
+        posteriors = getattr(model, method_name)(X, y)
+        assert isinstance(posteriors, nap.TsdFrame), "Did not return pynapple!"
+        assert np.all(
+            np.isnan(posteriors[nan_location])
+        ), "Not returning NaNs in the expected location!"
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_int_vs_float_y(self, method_name):
+        """Test that integer and float y with same values give same posteriors.
+
+        This is a regression test for a bug where y.dtype was used to cast params
+        before preprocessing, causing integer y to round float params to integers.
+        """
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        y = np.round(y)
+        y_float = y.astype(float)
+        y_int = y.astype(int)
+
+        # Get posteriors with float y
+        out_float = getattr(model, method_name)(X, y_float)
+
+        # Get posteriors with int y (same values)
+        out_int = getattr(model, method_name)(X, y_int)
+
+        # Posteriors should be identical regardless of y dtype
+        np.testing.assert_allclose(
+            out_float,
+            out_int,
+            rtol=1e-10,
+            err_msg=f"{method_name} gives different results for int vs float y with same values",
+        )
+
+    def test_onehot_vs_index_decode(self):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        out_onehot = model.decode_state(X, y, state_format="one-hot")
+        out_index = model.decode_state(X, y, state_format="index")
+        assert jnp.all(
+            jnp.where(out_onehot == 1)[1] == out_index
+        ), "index and one-hot do not match!"
+        assert jnp.all(
+            out_onehot.sum(axis=1) == 1
+        ), "more than one hot value in one-hot array!"
+
+    def test_decode_state_invalid_state_format(self):
+        """Test that decode_state raises ValueError for invalid state_format."""
+        model = MockHMM(n_states=3)
+        X = np.random.rand(100, 2)
+        y = np.random.rand(100)
+        model.fit(X, y)
+        with pytest.raises(ValueError, match="Invalid state_format"):
+            model.decode_state(X, y, state_format="invalid")
+
+    @pytest.mark.parametrize("n_states", [2, 3, 5])
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_different_n_states(self, n_states, method_name):
+        """Test smooth_proba with different numbers of states."""
+        model = MockHMM(n_states=n_states)
+        n_samples, n_features = 100, 2
+        X = np.random.rand(n_samples, n_features)
+        y = np.random.rand(n_samples)
+        model.fit(X, y)
+
+        out = getattr(model, method_name)(X, y)
+
+        # Check shape
+        assert out.shape == (
+            n_samples,
+            n_states,
+        ), f"Expected shape ({n_samples}, {n_states}), got {out.shape}"
+
+        # Check probabilities are valid
+        assert jnp.all(out >= 0)
+        assert jnp.all(out <= 1)
+        row_sums = jnp.sum(out, axis=1)
+        assert jnp.allclose(row_sums, 1.0)

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -143,7 +143,7 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams]):
         self.initial_prob_ = initial_prob
         self.transition_prob_ = transition_prob
 
-    def _log_likelihood(self, X, y, params):
+    def _log_likelihood(self, params, X, y):
         return jnp.zeros((y.shape[0], self.n_states))
 
     def _model_params_initialization(self, X, y, is_new_session):
@@ -1378,7 +1378,6 @@ class TestHMMInference:
 
         # Check that we get valid output (NaN rows filtered)
         assert posteriors.shape[1] == model.n_states
-        # After filtering NaNs, shape[0] should be reduced
         assert posteriors.shape[0] == X.shape[0]
 
     @pytest.mark.parametrize(
@@ -1496,3 +1495,32 @@ class TestHMMInference:
         assert jnp.all(out <= 1)
         row_sums = jnp.sum(out, axis=1)
         assert jnp.allclose(row_sums, 1.0)
+
+    @pytest.mark.parametrize(
+        "method_name", ["smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_is_new_session_is_used(self, method_name):
+        model = MockHMM(n_states=3)
+        X = np.random.rand(10, 2)
+        y = np.random.rand(10)
+        model.param_ = jnp.ones((3,))
+        model.initial_prob_ = jnp.array([0.8, 0.1, 0.1])
+        model.transition_prob_ = jnp.array(
+            [[0.1, 0.8, 0.1], [0.1, 0.1, 0.8], [0.8, 0.1, 0.1]]
+        )
+        out_all_new_sess = getattr(model, method_name)(
+            X, y, is_new_session=np.ones(10, dtype=bool)
+        )
+        assert np.all(
+            out_all_new_sess == out_all_new_sess[0]
+        ), "Output should be the same for all time points"
+        out_default = getattr(model, method_name)(X, y)
+        assert not np.allclose(
+            out_all_new_sess, out_default
+        ), "Output with all new sessions should not match default output"
+        out_no_new_sess = getattr(model, method_name)(
+            X, y, is_new_session=np.zeros(10, dtype=bool)
+        )
+        assert jnp.allclose(
+            out_no_new_sess, out_default
+        ), "Output with no new sessions should match default output"


### PR DESCRIPTION
## Summary
This PR reintroduces the inference methods `score`, `smooth_proba`, `filter_proba`, and `decode_state` (and their private counterparts) into `BaseHMM`. These functions are very similar to the original GLM-HMM versions with a few changes:
- `is_new_session` has been added as an optional input argument
- examples were removed (they should be re-added by the inheriting model)
- calls to EM functions were updated to match the new signatures

The (probably) most important change: A new abstract method for `_log_likelihood` was added, which needs to be implemented in the inheriting class. This is what gets passed as the `log_likelihood_func` to the EM algorithms. For the GLM-HMM, this just means storing the output of `prepare_estep_log_likelihood` into this method