### PR TITLE
pynapple>=0.11 for docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "tox-uv",                       # Run tox with uv for faster installs
 ]
 docs = [
+    "pynapple>=0.11",               # Required for nap.compute_event_triggered_average(...) in a tutorial
     "numpydoc",
     "sphinx",
     "pydata-sphinx-theme",


### PR DESCRIPTION
The `docs/tutorials/plot_04_v1_cells.md` tutorial now calls `nap.compute_event_triggered_average(...)`, which is a new name introduced in `pynapple 0.11`.
But the project dependency spec in `pyproject.toml` still allows `pynapple>=0.10.1`.

Just added `pynapple>=0.11` to the `docs` dependencies.
All new installs likely resolve to 0.11 anyway, but this should keep normal installs as they are and make sure that the docs build with 0.11.