### PR TITLE
Glm hmm ref init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   CODECOV_OS: ubuntu-latest
-  CODECOV_PY: '3.13'
+  CODECOV_PY: '3.14'
 
 jobs:
   tox_tests_not_solver_related:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 #v7.3.1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
     ruby: "3.3"
   jobs:
     pre_build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "hmmlearn",                     # Test algorithmic implementations of HMM
     "tox-uv",                       # Run tox with uv for faster installs
     "fsspec",
+    "tqdm",
 ]
 docs = [
     "pynapple>=0.11",               # Required for nap.compute_event_triggered_average(...) in a tutorial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,16 @@ dynamic = ["version"]
 authors = [{name = "nemos authors"}]
 description = "NEural MOdelS, a statistical modeling framework for neuroscience."
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.12,<3.15"
 keywords = ["neuroscience", "Poisson-GLM"]
 license = { file = "LICENSE" }
 classifiers = [
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
 
 # Define dependencies for the project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "myst-nb",                      # Test myst_nb utils for glue
     "hmmlearn",                     # Test algorithmic implementations of HMM
     "tox-uv",                       # Run tox with uv for faster installs
+    "fsspec",
 ]
 docs = [
     "pynapple>=0.11",               # Required for nap.compute_event_triggered_average(...) in a tutorial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dev = [
     "scikit-learn",                 # Testing compatibility with CV & pipelines
     "matplotlib>=3.7",              # Needed by doctest to run docstrings examples
     "pooch",                        # Required by doctest for fetch module
-    "dandi",                        # Required by doctest for fetch module
     "seaborn",                      # Required by doctest for _documentation_utils module
     "myst-nb",                      # Test myst_nb utils for glue
     "hmmlearn",                     # Test algorithmic implementations of HMM

--- a/scripts/check_markdown_links.sh
+++ b/scripts/check_markdown_links.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 MARKDOWN_LINK_CHECK=$(which markdown-link-check || echo "")
 if [[ -z "$MARKDOWN_LINK_CHECK" ]]; then
@@ -8,80 +7,47 @@ if [[ -z "$MARKDOWN_LINK_CHECK" ]]; then
 fi
 
 CONFIG=".mlc.external.json"
-LOG_FILE=$(mktemp)
+FAILED_FILES=()
+FAILED_DETAILS=""
 
 echo "🔍 Checking external Markdown links..."
 echo "🔎 Using config: $CONFIG"
 
-run_check() {
-    local CONFIG=$1
-
-    # Check root directory
-    echo "📁 Checking root directory..."
-    for file in $(find . -maxdepth 1 -name "*.md"); do
-        echo "📄 Checking $file..."
-        $MARKDOWN_LINK_CHECK -c "$CONFIG" "$file" 2>&1 | tee -a "$LOG_FILE"
-    done
-
-    # Check docs directory (up to 2 levels deep) if it exists
-    if [[ -d "docs" ]]; then
-        echo "📁 Checking docs directory..."
-        for file in $(find docs -maxdepth 2 -name "*.md"); do
-            echo "📄 Checking $file..."
-            $MARKDOWN_LINK_CHECK -c "$CONFIG" "$file" 2>&1 | tee -a "$LOG_FILE"
-        done
+check_file() {
+    local file="$1"
+    echo "📄 Checking $file..."
+    local output
+    output=$($MARKDOWN_LINK_CHECK -c "$CONFIG" "$file" 2>&1)
+    echo "$output"
+    if echo "$output" | grep -q "ERROR:"; then
+        FAILED_FILES+=("$file")
+        # Collect broken-link lines (bracket lines that are not the ✓ passing marker)
+        local broken_lines
+        broken_lines=$(echo "$output" | grep -E "^\s+\[" | grep -vF "[✓]")
+        FAILED_DETAILS+=$'\n'"=== $file ==="$'\n'"${broken_lines}"$'\n'
     fi
 }
 
-run_check "$CONFIG"
+# Check root directory
+echo "📁 Checking root directory..."
+while IFS= read -r -d '' file; do
+    check_file "$file"
+done < <(find . -maxdepth 1 -name "*.md" -print0)
 
-# Check for errors
-if grep -q "ERROR:" "$LOG_FILE"; then
-    echo "🚨 Link check failed! Please fix broken links."
-    exit 1
-else
-    echo "✅ All external links passed validation."
-fi
-#!/bin/bash
-set -e
-
-MARKDOWN_LINK_CHECK=$(which markdown-link-check || echo "")
-if [[ -z "$MARKDOWN_LINK_CHECK" ]]; then
-    echo "❌ ERROR: markdown-link-check command not found. Install it globally via:"
-    exit 1
+# Check docs directory (up to 2 levels deep) if it exists
+if [[ -d "docs" ]]; then
+    echo "📁 Checking docs directory..."
+    while IFS= read -r -d '' file; do
+        check_file "$file"
+    done < <(find docs -maxdepth 2 -name "*.md" -print0)
 fi
 
-CONFIG=".mlc.external.json"
-LOG_FILE=$(mktemp)
-
-echo "🔍 Checking external Markdown links..."
-echo "🔎 Using config: $CONFIG"
-
-run_check() {
-    local CONFIG=$1
-
-    # Check root directory
-    echo "📁 Checking root directory..."
-    for file in $(find . -maxdepth 1 -name "*.md"); do
-        echo "📄 Checking $file..."
-        $MARKDOWN_LINK_CHECK -c "$CONFIG" "$file" 2>&1 | tee -a "$LOG_FILE"
-    done
-
-    # Check docs directory (up to 2 levels deep) if it exists
-    if [[ -d "docs" ]]; then
-        echo "📁 Checking docs directory..."
-        for file in $(find docs -maxdepth 2 -name "*.md"); do
-            echo "📄 Checking $file..."
-            $MARKDOWN_LINK_CHECK -c "$CONFIG" "$file" 2>&1 | tee -a "$LOG_FILE"
-        done
-    fi
-}
-
-run_check "$CONFIG"
-
-# Check for errors
-if grep -q "ERROR:" "$LOG_FILE"; then
-    echo "🚨 Link check failed! Please fix broken links."
+if [[ ${#FAILED_FILES[@]} -gt 0 ]]; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "🚨 SUMMARY: broken links in ${#FAILED_FILES[@]} file(s):"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "$FAILED_DETAILS"
     exit 1
 else
     echo "✅ All external links passed validation."

--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -129,6 +129,8 @@ VALID_PAIRS = [
     {"transition_proba_init", "transition_proba_init_kwargs"},
     {"initial_proba_init_kwargs", "transition_proba_init_kwargs"},
     {"is_nan", "is_nap"},
+    {"_func", "func"},
+    {"_func", "funcs"},
     {"dirichlet_initial_proba", "dirichlet_transition_proba"},
     {"random_key_pair", "random_key"},
 ]

--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -132,6 +132,8 @@ VALID_PAIRS = [
     {"_func", "func"},
     {"_func", "funcs"},
     {"dirichlet_initial_proba", "dirichlet_transition_proba"},
+    {"glm_params_init", "glm_params_init_kwargs"},
+    {"scale_init_kwargs", "solver_init_kwargs"},
     {"random_key_pair", "random_key"},
 ]
 

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -27,7 +27,6 @@ from . import solvers, tree_utils, utils
 from ._regularizer_builder import AVAILABLE_REGULARIZERS, instantiate_regularizer
 from .base_class import Base
 from .base_validator import RegressorValidator
-from .glm.params import GLMParams
 from .pytrees import FeaturePytree
 from .regularizer import GroupLasso, Regularizer
 from .solvers import SolverProtocol, SolverSpec
@@ -640,10 +639,36 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
                     "Mask has not been set. Defaulting to a single group for all parameters. "
                     "Please see the documentation on GroupLasso regularization for defining a mask."
                 )
+            elif self.regularizer.mask is not None:
+                import equinox as eqx
 
-            if isinstance(self.regularizer.mask, jnp.ndarray):
-                # Wrap into a GLM param structure.
-                self.regularizer.mask = GLMParams(self.regularizer.mask, None)
+                model_pars = self._validator.get_empty_params(data, y)
+                # Skip if mask is already in the internal structured format.
+                if not isinstance(self.regularizer.mask, type(model_pars)):
+                    select_subtrees = (
+                        model_pars.regularizable_subtrees()
+                        if hasattr(model_pars, "regularizable_subtrees")
+                        else [lambda p: p]
+                    )
+                    if len(select_subtrees) == 1:
+                        # Single regularizable param: mask matches its pytree structure (e.g. coef_).
+                        mask_list = [self.regularizer.mask]
+                    else:
+                        mask_list = list(self.regularizer.mask)
+                        if len(mask_list) != len(select_subtrees):
+                            raise ValueError(
+                                f"{type(self).__name__} has {len(select_subtrees)} regularizable "
+                                f"parameters but {len(mask_list)} masks were provided."
+                            )
+                    struct = jax.tree_util.tree_structure(model_pars)
+                    mask_tree = jax.tree_util.tree_unflatten(
+                        struct, [None] * struct.num_leaves
+                    )
+                    for where, m in zip(select_subtrees, mask_list):
+                        mask_tree = eqx.tree_at(
+                            where, mask_tree, m, is_leaf=lambda x: x is None
+                        )
+                    self.regularizer.mask = mask_tree
 
         return data, y, *args
 

--- a/src/nemos/fetch/fetch_data.py
+++ b/src/nemos/fetch/fetch_data.py
@@ -207,12 +207,12 @@ def download_dandi_data(
 
     Examples
     --------
-    >>> import nemos as nmo
-    >>> import pynapple as nap
-    >>> io = nmo.fetch.download_dandi_data("000582",
+    >>> import nemos as nmo  # doctest: +SKIP
+    >>> import pynapple as nap  # doctest: +SKIP
+    >>> io = nmo.fetch.download_dandi_data("000582",  # doctest: +SKIP
     ...                                    "sub-11265/sub-11265_ses-07020602_behavior+ecephys.nwb")
-    >>> nwb = nap.NWBFile(io.read(), lazy_loading=False)
-    >>> print(nwb)
+    >>> nwb = nap.NWBFile(io.read(), lazy_loading=False)  # doctest: +SKIP
+    >>> print(nwb)  # doctest: +SKIP
     07020602
     ┍━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┑
     │ Keys                │ Type     │

--- a/src/nemos/glm_hmm/algorithm_configs.py
+++ b/src/nemos/glm_hmm/algorithm_configs.py
@@ -24,6 +24,11 @@ _ANALYTICAL_SCALE_UPDATE: dict[Type[Observations], Callable] = {
 }
 
 
+def has_fixed_scale(observation_model: Observations) -> bool:
+    """Check if observation has fixed scale."""
+    return type(observation_model) in _NO_SCALE
+
+
 def _posterior_weighted_objective_impl(
     y: Array,
     predicted_rate: Array,
@@ -208,7 +213,7 @@ def prepare_estep_log_likelihood(
             x, z, scale=s, aggregate_sample_scores=lambda v: v
         )
 
-    if type(observation_model) in _NO_SCALE:
+    if has_fixed_scale(observation_model):
 
         log_likelihood_per_sample = jax.vmap(
             log_likelihood_per_sample,
@@ -479,9 +484,7 @@ def prepare_mstep_update_fn(
     )
 
     # if scale is separable and needs to be optimized, get update function for optimizing scale
-    if observation_model._separable_scale and (
-        type(observation_model) not in _NO_SCALE
-    ):
+    if observation_model._separable_scale and (not has_fixed_scale(observation_model)):
         # GLM params solver only needs coef and intercept — exclude log_scale
         glm_init_params = GLMParams(init_params.coef, init_params.intercept)
         params_update_fn = setup_solver(

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -483,6 +483,7 @@ def setup_glm_hmm_initialization(
             glm_params_init,
             glm_params_init_kwargs,
             AVAIL_INIT_FUNCTIONS_GLM,
+            protocol=InitFunctionGLM,
         )
     elif glm_params_init_kwargs is not None:
         glm_init_funcs["glm_params_init_kwargs"] = _validate_init_funcs_kwargs(
@@ -497,7 +498,11 @@ def setup_glm_hmm_initialization(
             glm_init_funcs["scale_init_kwargs"],
             glm_init_funcs["scale_init_custom"],
         ) = _resolve_init_funcs(
-            "scale_init", scale_init, scale_init_kwargs, AVAIL_INIT_FUNCTIONS_GLM
+            "scale_init",
+            scale_init,
+            scale_init_kwargs,
+            AVAIL_INIT_FUNCTIONS_GLM,
+            protocol=InitFunctionGLM,
         )
     elif scale_init_kwargs is not None:
         glm_init_funcs["scale_init_kwargs"] = _validate_init_funcs_kwargs(

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Callable, Dict, Literal, Optional, Protocol, Tuple
 
 import jax
@@ -15,26 +16,22 @@ from ..hmm.initialize_parameters import (
     DEFAULT_INIT_FUNCTIONS,
     InitFunctionHMM,
     KMeansInitializer,
-    _resolve_init_funcs,
+    _get_protocol_parameters,
     _validate_init_funcs_keys,
     _validate_init_funcs_kwargs,
     generate_hmm_initial_params,
     setup_hmm_initialization,
 )
 from ..pytrees import FeaturePytree
-from ..tree_utils import pytree_map_and_reduce
-from ..type_casting import cast_to_jax, is_numpy_array_like
+from ..type_casting import cast_to_jax
 from ..typing import DESIGN_INPUT_TYPE
-from ..validation import check_tree_structure
-from .algorithm_configs import (
-    has_fixed_scale,
-)
+from .algorithm_configs import has_fixed_scale
 
 RANDOM_KEY = jax.Array
 
 
 class InitFunctionGLM(Protocol):
-    """Protocol for HMM probability initialization functions (initial and transition)."""
+    """Protocol for GLM parameter initialization functions (coefficients, intercept, scale)."""
 
     def __call__(
         self,
@@ -42,6 +39,7 @@ class InitFunctionGLM(Protocol):
         X: DESIGN_INPUT_TYPE,
         y: NDArray | jnp.ndarray,
         inverse_link_function: Callable,
+        is_new_session: Optional[NDArray | jnp.ndarray],
         random_key: jax.Array,
         **kwargs: Any,
     ) -> jnp.ndarray:
@@ -55,6 +53,7 @@ def random_glm_params_init(
     X: DESIGN_INPUT_TYPE,
     y: jnp.ndarray,
     inverse_link_function: Callable,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
     random_key=jax.random.PRNGKey(123),
     std_dev=0.001,
 ) -> GLMUserParams:
@@ -74,6 +73,9 @@ def random_glm_params_init(
         Observations, shape (n_samples,) or (n_samples, n_neurons).
     inverse_link_function :
         Inverse link function of the GLM.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions.
+        Unused for this initialization, but included for API consistency.
     random_key : jax.random.PRNGKey
         Random key for reproducibility. Default is PRNGKey(123).
     std_dev :
@@ -181,8 +183,8 @@ class KMeansInitializerGLM(KMeansInitializer):
             self._X,
             self._y,
             self.inverse_link_function,
-            random_key=key,
             std_dev=0.0,
+            random_key=key,
         )
         # initialize
         for i, state_mask in enumerate(states.T):
@@ -341,6 +343,7 @@ def constant_scale_init(
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
     inverse_link_function: Callable,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
     random_key=jax.random.PRNGKey(124),
     scale_val: float = 1.0,
 ):
@@ -359,6 +362,9 @@ def constant_scale_init(
         Observations, used to determine number of neurons from shape.
     inverse_link_function :
         Inverse link function of the GLM. Unused for this initialization, but included for API consistency.
+    is_new_session :
+        Optional boolean array of shape (n_samples,). Unused for this initialization,
+        but included for API consistency.
     random_key : jax.random.PRNGKey
         Random key, unused for this initialization, but included for API consistency.
     scale_val : float
@@ -416,6 +422,47 @@ GLMHMM_INITIALIZATION_FN_DICT = dict[
 ]
 
 
+def _validate_custom_glm_init_func(
+    func: Callable, kwargs: Optional[dict] = None
+) -> Tuple[InitFunctionGLM, dict, bool]:
+    """Validate a custom GLM initialization function against InitFunctionGLM."""
+    required_params = _get_protocol_parameters(InitFunctionGLM)
+    sig = inspect.signature(func)
+    missing = required_params - sig.parameters.keys()
+    if missing:
+        raise ValueError(
+            f"Custom initialization function must have the parameters {sorted(required_params)}. "
+            f"Missing: {sorted(missing)}."
+        )
+    kwargs = _validate_init_funcs_kwargs(func, kwargs, protocol=InitFunctionGLM)
+    return func, kwargs, True
+
+
+def _glm_resolve_init_funcs(
+    key: str,
+    value: str | Callable,
+    kwargs: Optional[dict] = None,
+) -> Tuple[InitFunctionGLM, dict, bool]:
+    """Resolve and validate a GLM initialization function, using InitFunctionGLM for custom callables."""
+    if isinstance(value, str):
+        if value not in AVAIL_INIT_FUNCTIONS_GLM[key]:
+            raise ValueError(
+                f"Invalid initialization function name '{value}' for '{key}'. "
+                f"Available options are: {list(AVAIL_INIT_FUNCTIONS_GLM[key].keys())}."
+            )
+        kwargs = _validate_init_funcs_kwargs(
+            AVAIL_INIT_FUNCTIONS_GLM[key][value], kwargs, protocol=InitFunctionGLM
+        )
+        return AVAIL_INIT_FUNCTIONS_GLM[key][value], kwargs, False
+    elif callable(value):
+        return _validate_custom_glm_init_func(value, kwargs)
+    else:
+        raise TypeError(
+            f"Initialization function for '{key}' must be either a string or a callable. "
+            f"Got {type(value)} instead."
+        )
+
+
 def setup_glm_hmm_initialization(
     initial_proba_init: Optional[str | Callable] = None,
     initial_proba_init_kwargs: Optional[dict] = None,
@@ -450,7 +497,7 @@ def setup_glm_hmm_initialization(
     glm_params_init:
         Initialization function for the GLM coefficient and intercept.
     glm_params_init_kwargs:
-        IKeyword arguments to pass to the GLM coefficient and intercept initialization function.
+        Keyword arguments to pass to the GLM coefficient and intercept initialization function.
     scale_init:
         Initialization function for the scale of the observation model.
     scale_init_kwargs:
@@ -469,10 +516,9 @@ def setup_glm_hmm_initialization(
         init_funcs = DEFAULT_INIT_FUNCTIONS_GLMHMM.copy()
         glm_init_funcs = GLM_INIT_FUNCS.copy()
     else:
-
         glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
         # check for unexpected/unknown keys in init_funcs and backfill with defaults
-        # note that the hmm init function falidation will be done in the setup
+        # note that the hmm init function validation will be done in the setup
         init_funcs = _validate_init_funcs_keys(init_funcs, glm_init_funcs)
 
     hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
@@ -491,11 +537,8 @@ def setup_glm_hmm_initialization(
             glm_init_funcs["glm_params_init"],
             glm_init_funcs["glm_params_init_kwargs"],
             glm_init_funcs["glm_params_init_custom"],
-        ) = _resolve_init_funcs(
-            "glm_params_init",
-            glm_params_init,
-            glm_params_init_kwargs,
-            available_init_funcs=AVAIL_INIT_FUNCTIONS_GLM,
+        ) = _glm_resolve_init_funcs(
+            "glm_params_init", glm_params_init, glm_params_init_kwargs
         )
     elif glm_params_init_kwargs is not None:
         glm_init_funcs["glm_params_init_kwargs"] = _validate_init_funcs_kwargs(
@@ -509,12 +552,7 @@ def setup_glm_hmm_initialization(
             glm_init_funcs["scale_init"],
             glm_init_funcs["scale_init_kwargs"],
             glm_init_funcs["scale_init_custom"],
-        ) = _resolve_init_funcs(
-            "scale_init",
-            scale_init,
-            scale_init_kwargs,
-            available_init_funcs=AVAIL_INIT_FUNCTIONS_GLM,
-        )
+        ) = _glm_resolve_init_funcs("scale_init", scale_init, scale_init_kwargs)
     elif scale_init_kwargs is not None:
         glm_init_funcs["scale_init_kwargs"] = _validate_init_funcs_kwargs(
             glm_init_funcs["scale_init"],
@@ -530,6 +568,7 @@ def generate_glm_hmm_initial_params(
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
     inverse_link_function: Callable,
+    is_new_session: Optional[NDArray | jnp.ndarray] = None,
     random_key: int | jax.Array = 123,
     init_funcs: Optional[dict] = None,
 ) -> Tuple[Any, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
@@ -550,6 +589,9 @@ def generate_glm_hmm_initial_params(
         Output data (e.g., neural activity) of shape (n_samples,) or (n_samples, n_neurons).
     inverse_link_function :
         Inverse link function of the GLM, passed to GLM parameter and scale initialization functions.
+    is_new_session :
+        Boolean array of shape (n_samples,) indicating the start of new sessions. Passed to all
+        initialization functions. If None, a single session is assumed.
     random_key :
         Key for random number generation. Split into three independent subkeys for GLM params,
         scale, and HMM probabilities respectively.
@@ -600,11 +642,10 @@ def generate_glm_hmm_initial_params(
         X=X,
         y=y,
         inverse_link_function=inverse_link_function,
+        is_new_session=is_new_session,
         random_key=glm_params_key,
         **glm_params_init_kwargs,
     )
-    if glm_init_funcs["glm_params_init_custom"]:
-        _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
 
     scale_init_fn = glm_init_funcs["scale_init"] or GLM_INIT_FUNCS["scale_init"]
     scale_init_kwargs = glm_init_funcs["scale_init_kwargs"] or {}
@@ -614,119 +655,18 @@ def generate_glm_hmm_initial_params(
         X=X,
         y=y,
         inverse_link_function=inverse_link_function,
+        is_new_session=is_new_session,
         random_key=scale_key,
         **scale_init_kwargs,
     )
-
-    if glm_init_funcs["scale_init_custom"]:
-        _validate_custom_scale_output(scale, n_states, y)
 
     initial_probs, transition_matrix = generate_hmm_initial_params(
         n_states,
         X,
         y,
+        is_new_session,
         hmm_key,
         hmm_init_funcs,
     )
 
     return coef, intercept, scale, initial_probs, transition_matrix
-
-
-def _validate_custom_glm_params_output(
-    params: GLMUserParams,
-    n_states: int,
-    X: DESIGN_INPUT_TYPE,
-    y: jnp.ndarray,
-):
-    coef, intercept = params
-    is_pop = y.ndim > 1
-    n_neurons = 1 if not is_pop else y.shape[1]
-
-    if not all(is_numpy_array_like(x)[1] for x in jax.tree_util.tree_leaves(coef)):
-        raise TypeError(
-            "The custom initialization function for the glm coefficients"
-            " did not return a pytree of arrays. "
-            "Some of the leaves of the coefficient pytree are not arrays."
-        )
-
-    data = X.data if isinstance(X, FeaturePytree) else X
-    if isinstance(X, FeaturePytree):
-        msg = (
-            "The custom initialization function for the glm coefficients returned an incorrect tree structure. "
-            "X and coef must have the same structure. "
-            "X was provided as a FeaturePytree, so coef should be a dictionary with matching keys. "
-            f"X keys are ``{X.keys()}``, but coef has structure "
-            f"``{jax.tree_util.tree_structure(coef)}`` instead."
-        )
-    else:
-        msg = (
-            "The custom initialization function for the glm coefficients returned an incorrect tree structure. "
-            "X and coef must have the same structure. "
-            f"X has pytree structure ``{jax.tree_util.tree_structure(X)}``, "
-            f"but coef has structure ``{jax.tree_util.tree_structure(coef)}``."
-        )
-    check_tree_structure(data, coef, err_message=msg)
-
-    if is_pop:
-        if not pytree_map_and_reduce(
-            lambda p, x: p.shape == (x.shape[1], n_states, n_neurons),
-            all,
-            coef,
-            data,
-        ):
-            actual_shapes = jax.tree_util.tree_map(lambda p: p.shape, coef)
-            expected_shapes = jax.tree_util.tree_map(
-                lambda x: (x.shape[1], n_states, n_neurons), data
-            )
-            raise ValueError(
-                "The custom initialization function for the glm coefficients returned mis-shaped coefficients. "
-                "Each array in the coefficient pytree must have shape ``(n_features, n_states, n_neurons)``.\n"
-                f"  Actual shapes:   {actual_shapes}\n"
-                f"  Expected shapes: {expected_shapes}"
-            )
-    else:
-        if not pytree_map_and_reduce(
-            lambda p, x: p.shape == (x.shape[1], n_states), all, coef, data
-        ):
-            actual_shapes = jax.tree_util.tree_map(lambda p: p.shape, coef)
-            expected_shapes = jax.tree_util.tree_map(
-                lambda x: (x.shape[1], n_states), data
-            )
-            raise ValueError(
-                "The custom initialization function for the glm coefficients returned mis-shaped coefficients. "
-                "Each array in the coefficient pytree must have shape ``(n_features, n_states)``.\n"
-                f"  Actual shapes:   {actual_shapes}\n"
-                f"  Expected shapes: {expected_shapes}"
-            )
-
-    if not is_numpy_array_like(intercept)[1]:
-        raise TypeError(
-            "The custom initialization function for the glm intercept did not return an array. "
-            f"Return type was {type(intercept)}."
-        )
-    expected_intercept_shape = (n_states, n_neurons) if is_pop else (n_states,)
-    if intercept.shape != expected_intercept_shape:
-        raise ValueError(
-            "The custom initialization function for the glm intercept returned an array with incorrect shape. "
-            f"Expected ``{expected_intercept_shape}``, got ``{intercept.shape}``."
-        )
-
-
-def _validate_custom_scale_output(
-    params: jnp.ndarray,
-    n_states: int,
-    y: jnp.ndarray,
-):
-    is_pop = y.ndim > 1
-    n_neurons = 1 if not is_pop else y.shape[1]
-    if not is_numpy_array_like(params)[1]:
-        raise TypeError(
-            "The custom initialization function for the scale must return an array. "
-            f"Return type was {type(params)}."
-        )
-    expected_shape = (n_states, n_neurons) if is_pop else (n_states,)
-    if params.shape != expected_shape:
-        raise ValueError(
-            "The custom initialization function for the scale returned an array with incorrect shape. "
-            f"Expected ``{expected_shape}``, got ``{params.shape}``."
-        )

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import Any, Callable, Dict, Literal, Optional, Protocol, Tuple
 
 import jax
@@ -13,12 +12,10 @@ from ..glm import GLM, PopulationGLM
 from ..glm.initialize_parameters import initialize_intercept_matching_mean_rate
 from ..glm.params import GLMUserParams
 from ..hmm.initialize_parameters import (
-    DEFAULT_INIT_FUNCTIONS,
     InitFunctionHMM,
     KMeansInitializer,
-    _get_protocol_parameters,
+    _resolve_init_funcs,
     _validate_init_funcs_kwargs,
-    setup_hmm_initialization,
 )
 from ..pytrees import FeaturePytree
 from ..type_casting import cast_to_jax
@@ -127,6 +124,8 @@ class KMeansInitializerGLM(KMeansInitializer):
         Output data (e.g., neural activity) of shape (n_samples,).
     inverse_link_function :
         Inverse link function of the GLM.
+    observation_model :
+        Observation model of the GLM.
     is_new_session :
         Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
         (default), it is assumed that all data belongs to a single session.
@@ -146,9 +145,9 @@ class KMeansInitializerGLM(KMeansInitializer):
         X: DESIGN_INPUT_TYPE,
         y: NDArray | jnp.ndarray,
         inverse_link_function: Callable,
+        observation_model: str,
         is_new_session: Optional[jnp.ndarray] = None,
         glm_kwargs: Optional[Dict[str, Any]] = None,
-        minimum_prob: float = 0.02,
         random_key: int | jax.Array = 0,
     ):
         super().__init__(
@@ -156,7 +155,6 @@ class KMeansInitializerGLM(KMeansInitializer):
             X,
             y,
             is_new_session,
-            minimum_prob=minimum_prob,
             random_key=random_key,
         )
         self._X = jax.tree_util.tree_map(jnp.asarray, X)
@@ -164,13 +162,26 @@ class KMeansInitializerGLM(KMeansInitializer):
             self._X = self._X.data
         self._y = jnp.asarray(y)
         self.inverse_link_function = inverse_link_function
+        self.observation_model = observation_model
         self.glm_kwargs = glm_kwargs if glm_kwargs is not None else {}
         if self._y.ndim == 1:
-            self._glm_models = {i: GLM(**self.glm_kwargs) for i in range(self.n_states)}
+            self._glm_models = {
+                i: GLM(
+                    observation_model=observation_model,
+                    inverse_link_function=inverse_link_function,
+                    **self.glm_kwargs,
+                )
+                for i in range(self.n_states)
+            }
             self._is_population = False
         else:
             self._glm_models = {
-                i: PopulationGLM(**self.glm_kwargs) for i in range(self.n_states)
+                i: PopulationGLM(
+                    observation_model=observation_model,
+                    inverse_link_function=inverse_link_function,
+                    **self.glm_kwargs,
+                )
+                for i in range(self.n_states)
             }
             self._is_population = True
 
@@ -231,9 +242,9 @@ def kmeans_glm_params_init(
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
     inverse_link_function: Callable,
+    observation_model: str,
     is_new_session: Optional[jnp.ndarray] = None,
     glm_kwargs: Optional[dict] = None,
-    minimum_prob: float = 0.02,
     random_key: Optional[jax.Array] = None,
     initializer: Optional[KMeansInitializer] = None,
 ):
@@ -250,15 +261,13 @@ def kmeans_glm_params_init(
         Output data (e.g., neural activity) of shape (n_samples,).
     inverse_link_function :
         Inverse link function of the GLM.
+    observation_model :
+        Observation model of the GLM.
     is_new_session :
         Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
         (default), it is assumed that all data belongs to a single session.
     glm_kwargs:
         GLM parameters as keyword arguments. These are passed at model initialization.
-    minimum_prob :
-        Minimum probability added to each state to avoid zero probabilities.
-        Note that probabilities will be renormalized after adding this minimum value, so the final
-        probabilities will not be exactly this value.
     random_key :
         Random key for reproducibility of KMeans initialization.
     initializer :
@@ -277,9 +286,9 @@ def kmeans_glm_params_init(
             X,
             y,
             inverse_link_function,
+            observation_model,
             is_new_session,
             glm_kwargs,
-            minimum_prob,
             random_key,
         )
     return initializer.glm_params()
@@ -290,9 +299,9 @@ def kmeans_scale_init(
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
     inverse_link_function: Callable,
+    observation_model: str,
     is_new_session: Optional[jnp.ndarray] = None,
     glm_kwargs: Optional[dict] = None,
-    minimum_prob: float = 0.02,
     random_key: Optional[jax.Array] = None,
     initializer: Optional[KMeansInitializer] = None,
 ):
@@ -309,15 +318,13 @@ def kmeans_scale_init(
         Output data (e.g., neural activity) of shape (n_samples,).
     inverse_link_function :
         Inverse link function of the GLM.
+    observation_model :
+        Observation model of the GLM.
     is_new_session :
         Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
         (default), it is assumed that all data belongs to a single session.
     glm_kwargs:
         GLM parameters as keyword arguments. These are passed at model initialization.
-    minimum_prob :
-        Minimum probability added to each state to avoid zero probabilities.
-        Note that probabilities will be renormalized after adding this minimum value, so the final
-        probabilities will not be exactly this value.
     random_key :
         Random key for reproducibility of KMeans initialization.
     initializer :
@@ -336,9 +343,9 @@ def kmeans_scale_init(
             X,
             y,
             inverse_link_function,
+            observation_model,
             is_new_session,
             glm_kwargs,
-            minimum_prob,
             random_key,
         )
     return initializer.scale()
@@ -391,7 +398,7 @@ def constant_scale_init(
     return scale
 
 
-GLM_INIT_FUNCS = {
+DEFAULT_INIT_FUNCTIONS_GLMHMM = {
     "glm_params_init": random_glm_params_init,
     "glm_params_init_kwargs": {},
     "glm_params_init_custom": False,
@@ -399,8 +406,6 @@ GLM_INIT_FUNCS = {
     "scale_init_kwargs": {},
     "scale_init_custom": False,
 }
-DEFAULT_INIT_FUNCTIONS_GLMHMM = DEFAULT_INIT_FUNCTIONS.copy()
-DEFAULT_INIT_FUNCTIONS_GLMHMM.update(GLM_INIT_FUNCS)
 
 AVAIL_INIT_FUNCTIONS_GLM = {
     "glm_params_init": {
@@ -412,12 +417,6 @@ AVAIL_INIT_FUNCTIONS_GLM = {
 
 GLMHMM_INITIALIZATION_FN_DICT = dict[
     Literal[
-        "initial_proba_init",
-        "initial_proba_init_kwargs",
-        "initial_proba_init_custom",
-        "transition_proba_init",
-        "transition_proba_init_kwargs",
-        "transition_proba_init_custom",
         "glm_params_init",
         "glm_params_init_kwargs",
         "glm_params_init_custom",
@@ -429,52 +428,7 @@ GLMHMM_INITIALIZATION_FN_DICT = dict[
 ]
 
 
-def _validate_custom_glm_init_func(
-    func: Callable, kwargs: Optional[dict] = None
-) -> Tuple[InitFunctionGLM, dict, bool]:
-    """Validate a custom GLM initialization function against InitFunctionGLM."""
-    required_params = _get_protocol_parameters(InitFunctionGLM)
-    sig = inspect.signature(func)
-    missing = required_params - sig.parameters.keys()
-    if missing:
-        raise ValueError(
-            f"Custom initialization function must have the parameters {sorted(required_params)}. "
-            f"Missing: {sorted(missing)}."
-        )
-    kwargs = _validate_init_funcs_kwargs(func, kwargs, protocol=InitFunctionGLM)
-    return func, kwargs, True
-
-
-def _glm_resolve_init_funcs(
-    key: str,
-    value: str | Callable,
-    kwargs: Optional[dict] = None,
-) -> Tuple[InitFunctionGLM, dict, bool]:
-    """Resolve and validate a GLM initialization function, using InitFunctionGLM for custom callables."""
-    if isinstance(value, str):
-        if value not in AVAIL_INIT_FUNCTIONS_GLM[key]:
-            raise ValueError(
-                f"Invalid initialization function name '{value}' for '{key}'. "
-                f"Available options are: {list(AVAIL_INIT_FUNCTIONS_GLM[key].keys())}."
-            )
-        kwargs = _validate_init_funcs_kwargs(
-            AVAIL_INIT_FUNCTIONS_GLM[key][value], kwargs, protocol=InitFunctionGLM
-        )
-        return AVAIL_INIT_FUNCTIONS_GLM[key][value], kwargs, False
-    elif callable(value):
-        return _validate_custom_glm_init_func(value, kwargs)
-    else:
-        raise TypeError(
-            f"Initialization function for '{key}' must be either a string or a callable. "
-            f"Got {type(value)} instead."
-        )
-
-
 def setup_glm_hmm_initialization(
-    initial_proba_init: Optional[str | Callable] = None,
-    initial_proba_init_kwargs: Optional[dict] = None,
-    transition_proba_init: Optional[str | Callable] = None,
-    transition_proba_init_kwargs: Optional[dict] = None,
     glm_params_init: Optional[str | Callable] = None,
     glm_params_init_kwargs: Optional[dict] = None,
     scale_init: Optional[str | Callable] = None,
@@ -492,16 +446,6 @@ def setup_glm_hmm_initialization(
 
     Parameters
     ----------
-    initial_proba_init :
-        User-specified initialization function for initial state probabilities. Can be a string key for built-in
-        functions or a custom callable. If None, the default build-in function will be used.
-    initial_proba_init_kwargs :
-        Keyword arguments to pass to the initial state probability initialization function.
-    transition_proba_init :
-        User-specified initialization function for transition probabilities. Can be a string key for built-in functions
-        or a custom callable. If None, the default built-in function will be used.
-    transition_proba_init_kwargs :
-        Keyword arguments to pass to the transition probability initialization function.
     glm_params_init:
         Initialization function for the GLM coefficient and intercept.
     glm_params_init_kwargs:
@@ -522,20 +466,11 @@ def setup_glm_hmm_initialization(
     """
 
     if init_funcs is None:
-        init_funcs = DEFAULT_INIT_FUNCTIONS_GLMHMM.copy()
-        glm_init_funcs = GLM_INIT_FUNCS.copy()
+        glm_init_funcs = DEFAULT_INIT_FUNCTIONS_GLMHMM.copy()
     else:
-        glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
+        glm_init_funcs = init_funcs.copy()
 
-    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
-    hmm_init_funcs = setup_hmm_initialization(
-        initial_proba_init,
-        initial_proba_init_kwargs,
-        transition_proba_init,
-        transition_proba_init_kwargs,
-        init_funcs=hmm_init_funcs,
-    )
-    # update functions and kwargs for init prob and transition prob
+    # update functions and kwargs for glm params and scale
     # if a function is passed but not kwargs, kwargs will be reset
     # if kwargs are passed but not function, kwargs will be validated against existing function in init_funcs
     if glm_params_init is not None:
@@ -543,8 +478,11 @@ def setup_glm_hmm_initialization(
             glm_init_funcs["glm_params_init"],
             glm_init_funcs["glm_params_init_kwargs"],
             glm_init_funcs["glm_params_init_custom"],
-        ) = _glm_resolve_init_funcs(
-            "glm_params_init", glm_params_init, glm_params_init_kwargs
+        ) = _resolve_init_funcs(
+            "glm_params_init",
+            glm_params_init,
+            glm_params_init_kwargs,
+            AVAIL_INIT_FUNCTIONS_GLM,
         )
     elif glm_params_init_kwargs is not None:
         glm_init_funcs["glm_params_init_kwargs"] = _validate_init_funcs_kwargs(
@@ -558,14 +496,15 @@ def setup_glm_hmm_initialization(
             glm_init_funcs["scale_init"],
             glm_init_funcs["scale_init_kwargs"],
             glm_init_funcs["scale_init_custom"],
-        ) = _glm_resolve_init_funcs("scale_init", scale_init, scale_init_kwargs)
+        ) = _resolve_init_funcs(
+            "scale_init", scale_init, scale_init_kwargs, AVAIL_INIT_FUNCTIONS_GLM
+        )
     elif scale_init_kwargs is not None:
         glm_init_funcs["scale_init_kwargs"] = _validate_init_funcs_kwargs(
             glm_init_funcs["scale_init"],
             scale_init_kwargs,
             protocol=InitFunctionGLM,
         )
-    glm_init_funcs.update(hmm_init_funcs)
     return glm_init_funcs
 
 
@@ -622,15 +561,15 @@ def generate_glm_hmm_initial_model_params(
     :func:`nemos.glm_hmm.initialize_parameters.setup_glm_hmm_initialization`
         Function to set up the initialization functions and their kwargs based on user input.
     """
-    init_funcs = {} if init_funcs is None else init_funcs
-    glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
+    glm_init_funcs = {} if init_funcs is None else init_funcs.copy()
     if isinstance(random_key, int):
         random_key = jax.random.PRNGKey(random_key)
 
     glm_params_key, scale_key = jax.random.split(random_key, 2)
 
     glm_params_init = (
-        glm_init_funcs.get("glm_params_init") or GLM_INIT_FUNCS["glm_params_init"]
+        glm_init_funcs.get("glm_params_init")
+        or DEFAULT_INIT_FUNCTIONS_GLMHMM["glm_params_init"]
     )
     glm_params_init_kwargs = glm_init_funcs.get("glm_params_init_kwargs") or {}
 
@@ -644,7 +583,9 @@ def generate_glm_hmm_initial_model_params(
         **glm_params_init_kwargs,
     )
 
-    scale_init_fn = glm_init_funcs.get("scale_init") or GLM_INIT_FUNCS["scale_init"]
+    scale_init_fn = (
+        glm_init_funcs.get("scale_init") or DEFAULT_INIT_FUNCTIONS_GLMHMM["scale_init"]
+    )
     scale_init_kwargs = glm_init_funcs.get("scale_init_kwargs") or {}
 
     scale = scale_init_fn(

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -1,0 +1,151 @@
+"""Initialization functions and related utility functions."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+import jax
+import jax.numpy as jnp
+from numpy.typing import NDArray
+
+from ..glm import GLM, PopulationGLM
+from ..glm.initialize_parameters import initialize_intercept_matching_mean_rate
+from ..glm.params import GLMUserParams
+from ..hmm.initialize_parameters import KMeansInitializer
+from ..type_casting import cast_to_jax
+from ..typing import DESIGN_INPUT_TYPE
+
+RANDOM_KEY = jax.Array
+
+
+@cast_to_jax(dtype=None)
+def random_glm_params_init(
+    n_states: int,
+    X: DESIGN_INPUT_TYPE,
+    y: jnp.ndarray,
+    inverse_link_function: Callable,
+    random_key=jax.random.PRNGKey(123),
+    std_dev=0.001,
+) -> GLMUserParams:
+    """
+    Initialize GLM coefficients and intercept with random normal values.
+
+    Generates random GLM parameters for each HMM state by sampling from a normal
+    distribution scaled by 0.1.
+
+    Parameters
+    ----------
+    n_states : int
+        Number of HMM states.
+    X : DESIGN_INPUT_TYPE
+        Design matrix with shape (n_samples, n_features).
+    y : jnp.ndarray
+        Observations, shape (n_samples,) or (n_samples, n_neurons).
+    inverse_link_function :
+        Inverse link function of the GLM.
+    random_key : jax.random.PRNGKey
+        Random key for reproducibility. Default is PRNGKey(123).
+    std_dev :
+        The standard deviation of the normal distribution that generates the coefficients.
+        Default is 0.001.
+
+    Returns
+    -------
+    coef : jnp.ndarray
+        Coefficient matrix of shape (n_features, n_neurons, n_states).
+    intercept : jnp.ndarray
+        Intercept array of shape (n_neurons, n_states).
+    """
+    n_features = X.shape[1]
+    is_one_dim = y.ndim == 1
+    n_neurons = 1 if is_one_dim else y.shape[1]
+
+    # small random noisy coef
+    coef = std_dev * jax.random.normal(random_key, (n_features, n_neurons, n_states))
+    # mean-rate
+    intercept = initialize_intercept_matching_mean_rate(inverse_link_function, y)
+    intercept = jnp.tile(intercept[:, jnp.newaxis], (1, n_states))
+    if is_one_dim:
+        coef = jnp.squeeze(coef, axis=1)
+        intercept = jnp.squeeze(intercept, axis=0)
+    return coef, intercept
+
+
+class KMeansInitializerGLM(KMeansInitializer):
+    """
+    Initializer class that uses KMeans clustering to initialize HMM parameters.
+
+    This class fits a KMeans model to the combined predictors and output data to assign states, then computes
+    initial state probabilities and transition probabilities based on the assigned states. It can be used to provide
+    a more informed initialization for HMM parameters based on the structure of the data.
+
+    Parameters
+    ----------
+    n_states :
+        Number of HMM states.
+    X :
+        Predictor data (e.g., model design for GLM) of shape (n_samples, n_features).
+    y :
+        Output data (e.g., neural activity) of shape (n_samples,).
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
+        (default), it is assumed that all data belongs to a single session.
+    minimum_prob :
+        Minimum probability added to each state to avoid zero probabilities.
+        Note that probabilities will be renormalized after adding this minimum value, so the final
+        probabilities will not be exactly this value.
+    inverse_link_function :
+        Inverse link function of the GLM.
+    random_key :
+        Random key for reproducibility of KMeans initialization.
+    """
+
+    def __init__(
+        self,
+        n_states: int,
+        X: DESIGN_INPUT_TYPE,
+        y: NDArray | jnp.ndarray,
+        inverse_link_function: Callable,
+        is_new_session: Optional[jnp.ndarray] = None,
+        glm_kwargs: Optional[Dict[str, Any]] = None,
+        minimum_prob: float = 0.02,
+        random_key: int | jax.Array = 0,
+    ):
+        super().__init__(
+            n_states,
+            X,
+            y,
+            is_new_session,
+            minimum_prob=minimum_prob,
+            random_key=random_key,
+        )
+        self.inverse_link_function = inverse_link_function
+        self.glm_kwargs = glm_kwargs if glm_kwargs is not None else {}
+
+    def glm_params(self) -> GLMUserParams:
+        """Generate glm parameters for initialization."""
+        if isinstance(self.random_key, int):
+            key = jax.random.PRNGKey(self.random_key)
+        sub, _ = jax.random.split(key)
+        states = self.states.astype(bool)
+        is_one_dim = self._y.ndim == 1
+        coef, intercept = random_glm_params_init(
+            states.shape[1],
+            self._X,
+            self._y,
+            self.inverse_link_function,
+            random_key=sub,
+            std_dev=0.0,
+        )
+        if is_one_dim:
+            model = GLM(**self.glm_kwargs)
+        else:
+            model = PopulationGLM(**self.glm_kwargs)
+        # initialize
+        for i, state_mask in enumerate(states.T):
+            X_state, y_state = self._X[state_mask], self._y[state_mask]
+            model.fit(X_state, y_state)
+            coef = coef.at[:, i].set(model.coef_)
+            intercept = intercept.at[i : i + 1].set(model.intercept_)
+
+        return coef, intercept

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Literal, Optional, Protocol, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -11,11 +11,39 @@ from numpy.typing import NDArray
 from ..glm import GLM, PopulationGLM
 from ..glm.initialize_parameters import initialize_intercept_matching_mean_rate
 from ..glm.params import GLMUserParams
-from ..hmm.initialize_parameters import KMeansInitializer
+from ..hmm.initialize_parameters import (
+    DEFAULT_INIT_FUNCTIONS,
+    InitFunctionHMM,
+    KMeansInitializer,
+    _resolve_init_funcs,
+    _validate_init_funcs_keys,
+    _validate_init_funcs_kwargs,
+    generate_hmm_initial_params,
+    setup_hmm_initialization,
+)
 from ..type_casting import cast_to_jax
 from ..typing import DESIGN_INPUT_TYPE
+from .algorithm_configs import (
+    has_fixed_scale,
+)
 
 RANDOM_KEY = jax.Array
+
+
+class InitFunctionGLM(Protocol):
+    """Protocol for HMM probability initialization functions (initial and transition)."""
+
+    def __call__(
+        self,
+        n_states: int,
+        X: DESIGN_INPUT_TYPE,
+        y: NDArray | jnp.ndarray,
+        inverse_link_function: Callable,
+        random_key: jax.random.PRNGKey,
+        **kwargs: Any,
+    ) -> jnp.ndarray:
+        """Initialize HMM probabilities."""
+        ...
 
 
 @cast_to_jax(dtype=None)
@@ -87,15 +115,17 @@ class KMeansInitializerGLM(KMeansInitializer):
         Predictor data (e.g., model design for GLM) of shape (n_samples, n_features).
     y :
         Output data (e.g., neural activity) of shape (n_samples,).
+    inverse_link_function :
+        Inverse link function of the GLM.
     is_new_session :
         Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
         (default), it is assumed that all data belongs to a single session.
+    glm_kwargs:
+        Keyword arguments defining the GLM model: observation model, regularization etc.
     minimum_prob :
         Minimum probability added to each state to avoid zero probabilities.
         Note that probabilities will be renormalized after adding this minimum value, so the final
         probabilities will not be exactly this value.
-    inverse_link_function :
-        Inverse link function of the GLM.
     random_key :
         Random key for reproducibility of KMeans initialization.
     """
@@ -119,8 +149,16 @@ class KMeansInitializerGLM(KMeansInitializer):
             minimum_prob=minimum_prob,
             random_key=random_key,
         )
+        self._X = jnp.asarray(X)
+        self._y = jnp.asarray(y)
         self.inverse_link_function = inverse_link_function
         self.glm_kwargs = glm_kwargs if glm_kwargs is not None else {}
+        if self._y.ndim == 1:
+            self._glm_models = {i: GLM(**self.glm_kwargs) for i in range(self.n_states)}
+        else:
+            self._glm_models = {
+                i: PopulationGLM(**self.glm_kwargs) for i in range(self.n_states)
+            }
 
     def glm_params(self) -> GLMUserParams:
         """Generate glm parameters for initialization."""
@@ -128,7 +166,6 @@ class KMeansInitializerGLM(KMeansInitializer):
             key = jax.random.PRNGKey(self.random_key)
         sub, _ = jax.random.split(key)
         states = self.states.astype(bool)
-        is_one_dim = self._y.ndim == 1
         coef, intercept = random_glm_params_init(
             states.shape[1],
             self._X,
@@ -137,15 +174,420 @@ class KMeansInitializerGLM(KMeansInitializer):
             random_key=sub,
             std_dev=0.0,
         )
-        if is_one_dim:
-            model = GLM(**self.glm_kwargs)
-        else:
-            model = PopulationGLM(**self.glm_kwargs)
         # initialize
         for i, state_mask in enumerate(states.T):
+            model = self._glm_models[i]
             X_state, y_state = self._X[state_mask], self._y[state_mask]
             model.fit(X_state, y_state)
             coef = coef.at[:, i].set(model.coef_)
             intercept = intercept.at[i : i + 1].set(model.intercept_)
 
         return coef, intercept
+
+    def scale(self) -> jnp.ndarray:
+        """KMeans-based scale estimate."""
+        is_population = self._y.ndim > 1
+        # initialize scale
+        if is_population:
+            n_neurons = self._y.shape[1]
+            scale = jnp.ones((self.n_states, n_neurons))
+        else:
+            scale = jnp.ones((self.n_states,))
+
+        # return fast for fixed scale
+        if has_fixed_scale(self._glm_models[0].observation_model):
+            return scale
+
+        # if not fitted, run a fit
+        if self._glm_models[0].scale_ is None:
+            self.glm_params()
+        for i, m in enumerate(self._glm_models.values()):
+            scale = scale.at[i].set(m.scale_)
+        return scale
+
+
+def kmeans_glm_params_init(
+    n_states: int,
+    X: DESIGN_INPUT_TYPE,
+    y: NDArray | jnp.ndarray,
+    inverse_link_function: Callable,
+    is_new_session: Optional[jnp.ndarray] = None,
+    glm_kwargs: Optional[dict] = None,
+    minimum_prob: float = 0.02,
+    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    initializer: Optional[KMeansInitializer] = None,
+):
+    """
+    Initialize the glm parameters using KMeans clustering.
+
+    Parameters
+    ----------
+    n_states :
+        Number of HMM states.
+    X :
+        Predictor data (e.g., model design for GLM) of shape (n_samples, n_features).
+    y :
+        Output data (e.g., neural activity) of shape (n_samples,).
+    inverse_link_function :
+        Inverse link function of the GLM.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
+        (default), it is assumed that all data belongs to a single session.
+    glm_kwargs:
+        GLM parameters as keyword arguments. These are passed at model initialization.
+    minimum_prob :
+        Minimum probability added to each state to avoid zero probabilities.
+        Note that probabilities will be renormalized after adding this minimum value, so the final
+        probabilities will not be exactly this value.
+    random_key :
+        Random key for reproducibility of KMeans initialization.
+    initializer :
+        Optional instance of KMeansInitializer to use for computing initial probabilities.
+
+    Returns
+    -------
+    coef, intercept :
+        The glm coefficients and intercept.
+    """
+    if initializer is None:
+        initializer = KMeansInitializerGLM(
+            n_states,
+            X,
+            y,
+            inverse_link_function,
+            is_new_session,
+            glm_kwargs,
+            minimum_prob,
+            random_key,
+        )
+    return initializer.glm_params()
+
+
+def kmeans_scale_init(
+    n_states: int,
+    X: DESIGN_INPUT_TYPE,
+    y: NDArray | jnp.ndarray,
+    inverse_link_function: Callable,
+    is_new_session: Optional[jnp.ndarray] = None,
+    glm_kwargs: Optional[dict] = None,
+    minimum_prob: float = 0.02,
+    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    initializer: Optional[KMeansInitializer] = None,
+):
+    """
+    Initialize the scale parameters using KMeans clustering.
+
+    Parameters
+    ----------
+    n_states :
+        Number of HMM states.
+    X :
+        Predictor data (e.g., model design for GLM) of shape (n_samples, n_features).
+    y :
+        Output data (e.g., neural activity) of shape (n_samples,).
+    inverse_link_function :
+        Inverse link function of the GLM.
+    is_new_session :
+        Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
+        (default), it is assumed that all data belongs to a single session.
+    glm_kwargs:
+        GLM parameters as keyword arguments. These are passed at model initialization.
+    minimum_prob :
+        Minimum probability added to each state to avoid zero probabilities.
+        Note that probabilities will be renormalized after adding this minimum value, so the final
+        probabilities will not be exactly this value.
+    random_key :
+        Random key for reproducibility of KMeans initialization.
+    initializer :
+        Optional instance of KMeansInitializer to use for computing initial probabilities.
+
+    Returns
+    -------
+    scale :
+        The inital scale.
+    """
+    if initializer is None:
+        initializer = KMeansInitializerGLM(
+            n_states,
+            X,
+            y,
+            inverse_link_function,
+            is_new_session,
+            glm_kwargs,
+            minimum_prob,
+            random_key,
+        )
+    return initializer.scale()
+
+
+@cast_to_jax(dtype=None)
+def constant_scale_init(
+    n_states: int,
+    X: DESIGN_INPUT_TYPE,
+    y: NDArray | jnp.ndarray,
+    random_key=jax.random.PRNGKey(124),
+    scale_val: float = 1.0,
+):
+    """
+    Initialize scale to a constant value.
+
+    Creates a scale parameter array where all elements are set to the same value.
+
+    Parameters
+    ----------
+    n_states : int
+        Number of HMM states.
+    X : DESIGN_INPUT_TYPE
+        Design matrix, unused but included for API consistency.
+    y : NDArray | jnp.ndarray
+        Observations, used to determine number of neurons from shape.
+    random_key : jax.random.PRNGKey
+        Random key, unused for this initialization, but included for API consistency.
+    scale_val : float
+        The constant value to initialize all scale parameters to. Default is 1.0.
+
+    Returns
+    -------
+    scale : jnp.ndarray
+        Scale array of shape (n_states,) for single neuron or (n_neurons, n_states)
+        for multiple neurons, with all values set to `scale_val`.
+    """
+    is_one_dim = y.ndim == 1
+    n_neurons = 1 if is_one_dim else y.shape[1]
+    scale = jnp.full((n_neurons, n_states), scale_val, dtype=float)
+    if is_one_dim:
+        scale = jnp.squeeze(scale, axis=0)
+    return scale
+
+
+GLM_INIT_FUCS = {
+    "glm_params_init": random_glm_params_init,
+    "glm_params_init_kwargs": {},
+    "scale_init": constant_scale_init,
+    "scale_init_kwargs": {},
+}
+DEFAULT_INIT_FUNCTIONS_GLMHMM = DEFAULT_INIT_FUNCTIONS.copy()
+DEFAULT_INIT_FUNCTIONS_GLMHMM.update(GLM_INIT_FUCS)
+
+AVAIL_INIT_FUNCTIONS_GLM = {
+    "glm_params_init": {
+        "random": random_glm_params_init,
+        "kmeans": kmeans_glm_params_init,
+    },
+    "glm_scale_init": {"constant": constant_scale_init, "kmeans": kmeans_scale_init},
+}
+
+INITIALIZATION_FN_DICT = dict[
+    Literal[
+        "initial_proba_init",
+        "initial_proba_init_kwargs",
+        "initial_proba_init_custom",
+        "transition_proba_init",
+        "transition_proba_init_kwargs",
+        "transition_proba_init_custom",
+        "glm_params_init",
+        "glm_params_init_kwargs",
+        "glm_params_init_custom",
+        "scale_init",
+        "scale_init_kwargs",
+        "scale_init_custom",
+    ],
+    InitFunctionGLM | InitFunctionHMM | dict[str, Any] | bool,
+]
+
+
+def setup_glm_hmm_initialization(
+    initial_proba_init: Optional[str | Callable] = None,
+    initial_proba_init_kwargs: Optional[dict] = None,
+    transition_proba_init: Optional[str | Callable] = None,
+    transition_proba_init_kwargs: Optional[dict] = None,
+    glm_params_init: Optional[str | Callable] = None,
+    glm_params_init_kwargs: Optional[dict] = None,
+    scale_init: Optional[str | Callable] = None,
+    scale_init_kwargs: Optional[dict] = None,
+    init_funcs: Optional[dict | INITIALIZATION_FN_DICT] = None,
+) -> INITIALIZATION_FN_DICT:
+    """
+    Set up HMM initialization functions based on user input, merging with defaults.
+
+    This function takes user-specified initialization functions (either as strings for built-in functions or callables
+    for custom functions) for both initial state probabilities and transition probabilities, validates them, and merges
+    them with default initialization functions for ones that are not provided. It ensures that the provided functions
+    and kwargs are valid and conform to expected signatures.
+
+    Parameters
+    ----------
+    initial_proba_init :
+        User-specified initialization function for initial state probabilities. Can be a string key for built-in
+        functions or a custom callable. If None, the default build-in function will be used.
+    initial_proba_init_kwargs :
+        Keyword arguments to pass to the initial state probability initialization function.
+    transition_proba_init :
+        User-specified initialization function for transition probabilities. Can be a string key for built-in functions
+        or a custom callable. If None, the default built-in function will be used.
+    transition_proba_init_kwargs :
+        Keyword arguments to pass to the transition probability initialization function.
+    glm_params_init:
+        Initialization function for the GLM coefficient and intercept.
+    glm_params_init_kwargs:
+        IKeyword arguments to pass to the GLM coefficient and intercept initialization function.
+    scale_init:
+        Initialization function for the scale of the observation model.
+    scale_init_kwargs:
+        Kwargs of the initialization function for the scale of the observation model.
+    init_funcs :
+        Existing dictionary of initialization functions to update. If None, a new dictionary will be created.
+        If the dictionary is missing any keys, they will be backfilled with defaults.
+
+    Returns
+    -------
+    init_funcs :
+        Updated or initialized dictionary based on provided inputs.
+    """
+
+    if init_funcs is None:
+        init_funcs = DEFAULT_INIT_FUNCTIONS_GLMHMM.copy()
+        glm_init_funcs = GLM_INIT_FUCS.copy()
+    else:
+
+        glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUCS}
+        # check for unexpected/unknown keys in init_funcs and backfill with defaults
+        # note that the hmm init function falidation will be done in the setup
+        init_funcs = _validate_init_funcs_keys(init_funcs, glm_init_funcs)
+
+    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUCS}
+    hmm_init_funcs = setup_hmm_initialization(
+        initial_proba_init,
+        initial_proba_init_kwargs,
+        transition_proba_init,
+        transition_proba_init_kwargs,
+        init_funcs=hmm_init_funcs,
+    )
+    # update functions and kwargs for init prob and transition prob
+    # if a function is passed but not kwargs, kwargs will be reset
+    # if kwargs are passed but not function, kwargs will be validated against existing function in init_funcs
+    if glm_params_init is not None:
+        (
+            glm_init_funcs["glm_params_init"],
+            glm_init_funcs["glm_params_init_kwargs"],
+            glm_init_funcs["glm_params_init_custom"],
+        ) = _resolve_init_funcs(
+            "glm_params_init",
+            glm_params_init,
+            glm_params_init_kwargs,
+            available_init_funcs=AVAIL_INIT_FUNCTIONS_GLM,
+        )
+    elif glm_params_init_kwargs is not None:
+        glm_init_funcs["glm_params_init_kwargs"] = _validate_init_funcs_kwargs(
+            glm_init_funcs["glm_params_init"],
+            glm_params_init_kwargs,
+            protocol=InitFunctionGLM,
+        )
+
+    if scale_init is not None:
+        (
+            glm_init_funcs["scale_init"],
+            glm_init_funcs["scale_init_kwargs"],
+            glm_init_funcs["scale_init_custom"],
+        ) = _resolve_init_funcs(
+            "scale_init",
+            scale_init,
+            scale_init_kwargs,
+            available_init_funcs=AVAIL_INIT_FUNCTIONS_GLM,
+        )
+    elif scale_init_kwargs is not None:
+        glm_init_funcs["scale_init_kwargs"] = _validate_init_funcs_kwargs(
+            glm_init_funcs["scale_init"],
+            scale_init_kwargs,
+            protocol=InitFunctionGLM,
+        )
+    glm_init_funcs.update(hmm_init_funcs)
+    return glm_init_funcs
+
+
+def generate_glm_hmm_initial_params(
+    n_states: int,
+    X: DESIGN_INPUT_TYPE,
+    y: NDArray | jnp.ndarray,
+    inverse_link_function: Callable,
+    random_key: int | jax.Array = 123,
+    init_funcs: Optional[dict] = None,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """
+    Generate initial HMM parameters using the provided initialization functions.
+
+    This function calls the specified initialization functions for initial state probabilities
+    stored in the `init_funcs` dictionary passing `n_states` and any additional stored kwargs.
+
+    Parameters
+    ----------
+    n_states :
+        Number of HMM states.
+    X :
+        Predictor data (e.g., model design for GLM) of shape (n_samples, n_features).
+    y :
+        Output data (e.g., neural activity) of shape (n_samples,).
+    random_key :
+        Optional key for random number generation, if needed by the initialization functions. The key is split to
+        ensure different random states for initial probabilities and transition probabilities.
+    init_funcs :
+        Dictionary containing the initialization functions and their kwargs for both initial state probabilities
+        and transition probabilities. This dictionary can be set up using the `setup_hmm_initialization` function.
+        If not provided, or if specific functions are missing, defaults will be used.
+
+    Returns
+    -------
+    initial_probs :
+        Initial state probability vector of shape (n_states,) that sums to 1.
+    transition_matrix :
+        Transition probability matrix of shape (n_states, n_states) where each row sums to 1.
+
+    See Also
+    --------
+    :func:`nemos.hmm.setup_hmm_initialization`
+        Function to set up the initialization functions and their kwargs based on user input.
+    """
+    # check for unexpected/unknown keys in init_funcs if user provided dictionary not made by setup_hmm_initialization
+    init_funcs = {} if init_funcs is None else init_funcs
+    glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUCS}
+    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUCS}
+
+    if isinstance(random_key, int):
+        random_key = jax.random.PRNGKey(random_key)
+
+    # glm, scale, hmm
+    glm_params_key, scale_key, hmm_key = jax.random.split(random_key, 3)
+
+    # validate glm specific
+    glm_init_funcs = _validate_init_funcs_keys(
+        glm_init_funcs, default_init_funcs=GLM_INIT_FUCS
+    )
+
+    # grab glm initialization function
+    glm_params_init = (
+        glm_init_funcs["glm_params_init"] or GLM_INIT_FUCS["glm_params_init"]
+    )
+
+    # set to empty kwargs if set to None
+    glm_params_init_kwargs = glm_init_funcs["glm_params_init_kwargs"] or {}
+
+    # split seed into a new key
+    # compute probabilities and validate if custom functions are used
+    coef, intercept = glm_params_init(
+        n_states=n_states,
+        X=X,
+        y=y,
+        inverse_link_function=inverse_link_function,
+        random_key=glm_params_key,
+        **glm_params_init_kwargs,
+    )
+
+    initial_probs, transition_matrix = generate_hmm_initial_params(
+        n_states,
+        X,
+        y,
+        hmm_key,
+        hmm_init_funcs,
+    )
+
+    return coef, intercept, initial_probs, transition_matrix

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -56,7 +56,7 @@ def random_glm_params_init(
     Initialize GLM coefficients and intercept with random normal values.
 
     Generates random GLM parameters for each HMM state by sampling from a normal
-    distribution scaled by 0.1.
+    distribution scaled by `std_dev`.
 
     Parameters
     ----------
@@ -131,10 +131,6 @@ class KMeansInitializerGLM(KMeansInitializer):
         (default), it is assumed that all data belongs to a single session.
     glm_kwargs:
         Keyword arguments defining the GLM model: observation model, regularization etc.
-    minimum_prob :
-        Minimum probability added to each state to avoid zero probabilities.
-        Note that probabilities will be renormalized after adding this minimum value, so the final
-        probabilities will not be exactly this value.
     random_key :
         Random key for reproducibility of KMeans initialization.
     """
@@ -188,8 +184,15 @@ class KMeansInitializerGLM(KMeansInitializer):
     def fit(self) -> "KMeansInitializerGLM":
         """Fit one GLM per state on samples assigned to that state by KMeans."""
         states = self.states.astype(bool)
-        for state_mask, model in zip(states.T, self._glm_models.values()):
+        for i, (state_mask, model) in enumerate(
+            zip(states.T, self._glm_models.values())
+        ):
             X_state, y_state = self._X[state_mask], self._y[state_mask]
+            if X_state.shape[0] == 0:
+                raise ValueError(
+                    f"KMeans assigned 0 samples to state {i}. Try reducing n_states "
+                    f"or using a different initialization method."
+                )
             model.fit(X_state, y_state)
         return self
 
@@ -358,7 +361,7 @@ def constant_scale_init(
     y: NDArray | jnp.ndarray,
     inverse_link_function: Callable,
     is_new_session: Optional[NDArray | jnp.ndarray] = None,
-    random_key=jax.random.PRNGKey(124),
+    random_key: Optional[jax.Array] = None,
     scale_val: float = 1.0,
 ):
     """
@@ -578,6 +581,12 @@ def generate_glm_hmm_initial_model_params(
     )
     glm_params_init_kwargs = glm_init_funcs.get("glm_params_init_kwargs") or {}
 
+    if glm_params_init is kmeans_glm_params_init and "observation_model" not in glm_params_init_kwargs:
+        raise ValueError(
+            "The 'kmeans' GLM parameter initializer requires 'observation_model' to be "
+            "provided in 'glm_params_init_kwargs'."
+        )
+
     coef, intercept = glm_params_init(
         n_states=n_states,
         X=X,
@@ -592,6 +601,12 @@ def generate_glm_hmm_initial_model_params(
         glm_init_funcs.get("scale_init") or DEFAULT_INIT_FUNCTIONS_GLMHMM["scale_init"]
     )
     scale_init_kwargs = glm_init_funcs.get("scale_init_kwargs") or {}
+
+    if scale_init_fn is kmeans_scale_init and "observation_model" not in scale_init_kwargs:
+        raise ValueError(
+            "The 'kmeans' scale initializer requires 'observation_model' to be "
+            "provided in 'scale_init_kwargs'."
+        )
 
     scale = scale_init_fn(
         n_states=n_states,

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -174,8 +174,18 @@ class KMeansInitializerGLM(KMeansInitializer):
             }
             self._is_population = True
 
+    def fit(self) -> "KMeansInitializerGLM":
+        """Fit one GLM per state on samples assigned to that state by KMeans."""
+        states = self.states.astype(bool)
+        for state_mask, model in zip(states.T, self._glm_models.values()):
+            X_state, y_state = self._X[state_mask], self._y[state_mask]
+            model.fit(X_state, y_state)
+        return self
+
     def glm_params(self) -> GLMUserParams:
-        """Generate glm parameters for initialization."""
+        """Generate GLM parameters for initialization."""
+        if self._glm_models[0].coef_ is None:
+            self.fit()
         key = jax.random.PRNGKey(self.random_key)
         states = self.states.astype(bool)
         coef, intercept = random_glm_params_init(
@@ -186,38 +196,30 @@ class KMeansInitializerGLM(KMeansInitializer):
             std_dev=0.0,
             random_key=key,
         )
-        # initialize
-        for i, state_mask in enumerate(states.T):
-            model = self._glm_models[i]
-            X_state, y_state = self._X[state_mask], self._y[state_mask]
-            model.fit(X_state, y_state)
+        for i, m in enumerate(self._glm_models.values()):
             coef = jax.tree_util.tree_map(
-                lambda c, mc: c.at[..., i].set(mc), coef, model.coef_
+                lambda c, mc: c.at[..., i].set(mc), coef, m.coef_
             )
             if self._is_population:
-                intercept = intercept.at[..., i].set(model.intercept_)
+                intercept = intercept.at[..., i].set(m.intercept_)
             else:
-                intercept = intercept.at[i : i + 1].set(model.intercept_)
-
+                intercept = intercept.at[i : i + 1].set(m.intercept_)
         return coef, intercept
 
     def scale(self) -> jnp.ndarray:
         """KMeans-based scale estimate."""
         is_population = self._y.ndim > 1
-        # initialize scale
         if is_population:
             n_neurons = self._y.shape[1]
             scale = jnp.ones((self.n_states, n_neurons))
         else:
             scale = jnp.ones((self.n_states,))
 
-        # return fast for fixed scale
         if has_fixed_scale(self._glm_models[0].observation_model):
             return scale
 
-        # if not fitted, run a fit
         if self._glm_models[0].scale_ is None:
-            self.glm_params()
+            self.fit()
         for i, m in enumerate(self._glm_models.values()):
             scale = scale.at[i].set(m.scale_)
         return scale

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -476,12 +476,13 @@ def setup_glm_hmm_initialization(
     init_funcs: Optional[dict | GLMHMM_INITIALIZATION_FN_DICT] = None,
 ) -> GLMHMM_INITIALIZATION_FN_DICT:
     """
-    Set up HMM initialization functions based on user input, merging with defaults.
+    Set up GLM-HMM initialization functions based on user input, merging with defaults.
 
     This function takes user-specified initialization functions (either as strings for built-in functions or callables
-    for custom functions) for both initial state probabilities and transition probabilities, validates them, and merges
+    for custom functions) for both initial state probabilities and transition probabilities, and merges
     them with default initialization functions for ones that are not provided. It ensures that the provided functions
     and kwargs are valid and conform to expected signatures.
+    Note that this function assumes pre-validated function keys, this is convenient because keys are model specific.
 
     Parameters
     ----------
@@ -518,11 +519,6 @@ def setup_glm_hmm_initialization(
         glm_init_funcs = GLM_INIT_FUNCS.copy()
     else:
         glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
-        # check for unexpected/unknown keys in init_funcs and backfill with defaults
-        # note that the hmm init function validation will be done in the setup
-        init_funcs = _validate_init_funcs_keys(
-            init_funcs, DEFAULT_INIT_FUNCTIONS_GLMHMM
-        )
 
     hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
     hmm_init_funcs = setup_hmm_initialization(
@@ -628,10 +624,6 @@ def generate_glm_hmm_initial_model_params(
         random_key = jax.random.PRNGKey(random_key)
 
     glm_params_key, scale_key = jax.random.split(random_key, 2)
-
-    glm_init_funcs = _validate_init_funcs_keys(
-        glm_init_funcs, default_init_dict=GLM_INIT_FUNCS
-    )
 
     glm_params_init = (
         glm_init_funcs["glm_params_init"] or GLM_INIT_FUNCS["glm_params_init"]

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -8,6 +8,8 @@ import jax
 import jax.numpy as jnp
 from numpy.typing import NDArray
 
+from build.lib.nemos.tree_utils import pytree_map_and_reduce
+
 from ..glm import GLM, PopulationGLM
 from ..glm.initialize_parameters import initialize_intercept_matching_mean_rate
 from ..glm.params import GLMUserParams
@@ -21,8 +23,10 @@ from ..hmm.initialize_parameters import (
     generate_hmm_initial_params,
     setup_hmm_initialization,
 )
-from ..type_casting import cast_to_jax
+from ..pytrees import FeaturePytree
+from ..type_casting import cast_to_jax, is_numpy_array_like
 from ..typing import DESIGN_INPUT_TYPE
+from ..validation import check_tree_structure
 from .algorithm_configs import (
     has_fixed_scale,
 )
@@ -87,6 +91,8 @@ def random_glm_params_init(
     """
     is_one_dim = y.ndim == 1
     n_neurons = 1 if is_one_dim else y.shape[1]
+    if isinstance(X, FeaturePytree):
+        X = X.data
     # small random noisy coef
     coef = jax.tree_util.tree_map(
         lambda x: std_dev
@@ -153,6 +159,8 @@ class KMeansInitializerGLM(KMeansInitializer):
             random_key=random_key,
         )
         self._X = jax.tree_util.tree_map(jnp.asarray, X)
+        if isinstance(self._X, FeaturePytree):
+            self._X = self._X.data
         self._y = jnp.asarray(y)
         self.inverse_link_function = inverse_link_function
         self.glm_kwargs = glm_kwargs if glm_kwargs is not None else {}
@@ -165,16 +173,14 @@ class KMeansInitializerGLM(KMeansInitializer):
 
     def glm_params(self) -> GLMUserParams:
         """Generate glm parameters for initialization."""
-        if isinstance(self.random_key, int):
-            key = jax.random.PRNGKey(self.random_key)
-        sub, _ = jax.random.split(key)
+        key = jax.random.PRNGKey(self.random_key)
         states = self.states.astype(bool)
         coef, intercept = random_glm_params_init(
             states.shape[1],
             self._X,
             self._y,
             self.inverse_link_function,
-            random_key=sub,
+            random_key=key,
             std_dev=0.0,
         )
         # initialize
@@ -330,6 +336,7 @@ def constant_scale_init(
     n_states: int,
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
+    inverse_link_function: Callable,
     random_key=jax.random.PRNGKey(124),
     scale_val: float = 1.0,
 ):
@@ -346,6 +353,8 @@ def constant_scale_init(
         Design matrix, unused but included for API consistency.
     y : NDArray | jnp.ndarray
         Observations, used to determine number of neurons from shape.
+    inverse_link_function :
+        Inverse link function of the GLM. Unused for this initialization, but included for API consistency.
     random_key : jax.random.PRNGKey
         Random key, unused for this initialization, but included for API consistency.
     scale_val : float
@@ -368,8 +377,10 @@ def constant_scale_init(
 GLM_INIT_FUCS = {
     "glm_params_init": random_glm_params_init,
     "glm_params_init_kwargs": {},
+    "glm_params_init_custom": False,
     "scale_init": constant_scale_init,
     "scale_init_kwargs": {},
+    "scale_init_custom": False,
 }
 DEFAULT_INIT_FUNCTIONS_GLMHMM = DEFAULT_INIT_FUNCTIONS.copy()
 DEFAULT_INIT_FUNCTIONS_GLMHMM.update(GLM_INIT_FUCS)
@@ -379,10 +390,10 @@ AVAIL_INIT_FUNCTIONS_GLM = {
         "random": random_glm_params_init,
         "kmeans": kmeans_glm_params_init,
     },
-    "glm_scale_init": {"constant": constant_scale_init, "kmeans": kmeans_scale_init},
+    "scale_init": {"constant": constant_scale_init, "kmeans": kmeans_scale_init},
 }
 
-INITIALIZATION_FN_DICT = dict[
+GLMHMM_INITIALIZATION_FN_DICT = dict[
     Literal[
         "initial_proba_init",
         "initial_proba_init_kwargs",
@@ -410,8 +421,8 @@ def setup_glm_hmm_initialization(
     glm_params_init_kwargs: Optional[dict] = None,
     scale_init: Optional[str | Callable] = None,
     scale_init_kwargs: Optional[dict] = None,
-    init_funcs: Optional[dict | INITIALIZATION_FN_DICT] = None,
-) -> INITIALIZATION_FN_DICT:
+    init_funcs: Optional[dict | GLMHMM_INITIALIZATION_FN_DICT] = None,
+) -> GLMHMM_INITIALIZATION_FN_DICT:
     """
     Set up HMM initialization functions based on user input, merging with defaults.
 
@@ -517,31 +528,41 @@ def generate_glm_hmm_initial_params(
     inverse_link_function: Callable,
     random_key: int | jax.Array = 123,
     init_funcs: Optional[dict] = None,
-) -> Tuple[Any, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+) -> Tuple[Any, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """
-    Generate initial HMM parameters using the provided initialization functions.
+    Generate initial GLM-HMM parameters using the provided initialization functions.
 
-    This function calls the specified initialization functions for initial state probabilities
-    stored in the `init_funcs` dictionary passing `n_states` and any additional stored kwargs.
+    Calls the specified initialization functions for GLM coefficients, intercept, scale,
+    initial state probabilities, and transition probabilities, splitting the random key
+    to ensure independent random states for each component.
 
     Parameters
     ----------
     n_states :
         Number of HMM states.
     X :
-        Predictor data (e.g., model design for GLM) of shape (n_samples, n_features).
+        Predictor data of shape (n_samples, n_features).
     y :
-        Output data (e.g., neural activity) of shape (n_samples,).
+        Output data (e.g., neural activity) of shape (n_samples,) or (n_samples, n_neurons).
+    inverse_link_function :
+        Inverse link function of the GLM, passed to GLM parameter and scale initialization functions.
     random_key :
-        Optional key for random number generation, if needed by the initialization functions. The key is split to
-        ensure different random states for initial probabilities and transition probabilities.
+        Key for random number generation. Split into three independent subkeys for GLM params,
+        scale, and HMM probabilities respectively.
     init_funcs :
-        Dictionary containing the initialization functions and their kwargs for both initial state probabilities
-        and transition probabilities. This dictionary can be set up using the `setup_hmm_initialization` function.
-        If not provided, or if specific functions are missing, defaults will be used.
+        Dictionary containing initialization functions and their kwargs for all GLM-HMM parameters.
+        Can be constructed with :func:`setup_glm_hmm_initialization`. Missing keys are backfilled
+        with defaults.
 
     Returns
     -------
+    coef :
+        GLM coefficients, a pytree matching the structure of X with leaves of shape
+        (n_features, n_neurons, n_states) or (n_features, n_states) for single-neuron.
+    intercept :
+        Intercept array of shape (n_neurons, n_states) or (n_states,) for single-neuron.
+    scale :
+        Scale array of shape (n_states,) for single-neuron or (n_neurons, n_states) for population.
     initial_probs :
         Initial state probability vector of shape (n_states,) that sums to 1.
     transition_matrix :
@@ -549,10 +570,9 @@ def generate_glm_hmm_initial_params(
 
     See Also
     --------
-    :func:`nemos.hmm.setup_hmm_initialization`
+    :func:`nemos.glm_hmm.initialize_parameters.setup_glm_hmm_initialization`
         Function to set up the initialization functions and their kwargs based on user input.
     """
-    # check for unexpected/unknown keys in init_funcs if user provided dictionary not made by setup_hmm_initialization
     init_funcs = {} if init_funcs is None else init_funcs
     glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUCS}
     hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUCS}
@@ -560,24 +580,17 @@ def generate_glm_hmm_initial_params(
     if isinstance(random_key, int):
         random_key = jax.random.PRNGKey(random_key)
 
-    # glm, scale, hmm
     glm_params_key, scale_key, hmm_key = jax.random.split(random_key, 3)
 
-    # validate glm specific
     glm_init_funcs = _validate_init_funcs_keys(
-        glm_init_funcs, default_init_funcs=GLM_INIT_FUCS
+        glm_init_funcs, default_init_dict=GLM_INIT_FUCS
     )
 
-    # grab glm initialization function
     glm_params_init = (
         glm_init_funcs["glm_params_init"] or GLM_INIT_FUCS["glm_params_init"]
     )
-
-    # set to empty kwargs if set to None
     glm_params_init_kwargs = glm_init_funcs["glm_params_init_kwargs"] or {}
 
-    # split seed into a new key
-    # compute probabilities and validate if custom functions are used
     coef, intercept = glm_params_init(
         n_states=n_states,
         X=X,
@@ -586,6 +599,23 @@ def generate_glm_hmm_initial_params(
         random_key=glm_params_key,
         **glm_params_init_kwargs,
     )
+    if glm_init_funcs["glm_params_init_custom"]:
+        _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
+
+    scale_init_fn = glm_init_funcs["scale_init"] or GLM_INIT_FUCS["scale_init"]
+    scale_init_kwargs = glm_init_funcs["scale_init_kwargs"] or {}
+
+    scale = scale_init_fn(
+        n_states=n_states,
+        X=X,
+        y=y,
+        inverse_link_function=inverse_link_function,
+        random_key=scale_key,
+        **scale_init_kwargs,
+    )
+
+    if glm_init_funcs["scale_init_custom"]:
+        _validate_custom_scale_output(scale, n_states, y)
 
     initial_probs, transition_matrix = generate_hmm_initial_params(
         n_states,
@@ -595,4 +625,104 @@ def generate_glm_hmm_initial_params(
         hmm_init_funcs,
     )
 
-    return coef, intercept, initial_probs, transition_matrix
+    return coef, intercept, scale, initial_probs, transition_matrix
+
+
+def _validate_custom_glm_params_output(
+    params: GLMUserParams,
+    n_states: int,
+    X: DESIGN_INPUT_TYPE,
+    y: jnp.ndarray,
+):
+    coef, intercept = params
+    is_pop = y.ndim > 1
+    n_neurons = 1 if not is_pop else y.shape[1]
+
+    if not all(is_numpy_array_like(x)[1] for x in jax.tree_util.tree_leaves(coef)):
+        raise TypeError(
+            "The custom initialization function for the glm coefficients"
+            " did not return a pytree of arrays. "
+            "Some of the leaves of the coefficient pytree are not arrays."
+        )
+
+    data = X.data if isinstance(X, FeaturePytree) else X
+    if isinstance(X, FeaturePytree):
+        msg = (
+            "The custom initialization function for the glm coefficients returned an incorrect tree structure. "
+            "X and coef must have the same structure. "
+            "X was provided as a FeaturePytree, so coef should be a dictionary with matching keys. "
+            f"X keys are ``{X.keys()}``, but coef has structure "
+            f"``{jax.tree_util.tree_structure(coef)}`` instead."
+        )
+    else:
+        msg = (
+            "The custom initialization function for the glm coefficients returned an incorrect tree structure. "
+            "X and coef must have the same structure. "
+            f"X has pytree structure ``{jax.tree_util.tree_structure(X)}``, "
+            f"but coef has structure ``{jax.tree_util.tree_structure(coef)}``."
+        )
+    check_tree_structure(data, coef, err_message=msg)
+
+    if is_pop:
+        if not pytree_map_and_reduce(
+            lambda p, x: p.shape == (x.shape[1], n_states, n_neurons),
+            all,
+            coef,
+            data,
+        ):
+            actual_shapes = jax.tree_util.tree_map(lambda p: p.shape, coef)
+            expected_shapes = jax.tree_util.tree_map(
+                lambda x: (x.shape[1], n_states, n_neurons), data
+            )
+            raise ValueError(
+                "The custom initialization function for the glm coefficients returned mis-shaped coefficients. "
+                "Each array in the coefficient pytree must have shape ``(n_features, n_states, n_neurons)``.\n"
+                f"  Actual shapes:   {actual_shapes}\n"
+                f"  Expected shapes: {expected_shapes}"
+            )
+    else:
+        if not pytree_map_and_reduce(
+            lambda p, x: p.shape == (x.shape[1], n_states), all, coef, data
+        ):
+            actual_shapes = jax.tree_util.tree_map(lambda p: p.shape, coef)
+            expected_shapes = jax.tree_util.tree_map(
+                lambda x: (x.shape[1], n_states), data
+            )
+            raise ValueError(
+                "The custom initialization function for the glm coefficients returned mis-shaped coefficients. "
+                "Each array in the coefficient pytree must have shape ``(n_features, n_states)``.\n"
+                f"  Actual shapes:   {actual_shapes}\n"
+                f"  Expected shapes: {expected_shapes}"
+            )
+
+    if not is_numpy_array_like(intercept)[1]:
+        raise TypeError(
+            "The custom initialization function for the glm intercept did not return an array. "
+            f"Return type was {type(intercept)}."
+        )
+    expected_intercept_shape = (n_states, n_neurons) if is_pop else (n_states,)
+    if intercept.shape != expected_intercept_shape:
+        raise ValueError(
+            "The custom initialization function for the glm intercept returned an array with incorrect shape. "
+            f"Expected ``{expected_intercept_shape}``, got ``{intercept.shape}``."
+        )
+
+
+def _validate_custom_scale_output(
+    params: jnp.ndarray,
+    n_states: int,
+    y: jnp.ndarray,
+):
+    is_pop = y.ndim > 1
+    n_neurons = 1 if not is_pop else y.shape[1]
+    if not is_numpy_array_like(params)[1]:
+        raise TypeError(
+            "The custom initialization function for the scale must return an array. "
+            f"Return type was {type(params)}."
+        )
+    expected_shape = (n_states, n_neurons) if is_pop else (n_states,)
+    if params.shape != expected_shape:
+        raise ValueError(
+            "The custom initialization function for the scale returned an array with incorrect shape. "
+            f"Expected ``{expected_shape}``, got ``{params.shape}``."
+        )

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -521,7 +521,7 @@ def setup_glm_hmm_initialization(
         glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
         # check for unexpected/unknown keys in init_funcs and backfill with defaults
         # note that the hmm init function validation will be done in the setup
-        init_funcs = _validate_init_funcs_keys(init_funcs, glm_init_funcs)
+        init_funcs = _validate_init_funcs_keys(init_funcs, DEFAULT_INIT_FUNCTIONS_GLMHMM)
 
     hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
     hmm_init_funcs = setup_hmm_initialization(

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -17,7 +17,6 @@ from ..hmm.initialize_parameters import (
     InitFunctionHMM,
     KMeansInitializer,
     _get_protocol_parameters,
-    _validate_init_funcs_keys,
     _validate_init_funcs_kwargs,
     setup_hmm_initialization,
 )

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -504,13 +504,14 @@ def setup_glm_hmm_initialization(
     scale_init_kwargs:
         Kwargs of the initialization function for the scale of the observation model.
     init_funcs :
-        Existing dictionary of initialization functions to update. If None, a new dictionary will be created.
-        If the dictionary is missing any keys, they will be backfilled with defaults.
+        Existing dictionary of initialization functions to update. If None, a fresh copy of
+        ``DEFAULT_INIT_FUNCTIONS_GLMHMM`` is used. Keys must already be validated before calling
+        this function; use the class ``initialization_funcs`` setter for key validation.
 
     Returns
     -------
     init_funcs :
-        Updated or initialized dictionary based on provided inputs.
+        Updated dictionary of initialization functions based on provided inputs.
     """
 
     if init_funcs is None:
@@ -571,11 +572,12 @@ def generate_glm_hmm_initial_model_params(
     init_funcs: Optional[dict] = None,
 ) -> Tuple[Any, jnp.ndarray, jnp.ndarray]:
     """
-    Generate initial GLM-HMM parameters using the provided initialization functions.
+    Generate initial GLM model parameters for a GLM-HMM.
 
-    Calls the specified initialization functions for GLM coefficients, intercept, scale,
-    initial state probabilities, and transition probabilities, splitting the random key
-    to ensure independent random states for each component.
+    Calls the specified initialization functions for GLM coefficients, intercept, and scale,
+    splitting the random key to ensure independent random states for each component.
+    HMM parameters (initial and transition probabilities) are initialized separately via
+    :meth:`~nemos.hmm.BaseHMM._hmm_params_initialization`.
 
     Parameters
     ----------
@@ -588,29 +590,25 @@ def generate_glm_hmm_initial_model_params(
     inverse_link_function :
         Inverse link function of the GLM, passed to GLM parameter and scale initialization functions.
     is_new_session :
-        Boolean array of shape (n_samples,) indicating the start of new sessions. Passed to all
-        initialization functions. If None, a single session is assumed.
+        Boolean array of shape (n_samples,) indicating the start of new sessions. If None, a single
+        session is assumed.
     random_key :
-        Key for random number generation. Split into three independent subkeys for GLM params,
-        scale, and HMM probabilities respectively.
+        Key for random number generation. Split into two independent subkeys for GLM params
+        and scale respectively.
     init_funcs :
-        Dictionary containing initialization functions and their kwargs for all GLM-HMM parameters.
-        Can be constructed with :func:`setup_glm_hmm_initialization`. Missing keys are backfilled
-        with defaults.
+        Dictionary containing initialization functions and their kwargs for GLM parameters.
+        Can be constructed with :func:`setup_glm_hmm_initialization`. GLM-specific keys missing
+        from the dict fall back to ``GLM_INIT_FUNCS`` defaults.
 
     Returns
     -------
     coef :
         GLM coefficients, a pytree matching the structure of X with leaves of shape
-        (n_features, n_neurons, n_states) or (n_features, n_states) for single-neuron.
+        ``(n_features, n_neurons, n_states)`` or ``(n_features, n_states)`` for single-neuron.
     intercept :
-        Intercept array of shape (n_neurons, n_states) or (n_states,) for single-neuron.
+        Intercept array of shape ``(n_neurons, n_states)`` or ``(n_states,)`` for single-neuron.
     scale :
-        Scale array of shape (n_states,) for single-neuron or (n_neurons, n_states) for population.
-    initial_probs :
-        Initial state probability vector of shape (n_states,) that sums to 1.
-    transition_matrix :
-        Transition probability matrix of shape (n_states, n_states) where each row sums to 1.
+        Scale array of shape ``(n_states,)`` for single-neuron or ``(n_neurons, n_states)`` for population.
 
     See Also
     --------

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -581,7 +581,10 @@ def generate_glm_hmm_initial_model_params(
     )
     glm_params_init_kwargs = glm_init_funcs.get("glm_params_init_kwargs") or {}
 
-    if glm_params_init is kmeans_glm_params_init and "observation_model" not in glm_params_init_kwargs:
+    if (
+        glm_params_init is kmeans_glm_params_init
+        and "observation_model" not in glm_params_init_kwargs
+    ):
         raise ValueError(
             "The 'kmeans' GLM parameter initializer requires 'observation_model' to be "
             "provided in 'glm_params_init_kwargs'."
@@ -602,7 +605,10 @@ def generate_glm_hmm_initial_model_params(
     )
     scale_init_kwargs = glm_init_funcs.get("scale_init_kwargs") or {}
 
-    if scale_init_fn is kmeans_scale_init and "observation_model" not in scale_init_kwargs:
+    if (
+        scale_init_fn is kmeans_scale_init
+        and "observation_model" not in scale_init_kwargs
+    ):
         raise ValueError(
             "The 'kmeans' scale initializer requires 'observation_model' to be "
             "provided in 'scale_init_kwargs'."

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -19,7 +19,6 @@ from ..hmm.initialize_parameters import (
     _get_protocol_parameters,
     _validate_init_funcs_keys,
     _validate_init_funcs_kwargs,
-    generate_hmm_initial_params,
     setup_hmm_initialization,
 )
 from ..pytrees import FeaturePytree
@@ -567,7 +566,7 @@ def setup_glm_hmm_initialization(
     return glm_init_funcs
 
 
-def generate_glm_hmm_initial_params(
+def generate_glm_hmm_initial_model_params(
     n_states: int,
     X: DESIGN_INPUT_TYPE,
     y: NDArray | jnp.ndarray,
@@ -575,7 +574,7 @@ def generate_glm_hmm_initial_params(
     is_new_session: Optional[NDArray | jnp.ndarray] = None,
     random_key: int | jax.Array = 123,
     init_funcs: Optional[dict] = None,
-) -> Tuple[Any, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+) -> Tuple[Any, jnp.ndarray, jnp.ndarray]:
     """
     Generate initial GLM-HMM parameters using the provided initialization functions.
 
@@ -625,12 +624,10 @@ def generate_glm_hmm_initial_params(
     """
     init_funcs = {} if init_funcs is None else init_funcs
     glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
-    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
-
     if isinstance(random_key, int):
         random_key = jax.random.PRNGKey(random_key)
 
-    glm_params_key, scale_key, hmm_key = jax.random.split(random_key, 3)
+    glm_params_key, scale_key = jax.random.split(random_key, 2)
 
     glm_init_funcs = _validate_init_funcs_keys(
         glm_init_funcs, default_init_dict=GLM_INIT_FUNCS
@@ -664,13 +661,4 @@ def generate_glm_hmm_initial_params(
         **scale_init_kwargs,
     )
 
-    initial_probs, transition_matrix = generate_hmm_initial_params(
-        n_states,
-        X,
-        y,
-        is_new_session,
-        hmm_key,
-        hmm_init_funcs,
-    )
-
-    return coef, intercept, scale, initial_probs, transition_matrix
+    return coef, intercept, scale

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -378,7 +378,7 @@ def constant_scale_init(
     return scale
 
 
-GLM_INIT_FUCS = {
+GLM_INIT_FUNCS = {
     "glm_params_init": random_glm_params_init,
     "glm_params_init_kwargs": {},
     "glm_params_init_custom": False,
@@ -387,7 +387,7 @@ GLM_INIT_FUCS = {
     "scale_init_custom": False,
 }
 DEFAULT_INIT_FUNCTIONS_GLMHMM = DEFAULT_INIT_FUNCTIONS.copy()
-DEFAULT_INIT_FUNCTIONS_GLMHMM.update(GLM_INIT_FUCS)
+DEFAULT_INIT_FUNCTIONS_GLMHMM.update(GLM_INIT_FUNCS)
 
 AVAIL_INIT_FUNCTIONS_GLM = {
     "glm_params_init": {
@@ -467,15 +467,15 @@ def setup_glm_hmm_initialization(
 
     if init_funcs is None:
         init_funcs = DEFAULT_INIT_FUNCTIONS_GLMHMM.copy()
-        glm_init_funcs = GLM_INIT_FUCS.copy()
+        glm_init_funcs = GLM_INIT_FUNCS.copy()
     else:
 
-        glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUCS}
+        glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
         # check for unexpected/unknown keys in init_funcs and backfill with defaults
         # note that the hmm init function falidation will be done in the setup
         init_funcs = _validate_init_funcs_keys(init_funcs, glm_init_funcs)
 
-    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUCS}
+    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
     hmm_init_funcs = setup_hmm_initialization(
         initial_proba_init,
         initial_proba_init_kwargs,
@@ -578,8 +578,8 @@ def generate_glm_hmm_initial_params(
         Function to set up the initialization functions and their kwargs based on user input.
     """
     init_funcs = {} if init_funcs is None else init_funcs
-    glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUCS}
-    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUCS}
+    glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
+    hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
 
     if isinstance(random_key, int):
         random_key = jax.random.PRNGKey(random_key)
@@ -587,11 +587,11 @@ def generate_glm_hmm_initial_params(
     glm_params_key, scale_key, hmm_key = jax.random.split(random_key, 3)
 
     glm_init_funcs = _validate_init_funcs_keys(
-        glm_init_funcs, default_init_dict=GLM_INIT_FUCS
+        glm_init_funcs, default_init_dict=GLM_INIT_FUNCS
     )
 
     glm_params_init = (
-        glm_init_funcs["glm_params_init"] or GLM_INIT_FUCS["glm_params_init"]
+        glm_init_funcs["glm_params_init"] or GLM_INIT_FUNCS["glm_params_init"]
     )
     glm_params_init_kwargs = glm_init_funcs["glm_params_init_kwargs"] or {}
 
@@ -606,7 +606,7 @@ def generate_glm_hmm_initial_params(
     if glm_init_funcs["glm_params_init_custom"]:
         _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
 
-    scale_init_fn = glm_init_funcs["scale_init"] or GLM_INIT_FUCS["scale_init"]
+    scale_init_fn = glm_init_funcs["scale_init"] or GLM_INIT_FUNCS["scale_init"]
     scale_init_kwargs = glm_init_funcs["scale_init_kwargs"] or {}
 
     scale = scale_init_fn(

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -521,7 +521,9 @@ def setup_glm_hmm_initialization(
         glm_init_funcs = {k: v for k, v in init_funcs.items() if k in GLM_INIT_FUNCS}
         # check for unexpected/unknown keys in init_funcs and backfill with defaults
         # note that the hmm init function validation will be done in the setup
-        init_funcs = _validate_init_funcs_keys(init_funcs, DEFAULT_INIT_FUNCTIONS_GLMHMM)
+        init_funcs = _validate_init_funcs_keys(
+            init_funcs, DEFAULT_INIT_FUNCTIONS_GLMHMM
+        )
 
     hmm_init_funcs = {k: v for k, v in init_funcs.items() if k not in GLM_INIT_FUNCS}
     hmm_init_funcs = setup_hmm_initialization(

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -39,10 +39,10 @@ class InitFunctionGLM(Protocol):
         X: DESIGN_INPUT_TYPE,
         y: NDArray | jnp.ndarray,
         inverse_link_function: Callable,
-        random_key: jax.random.PRNGKey,
+        random_key: jax.Array,
         **kwargs: Any,
     ) -> jnp.ndarray:
-        """Initialize HMM probabilities."""
+        """Initialize GLM parameters and scale."""
         ...
 
 
@@ -79,22 +79,25 @@ def random_glm_params_init(
 
     Returns
     -------
-    coef : jnp.ndarray
-        Coefficient matrix of shape (n_features, n_neurons, n_states).
+    coef : Any
+        Coefficient, a pytree with the same structure as X with leaves
+         of shape (n_features, n_neurons, n_states).
     intercept : jnp.ndarray
         Intercept array of shape (n_neurons, n_states).
     """
-    n_features = X.shape[1]
     is_one_dim = y.ndim == 1
     n_neurons = 1 if is_one_dim else y.shape[1]
-
     # small random noisy coef
-    coef = std_dev * jax.random.normal(random_key, (n_features, n_neurons, n_states))
+    coef = jax.tree_util.tree_map(
+        lambda x: std_dev
+        * jax.random.normal(random_key, (x.shape[1], n_neurons, n_states)),
+        X,
+    )
     # mean-rate
     intercept = initialize_intercept_matching_mean_rate(inverse_link_function, y)
     intercept = jnp.tile(intercept[:, jnp.newaxis], (1, n_states))
     if is_one_dim:
-        coef = jnp.squeeze(coef, axis=1)
+        coef = jax.tree_util.tree_map(lambda x: jnp.squeeze(x, axis=1), coef)
         intercept = jnp.squeeze(intercept, axis=0)
     return coef, intercept
 
@@ -149,7 +152,7 @@ class KMeansInitializerGLM(KMeansInitializer):
             minimum_prob=minimum_prob,
             random_key=random_key,
         )
-        self._X = jnp.asarray(X)
+        self._X = jax.tree_util.tree_map(jnp.asarray, X)
         self._y = jnp.asarray(y)
         self.inverse_link_function = inverse_link_function
         self.glm_kwargs = glm_kwargs if glm_kwargs is not None else {}
@@ -179,7 +182,9 @@ class KMeansInitializerGLM(KMeansInitializer):
             model = self._glm_models[i]
             X_state, y_state = self._X[state_mask], self._y[state_mask]
             model.fit(X_state, y_state)
-            coef = coef.at[:, i].set(model.coef_)
+            coef = jax.tree_util.tree_map(
+                lambda c, mc: c.at[:, i].set(mc), coef, model.coef_
+            )
             intercept = intercept.at[i : i + 1].set(model.intercept_)
 
         return coef, intercept
@@ -512,7 +517,7 @@ def generate_glm_hmm_initial_params(
     inverse_link_function: Callable,
     random_key: int | jax.Array = 123,
     init_funcs: Optional[dict] = None,
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+) -> Tuple[Any, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """
     Generate initial HMM parameters using the provided initialization functions.
 

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -8,8 +8,6 @@ import jax
 import jax.numpy as jnp
 from numpy.typing import NDArray
 
-from build.lib.nemos.tree_utils import pytree_map_and_reduce
-
 from ..glm import GLM, PopulationGLM
 from ..glm.initialize_parameters import initialize_intercept_matching_mean_rate
 from ..glm.params import GLMUserParams
@@ -24,6 +22,7 @@ from ..hmm.initialize_parameters import (
     setup_hmm_initialization,
 )
 from ..pytrees import FeaturePytree
+from ..tree_utils import pytree_map_and_reduce
 from ..type_casting import cast_to_jax, is_numpy_array_like
 from ..typing import DESIGN_INPUT_TYPE
 from ..validation import check_tree_structure
@@ -166,10 +165,12 @@ class KMeansInitializerGLM(KMeansInitializer):
         self.glm_kwargs = glm_kwargs if glm_kwargs is not None else {}
         if self._y.ndim == 1:
             self._glm_models = {i: GLM(**self.glm_kwargs) for i in range(self.n_states)}
+            self._is_population = False
         else:
             self._glm_models = {
                 i: PopulationGLM(**self.glm_kwargs) for i in range(self.n_states)
             }
+            self._is_population = True
 
     def glm_params(self) -> GLMUserParams:
         """Generate glm parameters for initialization."""
@@ -189,9 +190,12 @@ class KMeansInitializerGLM(KMeansInitializer):
             X_state, y_state = self._X[state_mask], self._y[state_mask]
             model.fit(X_state, y_state)
             coef = jax.tree_util.tree_map(
-                lambda c, mc: c.at[:, i].set(mc), coef, model.coef_
+                lambda c, mc: c.at[..., i].set(mc), coef, model.coef_
             )
-            intercept = intercept.at[i : i + 1].set(model.intercept_)
+            if self._is_population:
+                intercept = intercept.at[..., i].set(model.intercept_)
+            else:
+                intercept = intercept.at[i : i + 1].set(model.intercept_)
 
         return coef, intercept
 

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -52,7 +52,7 @@ def random_glm_params_init(
     y: jnp.ndarray,
     inverse_link_function: Callable,
     is_new_session: Optional[NDArray | jnp.ndarray] = None,
-    random_key=jax.random.PRNGKey(123),
+    random_key: Optional[jax.Array] = None,
     std_dev=0.001,
 ) -> GLMUserParams:
     """
@@ -88,6 +88,8 @@ def random_glm_params_init(
     intercept : jnp.ndarray
         Intercept array of shape (n_neurons, n_states).
     """
+    if random_key is None:
+        random_key = jax.random.PRNGKey(123)
     is_one_dim = y.ndim == 1
     n_neurons = 1 if is_one_dim else y.shape[1]
     if isinstance(X, FeaturePytree):
@@ -209,7 +211,7 @@ class KMeansInitializerGLM(KMeansInitializer):
         is_population = self._y.ndim > 1
         if is_population:
             n_neurons = self._y.shape[1]
-            scale = jnp.ones((self.n_states, n_neurons))
+            scale = jnp.ones((n_neurons, self.n_states))
         else:
             scale = jnp.ones((self.n_states,))
 
@@ -218,8 +220,9 @@ class KMeansInitializerGLM(KMeansInitializer):
 
         if self._glm_models[0].scale_ is None:
             self.fit()
+
         for i, m in enumerate(self._glm_models.values()):
-            scale = scale.at[i].set(m.scale_)
+            scale = scale.at[..., i].set(m.scale_)
         return scale
 
 
@@ -231,7 +234,7 @@ def kmeans_glm_params_init(
     is_new_session: Optional[jnp.ndarray] = None,
     glm_kwargs: Optional[dict] = None,
     minimum_prob: float = 0.02,
-    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    random_key: Optional[jax.Array] = None,
     initializer: Optional[KMeansInitializer] = None,
 ):
     """
@@ -266,6 +269,8 @@ def kmeans_glm_params_init(
     coef, intercept :
         The glm coefficients and intercept.
     """
+    if random_key is None:
+        random_key = jax.random.PRNGKey(123)
     if initializer is None:
         initializer = KMeansInitializerGLM(
             n_states,
@@ -288,7 +293,7 @@ def kmeans_scale_init(
     is_new_session: Optional[jnp.ndarray] = None,
     glm_kwargs: Optional[dict] = None,
     minimum_prob: float = 0.02,
-    random_key: jax.random.PRNGKey = jax.random.PRNGKey(123),
+    random_key: Optional[jax.Array] = None,
     initializer: Optional[KMeansInitializer] = None,
 ):
     """
@@ -323,6 +328,8 @@ def kmeans_scale_init(
     scale :
         The inital scale.
     """
+    if random_key is None:
+        random_key = jax.random.PRNGKey(123)
     if initializer is None:
         initializer = KMeansInitializerGLM(
             n_states,

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -623,9 +623,9 @@ def generate_glm_hmm_initial_model_params(
     glm_params_key, scale_key = jax.random.split(random_key, 2)
 
     glm_params_init = (
-        glm_init_funcs["glm_params_init"] or GLM_INIT_FUNCS["glm_params_init"]
+        glm_init_funcs.get("glm_params_init") or GLM_INIT_FUNCS["glm_params_init"]
     )
-    glm_params_init_kwargs = glm_init_funcs["glm_params_init_kwargs"] or {}
+    glm_params_init_kwargs = glm_init_funcs.get("glm_params_init_kwargs") or {}
 
     coef, intercept = glm_params_init(
         n_states=n_states,
@@ -637,8 +637,8 @@ def generate_glm_hmm_initial_model_params(
         **glm_params_init_kwargs,
     )
 
-    scale_init_fn = glm_init_funcs["scale_init"] or GLM_INIT_FUNCS["scale_init"]
-    scale_init_kwargs = glm_init_funcs["scale_init_kwargs"] or {}
+    scale_init_fn = glm_init_funcs.get("scale_init") or GLM_INIT_FUNCS["scale_init"]
+    scale_init_kwargs = glm_init_funcs.get("scale_init_kwargs") or {}
 
     scale = scale_init_fn(
         n_states=n_states,

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -31,8 +31,6 @@ from .initialize_parameters import (
     _resolve_dirichlet_priors,
     _validate_init_funcs_keys,
     generate_hmm_initial_params,
-    kmeans_initial_proba_init,
-    kmeans_transition_proba_init,
     setup_hmm_initialization,
 )
 from .params import HMMModelParamsT, HMMUserParams, HMMUserProvidedParamsT
@@ -95,11 +93,7 @@ class BaseHMM(
     """
 
     _validator_class: type[HMMValidator[HMMUserProvidedParamsT, HMMModelParamsT]]
-    _default_init_dict: dict = DEFAULT_INIT_FUNCTIONS
-    _kmeans_init_funcs: tuple[tuple[str, Callable]] = (
-        ("initial_proba_init", kmeans_initial_proba_init),
-        ("transition_proba_init", kmeans_transition_proba_init),
-    )
+    _model_default_init_dict: INITIALIZATION_FN_DICT_T
     _kmeans_init_class = KMeansInitializer
 
     def __init__(
@@ -118,7 +112,7 @@ class BaseHMM(
         maxiter: int = 1000,
         tol: float = 1e-8,
         seed=jax.random.PRNGKey(123),
-        initialization_funcs: Optional[INITIALIZATION_FN_DICT_T] = None,
+        hmm_initialization_funcs: Optional[INITIALIZATION_FN_DICT_T] = None,
     ):
         super().__init__(
             regularizer=regularizer,
@@ -139,9 +133,13 @@ class BaseHMM(
         self.transition_prob_: Optional[jnp.ndarray] = None
         self.initial_prob_: Optional[jnp.ndarray] = None
 
-        self.initialization_funcs = initialization_funcs
+        self.hmm_initialization_funcs = hmm_initialization_funcs
 
-    def setup(
+        # flags for kmeans initialization
+        self._hmm_use_kmeans = None
+        self._model_use_kmeans = None
+
+    def _hmm_setup(
         self,
         initial_proba_init: Optional[str | Callable] = None,
         initial_proba_init_kwargs: Optional[dict] = None,
@@ -187,14 +185,45 @@ class BaseHMM(
         transition_proba_init_kwargs :
             A dictionary of keyword arguments to pass to the transition probability initialization function.
         """
-        self._initialization_funcs = setup_hmm_initialization(
+        # flag for initializing kmeans model at parameter initialization
+        self._hmm_use_kmeans = {
+            "initial_proba_init": initial_proba_init == "kmeans",
+            "transition_proba_init": transition_proba_init == "kmeans",
+        }
+        self._hmm_initialization_funcs = setup_hmm_initialization(
             initial_proba_init=initial_proba_init,
             initial_proba_init_kwargs=initial_proba_init_kwargs,
             transition_proba_init=transition_proba_init,
             transition_proba_init_kwargs=transition_proba_init_kwargs,
-            init_funcs=self._initialization_funcs,
-            default_init_dict=self._default_init_dict,
+            init_funcs=self._hmm_initialization_funcs,
         )
+
+    @abc.abstractmethod
+    def _model_setup(self):
+        """Model-specific setup of initialization functions."""
+        # self._model_use_kmeans and self._model_initialization_funcs must be set here
+        pass
+
+    def setup(
+        self,
+        initial_proba_init: Optional[str | Callable] = None,
+        initial_proba_init_kwargs: Optional[dict] = None,
+        transition_proba_init: Optional[str | Callable] = None,
+        transition_proba_init_kwargs: Optional[dict] = None,
+        **kwargs,
+    ):
+        """
+        Set up the HMM-based model, including HMM and model-specific setup.
+
+        This can be overwritten by the child class for custom docstrings.
+        """
+        self._hmm_setup(
+            initial_proba_init=initial_proba_init,
+            initial_proba_init_kwargs=initial_proba_init_kwargs,
+            transition_proba_init=transition_proba_init,
+            transition_proba_init_kwargs=transition_proba_init_kwargs,
+        )
+        self._model_setup(**kwargs)
 
     @property
     def n_states(self) -> int:
@@ -321,24 +350,44 @@ class BaseHMM(
         self._seed = value
 
     @property
-    def initialization_funcs(self) -> INITIALIZATION_FN_DICT_T | None:
+    def hmm_initialization_funcs(self) -> INITIALIZATION_FN_DICT_T | None:
         """Dictionary of initialization functions for HMM parameters."""
-        return self._initialization_funcs
+        return self._hmm_initialization_funcs
 
-    @initialization_funcs.setter
-    def initialization_funcs(self, value: INITIALIZATION_FN_DICT_T | None):
+    @hmm_initialization_funcs.setter
+    def hmm_initialization_funcs(self, value: INITIALIZATION_FN_DICT_T | None):
         """
         Set the dictionary of initialization functions for HMM parameters.
 
-        Validates keys against the model-specific ``_default_init_dict`` and merges
-        with defaults before storing. Calls :meth:`setup` afterward to apply any
+        Validates keys against the HMM-specific DEFAULT_INIT_FUNCTIONS and merges
+        with defaults before storing. Calls :meth:`_hmm_setup` afterward to apply any
         function/kwargs updates. May be called directly or via ``__init__``.
         """
         # always key validated in a model dependent way
-        self._initialization_funcs = _validate_init_funcs_keys(
-            value, self._default_init_dict
+        self._hmm_initialization_funcs = _validate_init_funcs_keys(
+            value, DEFAULT_INIT_FUNCTIONS
         )
-        self.setup()
+        self._hmm_setup()
+
+    @property
+    def model_initialization_funcs(self) -> INITIALIZATION_FN_DICT_T | None:
+        """Dictionary of initialization functions for HMM parameters."""
+        return self._model_initialization_funcs
+
+    @model_initialization_funcs.setter
+    def model_initialization_funcs(self, value: INITIALIZATION_FN_DICT_T | None):
+        """
+        Set the dictionary of initialization functions for model parameters.
+
+        Validates keys against the model-specific ``_model_default_init_dict`` and merges
+        with defaults before storing. Calls :meth:`_model_setup` afterward to apply any
+        function/kwargs updates. May be called directly or via ``__init__``.
+        """
+        # always key validated in a model dependent way
+        self._model_initialization_funcs = _validate_init_funcs_keys(
+            value, self._model_default_init_dict
+        )
+        self._model_setup()
 
     def _hmm_params_initialization(
         self,
@@ -375,11 +424,11 @@ class BaseHMM(
             y,
             is_new_session,
             random_key_pair=random_key_pair,
-            init_funcs=self._initialization_funcs,
+            init_funcs=self._hmm_initialization_funcs,
         )
-        validate_params = self._initialization_funcs.get(
+        validate_params = self._hmm_initialization_funcs.get(
             "initial_proba_init_custom", True
-        ) or self._initialization_funcs.get("transition_proba_init_custom", True)
+        ) or self._hmm_initialization_funcs.get("transition_proba_init_custom", True)
         return hmm_params, validate_params
 
     @abc.abstractmethod
@@ -406,52 +455,78 @@ class BaseHMM(
         """
         pass
 
+    @property
+    def _use_kmeans(self) -> bool:
+        """Check if kmeans initialization is needed for any HMM parameters."""
+        return (
+            (self._hmm_use_kmeans is not None) and any(self._hmm_use_kmeans.values())
+        ) or (
+            (self._model_use_kmeans is not None)
+            and any(self._model_use_kmeans.values())
+        )
+
     def _kmeans_extra_kwargs(self) -> dict:
+        """Extra kwargs to initialize the kmeans model. Can be overridden by child classes if needed."""
         return {}
 
-    def _kmeans_resolve(
+    def _kmeans_resolve_model_kwargs(self, use_kmeans, init_funcs) -> dict:
+        """
+        Extract model kmeans kwargs and ensure consistency across relevant init funcs.
+
+        This is not relevant for HMM init funcs, whose kwargs are not needed for the kmeans initializer
+        """
+        kmeans_kwargs = {}
+        for param, use in use_kmeans.items():
+            if use:
+                kwargs = init_funcs.get(f"{param}_kwargs", {})
+                for k, v in kwargs.items():
+                    if k in kmeans_kwargs:
+                        if not eqx.tree_equal(kmeans_kwargs[k], v):
+                            raise ValueError(
+                                f"Inconsistent KMeans init arg '{k}': "
+                                f"{kmeans_kwargs[k]} != {v}"
+                            )
+                    else:
+                        kmeans_kwargs[k] = v
+        return kmeans_kwargs
+
+    def _kmeans_setup_initializer(
         self, X, y, is_new_session=None, random_key: jnp.ndarray = None
     ):
-        kmeans_kwargs = {}
-
-        # Only iterate over the canonical kmeans init funcs
-        has_kmeans = False
-        for func_name, func in self._kmeans_init_funcs:
-            registered_func = self._initialization_funcs.get(func_name)
-
-            if registered_func is not func:
-                continue  # skip anything that doesn't match expected function
-            has_kmeans = True
-            kwargs = self._initialization_funcs.get(f"{func_name}_kwargs", {})
-
-            for k, v in kwargs.items():
-                if k in kmeans_kwargs:
-                    if not eqx.tree_equal(kmeans_kwargs[k], v):
-                        raise ValueError(
-                            f"Inconsistent KMeans init arg '{k}': "
-                            f"{kmeans_kwargs[k]} != {v}"
-                        )
-                else:
-                    kmeans_kwargs[k] = v
-        if has_kmeans:
-            # Resolve initializer
-            initializer = kmeans_kwargs.get(
-                "initializer",
-                self._kmeans_init_class(
-                    self.n_states,
-                    X,
-                    y,
-                    is_new_session=is_new_session,
-                    random_key=random_key,
-                    **self._kmeans_extra_kwargs(),
-                    **kmeans_kwargs,
-                ),
+        """Set up the kmeans initializer if any HMM or model parameters require kmeans initialization."""
+        # get additional model-specific kwargs for kmeans initializer if needed
+        if self._model_use_kmeans is not None:
+            kmeans_kwargs = self._kmeans_resolve_model_kwargs(
+                self._model_use_kmeans, self._model_initialization_funcs
             )
+        else:
+            kmeans_kwargs = {}
 
-            # Inject initializer back only into relevant funcs
-            for func_name, func in self._kmeans_init_funcs:
-                if self._initialization_funcs.get(func_name) is func:
-                    self._initialization_funcs[f"{func_name}_kwargs"][
+        # setup initializer
+        initializer = kmeans_kwargs.get(
+            "initializer",
+            self._kmeans_init_class(
+                self.n_states,
+                X,
+                y,
+                is_new_session=is_new_session,
+                random_key=random_key,
+                **self._kmeans_extra_kwargs(),
+                **kmeans_kwargs,
+            ),
+        )
+
+        # Inject initializer back only into relevant funcs
+        if self._hmm_use_kmeans is not None:
+            for param, use_kmeans in self._hmm_use_kmeans.items():
+                if use_kmeans:
+                    self._hmm_initialization_funcs[f"{param}_kwargs"][
+                        "initializer"
+                    ] = initializer
+        if self._model_use_kmeans is not None:
+            for param, use_kmeans in self._model_use_kmeans.items():
+                if use_kmeans:
+                    self._model_initialization_funcs[f"{param}_kwargs"][
                         "initializer"
                     ] = initializer
 
@@ -463,9 +538,10 @@ class BaseHMM(
         model_key = keys[3]
 
         # check kmeans kwargs and setup initializer.
-        self._kmeans_resolve(
-            X, y, is_new_session=is_new_session, random_key=hmm_keys[0]
-        )
+        if self._use_kmeans:
+            self._kmeans_setup_initializer(
+                X, y, is_new_session=is_new_session, random_key=hmm_keys[0]
+            )
 
         hmm_params, validate_hmm = self._hmm_params_initialization(
             X,

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -415,12 +415,13 @@ class BaseHMM(
         kmeans_kwargs = {}
 
         # Only iterate over the canonical kmeans init funcs
+        has_kmeans = False
         for func_name, func in self._kmeans_init_funcs:
             registered_func = self._initialization_funcs.get(func_name)
 
             if registered_func is not func:
                 continue  # skip anything that doesn't match expected function
-
+            has_kmeans = True
             kwargs = self._initialization_funcs.get(f"{func_name}_kwargs", {})
 
             for k, v in kwargs.items():
@@ -432,27 +433,27 @@ class BaseHMM(
                         )
                 else:
                     kmeans_kwargs[k] = v
+        if has_kmeans:
+            # Resolve initializer
+            initializer = kmeans_kwargs.get(
+                "initializer",
+                self._kmeans_init_class(
+                    self.n_states,
+                    X,
+                    y,
+                    is_new_session=is_new_session,
+                    random_key=random_key,
+                    **self._kmeans_extra_kwargs(),
+                    **kmeans_kwargs,
+                ),
+            )
 
-        # Resolve initializer
-        initializer = kmeans_kwargs.get(
-            "initializer",
-            self._kmeans_init_class(
-                self.n_states,
-                X,
-                y,
-                is_new_session=is_new_session,
-                random_key=random_key,
-                **self._kmeans_extra_kwargs(),
-                **kmeans_kwargs,
-            ),
-        )
-
-        # Inject initializer back only into relevant funcs
-        for func_name, func in self._kmeans_init_funcs:
-            if self._initialization_funcs.get(func_name) is func:
-                self._initialization_funcs[f"{func_name}_kwargs"][
-                    "initializer"
-                ] = initializer
+            # Inject initializer back only into relevant funcs
+            for func_name, func in self._kmeans_init_funcs:
+                if self._initialization_funcs.get(func_name) is func:
+                    self._initialization_funcs[f"{func_name}_kwargs"][
+                        "initializer"
+                    ] = initializer
 
     def _model_specific_initialization(self, X, y, is_new_session=None):
         """Model-specific initialization."""

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -481,7 +481,8 @@ class BaseHMM(
                 kwargs = init_funcs.get(f"{param}_kwargs", {})
                 for k, v in kwargs.items():
                     if k in kmeans_kwargs:
-                        if not eqx.tree_equal(kmeans_kwargs[k], v):
+                        eq = eqx.tree_equal(kmeans_kwargs[k], v)
+                        if eq is None or not bool(eq):
                             raise ValueError(
                                 f"Inconsistent KMeans init arg '{k}': "
                                 f"{kmeans_kwargs[k]} != {v}"
@@ -491,7 +492,7 @@ class BaseHMM(
         return kmeans_kwargs
 
     def _kmeans_setup_initializer(
-        self, X, y, is_new_session=None, random_key: jnp.ndarray = None
+        self, X, y, is_new_session=None, random_key: Optional[jax.Array] = None
     ):
         """Set up the kmeans initializer if any HMM or model parameters require kmeans initialization."""
         # get additional model-specific kwargs for kmeans initializer if needed
@@ -532,15 +533,17 @@ class BaseHMM(
 
     def _model_specific_initialization(self, X, y, is_new_session=None):
         """Model-specific initialization."""
-        keys = jax.random.split(self._seed, 4)
-        hmm_keys = keys[1:3]
+        keys = jax.random.split(self._seed, 3)
+        hmm_keys = keys[:2]
         # the model needs to figure out how to split the key internally
-        model_key = keys[3]
+        model_key = keys[2]
 
         # check kmeans kwargs and setup initializer.
+        # fold_in derives an independent key so hmm_keys and model_key are unaffected.
         if self._use_kmeans:
+            kmeans_key = jax.random.fold_in(self._seed, 0)
             self._kmeans_setup_initializer(
-                X, y, is_new_session=is_new_session, random_key=hmm_keys[0]
+                X, y, is_new_session=is_new_session, random_key=kmeans_key
             )
 
         hmm_params, validate_hmm = self._hmm_params_initialization(

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -7,6 +7,7 @@ import warnings
 from numbers import Number
 from typing import Any, Callable, Generic, Literal, Optional, Tuple, TypeVar, Union
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lazy_loader as lazy
@@ -26,9 +27,12 @@ from ..typing import (
 )
 from .initialize_parameters import (
     DEFAULT_INIT_FUNCTIONS,
+    KMeansInitializer,
     _resolve_dirichlet_priors,
     _validate_init_funcs_keys,
     generate_hmm_initial_params,
+    kmeans_initial_proba_init,
+    kmeans_transition_proba_init,
     setup_hmm_initialization,
 )
 from .params import HMMModelParamsT, HMMUserParams, HMMUserProvidedParamsT
@@ -92,6 +96,11 @@ class BaseHMM(
 
     _validator_class: type[HMMValidator[HMMUserProvidedParamsT, HMMModelParamsT]]
     _default_init_dict: dict = DEFAULT_INIT_FUNCTIONS
+    _kmeans_init_funcs: tuple[tuple[str, Callable]] = (
+        ("initial_proba_init", kmeans_initial_proba_init),
+        ("transition_proba_init", kmeans_transition_proba_init),
+    )
+    _kmeans_init_class = KMeansInitializer
 
     def __init__(
         self,
@@ -397,12 +406,66 @@ class BaseHMM(
         """
         pass
 
+    def _kmeans_extra_kwargs(self) -> dict:
+        return {}
+
+    def _kmeans_resolve(
+        self, X, y, is_new_session=None, random_key: jnp.ndarray = None
+    ):
+        kmeans_kwargs = {}
+
+        # Only iterate over the canonical kmeans init funcs
+        for func_name, func in self._kmeans_init_funcs:
+            registered_func = self._initialization_funcs.get(func_name)
+
+            if registered_func is not func:
+                continue  # skip anything that doesn't match expected function
+
+            kwargs = self._initialization_funcs.get(f"{func_name}_kwargs", {})
+
+            for k, v in kwargs.items():
+                if k in kmeans_kwargs:
+                    if not eqx.tree_equal(kmeans_kwargs[k], v):
+                        raise ValueError(
+                            f"Inconsistent KMeans init arg '{k}': "
+                            f"{kmeans_kwargs[k]} != {v}"
+                        )
+                else:
+                    kmeans_kwargs[k] = v
+
+        # Resolve initializer
+        initializer = kmeans_kwargs.get(
+            "initializer",
+            self._kmeans_init_class(
+                self.n_states,
+                X,
+                y,
+                is_new_session=is_new_session,
+                random_key=random_key,
+                **self._kmeans_extra_kwargs(),
+                **kmeans_kwargs,
+            ),
+        )
+
+        # Inject initializer back only into relevant funcs
+        for func_name, func in self._kmeans_init_funcs:
+            if self._initialization_funcs.get(func_name) is func:
+                self._initialization_funcs[f"{func_name}_kwargs"][
+                    "initializer"
+                ] = initializer
+
     def _model_specific_initialization(self, X, y, is_new_session=None):
         """Model-specific initialization."""
-        keys = jax.random.split(self._seed, 3)
-        hmm_keys = keys[:2]
+        keys = jax.random.split(self._seed, 4)
+        hmm_keys = keys[1:3]
         # the model needs to figure out how to split the key internally
-        model_key = keys[2]
+        model_key = keys[3]
+
+        # check kmeans kwargs and setup initializer.
+        self._kmeans_resolve(
+            X, y, is_new_session=is_new_session, random_key=hmm_keys[0]
+        )
+
         hmm_params, validate_hmm = self._hmm_params_initialization(
             X,
             y,

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -465,6 +465,8 @@ class KMeansInitializer:
         )
         self.model.fit(data)
         self.states = jax.nn.one_hot(self.model.labels_, num_classes=n_states)
+        self._X = jnp.asarray(X)
+        self._y = jnp.asarray(y)
 
     def initial_probability(self):
         """

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -448,7 +448,6 @@ class KMeansInitializer:
             random_key = int(jax.random.randint(random_key, (), 0, 2**31 - 1))
 
         self.n_states = n_states
-        # self.minimum_prob = minimum_prob
         self.random_key = random_key
         self.is_new_session = initialize_is_new_session(X, y, is_new_session)
         self.model = sklearn.cluster.KMeans(

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -960,10 +960,7 @@ def generate_hmm_initial_params(
         random_key=random_key_pair[1],
         **transition_proba_init_kwargs,
     )
-    if init_funcs["transition_proba_init_custom"]:
-        _validate_custom_init_output(
-            transition_matrix, n_states, "transition_proba_init"
-        )
+
     return initial_probs, transition_matrix
 
 

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -465,8 +465,6 @@ class KMeansInitializer:
         )
         self.model.fit(data)
         self.states = jax.nn.one_hot(self.model.labels_, num_classes=n_states)
-        self._X = jnp.asarray(X)
-        self._y = jnp.asarray(y)
 
     def initial_probability(self):
         """
@@ -962,7 +960,10 @@ def generate_hmm_initial_params(
         random_key=random_key_pair[1],
         **transition_proba_init_kwargs,
     )
-
+    if init_funcs["transition_proba_init_custom"]:
+        _validate_custom_init_output(
+            transition_matrix, n_states, "transition_proba_init"
+        )
     return initial_probs, transition_matrix
 
 

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -765,6 +765,7 @@ def _resolve_init_funcs(
     value: str | Callable,
     kwargs: Optional[dict] = None,
     available_init_funcs: dict[str, Callable] = None,
+    protocol=InitFunctionHMM,
 ) -> Tuple[InitFunctionHMM, dict, bool]:
     """
     Validate a provided initialization function.
@@ -783,6 +784,9 @@ def _resolve_init_funcs(
         Optional keyword arguments to pass to the initialization function.
     available_init_funcs:
         Dictionary of available initialization functions and their kwargs (if any) to be used for initialization.
+    protocol :
+        The protocol that the custom function should conform to. This is used to check the required parameters in the
+        function signature.
 
     Returns
     -------
@@ -805,10 +809,12 @@ def _resolve_init_funcs(
                 f"Invalid initialization function name '{value}' for '{key}'. "
                 f"Available options are: {list(available_init_funcs[key].keys())}."
             )
-        kwargs = _validate_init_funcs_kwargs(available_init_funcs[key][value], kwargs)
+        kwargs = _validate_init_funcs_kwargs(
+            available_init_funcs[key][value], kwargs, protocol
+        )
         return available_init_funcs[key][value], kwargs, False
     elif callable(value):
-        return _validate_custom_init_func(value, kwargs)
+        return _validate_custom_init_func(value, kwargs, protocol)
     else:
         raise TypeError(
             f"Initialization function for '{key}' must be either a string or a callable. "
@@ -843,7 +849,9 @@ def _validate_init_funcs_kwargs(
 
 
 def _validate_custom_init_func(
-    func: Callable, kwargs: Optional[dict] = None
+    func: Callable,
+    kwargs: Optional[dict] = None,
+    protocol=InitFunctionHMM,
 ) -> Tuple[InitFunctionHMM, dict, bool]:
     """
     Validate a custom initialization function against the expected signature.
@@ -853,12 +861,13 @@ def _validate_custom_init_func(
 
     Parameters
     ----------
-    key : str
-        The name of the parameter being initialized (e.g., 'initial_proba_init' or 'transition_proba_init').
-    func : Callable
+    func :
         The user-provided initialization function to validate.
-    kwargs : Optional[dict]
+    kwargs :
         Optional keyword arguments to pass to the initialization function.
+    protocol :
+        The protocol that the custom function should conform to. This is used to check the required parameters in the
+        function signature.
 
     Returns
     -------
@@ -876,7 +885,7 @@ def _validate_custom_init_func(
     ValueError
         If the function does not return an array of the expected shape.
     """
-    required_params = _get_protocol_parameters(InitFunctionHMM)
+    required_params = _get_protocol_parameters(protocol)
     sig = inspect.signature(func)
     missing = required_params - sig.parameters.keys()
     if missing:
@@ -884,7 +893,7 @@ def _validate_custom_init_func(
             f"Custom initialization function must have the parameters {sorted(required_params)}. "
             f"Missing: {sorted(missing)}."
         )
-    kwargs = _validate_init_funcs_kwargs(func, kwargs)
+    kwargs = _validate_init_funcs_kwargs(func, kwargs, protocol)
 
     return func, kwargs, True
 

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -432,10 +432,6 @@ class KMeansInitializer:
     is_new_session :
         Optional boolean array of shape (n_samples,) indicating the start of new sessions. If None
         (default), it is assumed that all data belongs to a single session.
-    minimum_prob :
-        Minimum probability added to each state to avoid zero probabilities.
-        Note that probabilities will be renormalized after adding this minimum value, so the final
-        probabilities will not be exactly this value.
     random_key :
         Random key for reproducibility of KMeans initialization.
     """
@@ -446,14 +442,13 @@ class KMeansInitializer:
         X: DESIGN_INPUT_TYPE,
         y: NDArray | jnp.ndarray,
         is_new_session: Optional[jnp.ndarray] = None,
-        minimum_prob: float = 0.02,
         random_key: int | jax.Array = 0,
     ):
         if isinstance(random_key, jax.Array):
             random_key = int(jax.random.randint(random_key, (), 0, 2**31 - 1))
 
         self.n_states = n_states
-        self.minimum_prob = minimum_prob
+        # self.minimum_prob = minimum_prob
         self.random_key = random_key
         self.is_new_session = initialize_is_new_session(X, y, is_new_session)
         self.model = sklearn.cluster.KMeans(
@@ -466,26 +461,50 @@ class KMeansInitializer:
         self.model.fit(data)
         self.states = jax.nn.one_hot(self.model.labels_, num_classes=n_states)
 
-    def initial_probability(self):
+    def initial_probability(self, minimum_prob: float = 0.02):
         """
         Compute initial state probabilities based on KMeans assigned states.
 
         This takes the average occurrence of each state at the start of sessions to estimate the initial state
         probabilities.
+
+        Parameters
+        ----------
+        minimum_prob :
+            Minimum probability added to each state to avoid zero probabilities.
+            Note that probabilities will be renormalized after adding this minimum value, so the final
+            probabilities will not be exactly this value.
+
+        Returns
+        -------
+        initial_probability :
+            Initial state probability vector of shape (n_states,) computed from KMeans assigned states.
         """
         initial_probability = self.states[self.is_new_session].sum(axis=0)
         # normalize and add minimum_prob to avoid zero probabilities, then renormalize
         initial_probability = (
             initial_probability / initial_probability.sum()
-        ) + self.minimum_prob
+        ) + minimum_prob
         return initial_probability / initial_probability.sum()
 
-    def transition_probability(self):
+    def transition_probability(self, minimum_prob: float = 0.02):
         """
         Compute transition probabilities based on KMeans assigned states.
 
         This computes the transition probabilities by counting the transitions between states across time points,
         excluding transitions that occur at the start of new sessions.
+
+        Parameters
+        ----------
+        minimum_prob :
+            Minimum probability added to each state to avoid zero probabilities.
+            Note that probabilities will be renormalized after adding this minimum value, so the final
+            probabilities will not be exactly this value.
+
+        Returns
+        -------
+        transition_matrix :
+            Transition probability matrix of shape (n_states, n_states) computed from KMeans assigned states.
         """
         transition_matrix = (
             self.states[:-1][~self.is_new_session[1:]].T
@@ -494,7 +513,7 @@ class KMeansInitializer:
         # normalize and add minimum_prob to avoid zero probabilities, then renormalize
         transition_matrix = (
             transition_matrix / transition_matrix.sum(axis=1, keepdims=True)
-        ) + self.minimum_prob
+        ) + minimum_prob
         return transition_matrix / transition_matrix.sum(axis=1, keepdims=True)
 
 
@@ -539,10 +558,8 @@ def kmeans_initial_proba_init(
         Initial state probability vector of shape (n_states,) that sums to 1.
     """
     if initializer is None:
-        initializer = KMeansInitializer(
-            n_states, X, y, is_new_session, minimum_prob, random_key
-        )
-    return initializer.initial_probability()
+        initializer = KMeansInitializer(n_states, X, y, is_new_session, random_key)
+    return initializer.initial_probability(minimum_prob=minimum_prob)
 
 
 def kmeans_transition_proba_init(
@@ -586,10 +603,8 @@ def kmeans_transition_proba_init(
         Transition probability matrix of shape (n_states, n_states) computed from KMeans assigned states.
     """
     if initializer is None:
-        initializer = KMeansInitializer(
-            n_states, X, y, is_new_session, minimum_prob, random_key
-        )
-    return initializer.transition_probability()
+        initializer = KMeansInitializer(n_states, X, y, is_new_session, random_key)
+    return initializer.transition_probability(minimum_prob=minimum_prob)
 
 
 AVAILABLE_INIT_FUNCTIONS = MappingProxyType(
@@ -632,7 +647,6 @@ def setup_hmm_initialization(
     transition_proba_init: Optional[str | Callable] = None,
     transition_proba_init_kwargs: Optional[dict] = None,
     init_funcs: Optional[dict | INITIALIZATION_FN_DICT] = None,
-    default_init_dict: Optional[dict] = None,
     n_states: Optional[int] = None,
 ) -> INITIALIZATION_FN_DICT:
     """
@@ -661,9 +675,6 @@ def setup_hmm_initialization(
         Existing dictionary of initialization functions to update. If None, a fresh copy of
         ``default_init_dict`` is used. Keys must already be validated before calling this function;
         use :func:`_validate_init_funcs_keys` upstream (e.g., in the class setter).
-    default_init_dict :
-        Model-specific dictionary of default initialization functions. Defaults to
-        ``DEFAULT_INIT_FUNCTIONS`` when None.
     n_states :
         Number of HMM states. When provided, ``alphas`` in the init kwargs is validated
         via :func:`_resolve_dirichlet_priors` (same check as the model property setter).
@@ -673,11 +684,8 @@ def setup_hmm_initialization(
     init_funcs :
         Updated dictionary of initialization functions based on provided inputs.
     """
-    if default_init_dict is None:
-        default_init_dict = DEFAULT_INIT_FUNCTIONS.copy()
-
     if init_funcs is None:
-        init_funcs = default_init_dict
+        init_funcs = DEFAULT_INIT_FUNCTIONS.copy()
     else:
         init_funcs = init_funcs.copy()
 
@@ -731,7 +739,7 @@ def _validate_init_funcs_keys(
     if default_init_dict is None:
         default_init_dict = DEFAULT_INIT_FUNCTIONS.copy()
     if init_funcs is None:
-        return
+        return default_init_dict
     unexpected_keys = init_funcs.keys() - default_init_dict.keys()
     if unexpected_keys:
         suggested_keys = _suggest_keys(unexpected_keys, default_init_dict.keys())

--- a/src/nemos/type_casting.py
+++ b/src/nemos/type_casting.py
@@ -505,20 +505,34 @@ def support_pynapple(conv_type: Literal["jax", "numpy"] = "jax") -> Callable:
     return decorator
 
 
-def cast_to_jax(func):
-    """Cast argument to jax."""
+def cast_to_jax(_func=None, *, dtype=float) -> Callable:
+    """Cast argument to jax.
 
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            args, kwargs = jax.tree_util.tree_map(
-                lambda x: jnp_asarray_if(x, dtype=float), (args, kwargs)
-            )
-        except Exception:
-            raise TypeError(
-                "X and y should be array-like object (or trees of array like object) "
-                "with numeric data type!"
-            )
-        return func(*args, **kwargs)
+    Can be used as a plain decorator (``@cast_to_jax``) or as a decorator
+    factory (``@cast_to_jax(dtype=None)``).  The default ``dtype=float``
+    preserves the original behaviour: all array-like inputs are promoted to a
+    floating-point JAX array.  Pass ``dtype=None`` to keep each input's own
+    dtype (useful when some arguments are unsigned-integer keys).
+    """
 
-    return wrapper
+    def decorator(func):
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                args, kwargs = jax.tree_util.tree_map(
+                    lambda x: jnp_asarray_if(x, dtype=dtype), (args, kwargs)
+                )
+            except Exception:
+                raise TypeError(
+                    "X and y should be array-like object (or trees of array like object) "
+                    "with numeric data type!"
+                )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if _func is not None:
+        # Used as @cast_to_jax without parentheses
+        return decorator(_func)
+    return decorator

--- a/src/nemos/validation.py
+++ b/src/nemos/validation.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import difflib
 import warnings
-from typing import Any, Callable, List, Optional
+from collections.abc import Collection
+from typing import Any, Callable, Optional
 
 import jax
 import jax.numpy as jnp
@@ -422,7 +423,7 @@ def _check_batch_size_larger_than_convolution_window(
 
 
 def _suggest_keys(
-    unmatched_keys: List[str], valid_keys: List[str], cutoff: float = 0.6
+    unmatched_keys: Collection[str], valid_keys: Collection[str], cutoff: float = 0.6
 ):
     """
     Suggest the closest matching valid key for each unmatched key using fuzzy string matching.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,7 @@ def mock_glm_fit(monkeypatch):
         else:
             self.coef_ = jnp.zeros((n_features, y_arr.shape[1]))
             self.intercept_ = jnp.zeros(y_arr.shape[1])
+        self.scale_ = jnp.ones_like(self.intercept_)
         return self
 
     monkeypatch.setattr(nmo.glm.GLM, "fit", _fit)

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2425,16 +2425,16 @@ def _make_valid_group_mask(n_groups, n_features):
             id="list_mask-list_X",
         ),
         pytest.param(
-                lambda arr, _: nmo.glm.params.GLMParams(
-                    coef=jnp.asarray(arr), intercept=None
-                ),
-                lambda X: X,
-                # already-structured GLMParams: coef slot is unchanged, same 2-D array
-                lambda coef, n_groups, n_features: (
-                    hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
-                ),
-                id="already_structured_glmparams_mask",
+            lambda arr, _: nmo.glm.params.GLMParams(
+                coef=jnp.asarray(arr), intercept=None
             ),
+            lambda X: X,
+            # already-structured GLMParams: coef slot is unchanged, same 2-D array
+            lambda coef, n_groups, n_features: (
+                hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
+            ),
+            id="already_structured_glmparams_mask",
+        ),
     ],
 )
 def test_grouplasso_mask_wrapping_and_refit(
@@ -2464,9 +2464,9 @@ def test_grouplasso_mask_wrapping_and_refit(
     model.fit(X, y)
 
     # After first fit, mask must be wrapped into the internal GLMParams structure.
-    assert isinstance(model.regularizer.mask, nmo.glm.params.GLMParams), (
-        "mask must be a GLMParams pytree after fit"
-    )
+    assert isinstance(
+        model.regularizer.mask, nmo.glm.params.GLMParams
+    ), "mask must be a GLMParams pytree after fit"
     assert model.regularizer.mask.intercept is None
     assert check_coef(model.regularizer.mask.coef, n_groups, n_features)
     mask_coef_after_first = model.regularizer.mask.coef

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2390,6 +2390,98 @@ def test_grouplasso_fit_twice_different_pytree_structure():
     model.fit(X_dict, y)
 
 
+def _make_valid_group_mask(n_groups, n_features):
+    """Binary group mask: each group owns a contiguous slice of features."""
+    mask = np.zeros((n_groups, n_features))
+    split = n_features // n_groups
+    for i in range(n_groups):
+        start = i * split
+        end = (i + 1) * split if i < n_groups - 1 else n_features
+        mask[i, start:end] = 1.0
+    return mask
+
+
+@pytest.mark.parametrize(
+    "make_mask, make_X, check_coef",
+    [
+        pytest.param(
+            lambda arr, _: arr,
+            lambda X: X,
+            # flat array: coef slot should be a single 2-D array (n_groups, n_features)
+            lambda coef, n_groups, n_features: (
+                hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
+            ),
+            id="flat_array_mask-2d_X",
+        ),
+        pytest.param(
+            lambda arr, _: [arr],
+            lambda X: [X],
+            # list mask with list X: coef slot should be a list of one 2-D array
+            lambda coef, n_groups, n_features: (
+                isinstance(coef, list)
+                and len(coef) == 1
+                and coef[0].shape == (n_groups, n_features)
+            ),
+            id="list_mask-list_X",
+        ),
+        pytest.param(
+                lambda arr, _: nmo.glm.params.GLMParams(
+                    coef=jnp.asarray(arr), intercept=None
+                ),
+                lambda X: X,
+                # already-structured GLMParams: coef slot is unchanged, same 2-D array
+                lambda coef, n_groups, n_features: (
+                    hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
+                ),
+                id="already_structured_glmparams_mask",
+            ),
+    ],
+)
+def test_grouplasso_mask_wrapping_and_refit(
+    make_mask, make_X, check_coef, mock_optimizer_run
+):
+    """User-provided mask wraps into GLMParams on first fit; re-fit leaves it unchanged.
+
+    Regression test for three mask formats:
+    - flat array: mask has same shape as coef_ (mirrors X).
+    - list of one array: mask mirrors list-structured X.
+    - already-structured GLMParams: isinstance guard prevents double-wrapping.
+    """
+    rng = np.random.default_rng(0)
+    n_samples, n_features, n_groups = 50, 4, 2
+    X_arr = rng.standard_normal((n_samples, n_features))
+    y = rng.poisson(1, size=n_samples)
+
+    mask_arr = _make_valid_group_mask(n_groups, n_features)
+    mask = make_mask(mask_arr, n_features)
+    X = make_X(X_arr)
+
+    model = nmo.glm.GLM(
+        regularizer=nmo.regularizer.GroupLasso(mask=mask),
+        regularizer_strength=1.0,
+    )
+
+    model.fit(X, y)
+
+    # After first fit, mask must be wrapped into the internal GLMParams structure.
+    assert isinstance(model.regularizer.mask, nmo.glm.params.GLMParams), (
+        "mask must be a GLMParams pytree after fit"
+    )
+    assert model.regularizer.mask.intercept is None
+    assert check_coef(model.regularizer.mask.coef, n_groups, n_features)
+    mask_coef_after_first = model.regularizer.mask.coef
+
+    # Re-fit: isinstance guard must prevent double-wrapping; coef content unchanged.
+    model.fit(X, y)
+    assert isinstance(model.regularizer.mask, nmo.glm.params.GLMParams)
+    assert model.regularizer.mask.intercept is None
+    jax.tree_util.tree_map(
+        lambda a, b: np.testing.assert_array_equal(a, b),
+        mask_coef_after_first,
+        model.regularizer.mask.coef,
+    )
+
+
 @pytest.mark.parametrize(
     "model_instantiation",
     [

--- a/tests/test_glm_hmm_algorithms.py
+++ b/tests/test_glm_hmm_algorithms.py
@@ -800,7 +800,7 @@ class TestForwardBackward:
         )
         xis = jnp.exp(log_xis)
         np.testing.assert_array_almost_equal(
-            np.array([[log_alphas.shape[0] - sum(new_sess)]]).astype(xis), xis
+            np.array([[log_alphas.shape[0] - sum(new_sess)]]).astype(xis.dtype), xis
         )
 
 

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -38,7 +38,9 @@ class MockGLMHMM(BaseHMM):
     _default_init_dict = DEFAULT_INIT_FUNCTIONS_GLMHMM
 
     def __init__(self, n_states, initialization_funcs=None):
-        BaseHMM.__init__(self, n_states=n_states, initialization_funcs=initialization_funcs)
+        BaseHMM.__init__(
+            self, n_states=n_states, initialization_funcs=initialization_funcs
+        )
         self.coef_ = self.intercept_ = self.scale_ = None
 
     def setup(self, **kwargs):
@@ -46,20 +48,47 @@ class MockGLMHMM(BaseHMM):
             init_funcs=self._initialization_funcs,
         )
 
-    def _check_model_is_fit(self): pass
-    def _get_model_params(self): pass
-    def _set_model_params(self, params): pass
-    def _log_likelihood(self, params, X, y): pass
-    def _model_params_initialization(self, X, y, is_new_session, random_key=None): pass
-    def fit(self, *a, **kw): pass
-    def _initialize_optimizer_and_state(self, *a, **kw): pass
-    def _compute_loss(self, *a, **kw): pass
-    def _get_optimal_solver_params_config(self, *a, **kw): pass
-    def predict(self, *a, **kw): pass
-    def simulate(self, *a, **kw): pass
-    def save_params(self, *a, **kw): pass
-    def update(self, *a, **kw): pass
-    def score(self, *a, **kw): pass
+    def _check_model_is_fit(self):
+        pass
+
+    def _get_model_params(self):
+        pass
+
+    def _set_model_params(self, params):
+        pass
+
+    def _log_likelihood(self, params, X, y):
+        pass
+
+    def _model_params_initialization(self, X, y, is_new_session, random_key=None):
+        pass
+
+    def fit(self, *a, **kw):
+        pass
+
+    def _initialize_optimizer_and_state(self, *a, **kw):
+        pass
+
+    def _compute_loss(self, *a, **kw):
+        pass
+
+    def _get_optimal_solver_params_config(self, *a, **kw):
+        pass
+
+    def predict(self, *a, **kw):
+        pass
+
+    def simulate(self, *a, **kw):
+        pass
+
+    def save_params(self, *a, **kw):
+        pass
+
+    def update(self, *a, **kw):
+        pass
+
+    def score(self, *a, **kw):
+        pass
 
 
 # =============================================================================
@@ -682,6 +711,10 @@ class TestGenerateGLMHMMInitialParams:
         """Different random keys produce different GLM coefficient initializations."""
         X = jnp.ones((50, 5))
         y = jnp.ones(50)
-        coef1, *_ = generate_glm_hmm_initial_model_params(3, X, y, lambda x: x, random_key=1)
-        coef2, *_ = generate_glm_hmm_initial_model_params(3, X, y, lambda x: x, random_key=2)
+        coef1, *_ = generate_glm_hmm_initial_model_params(
+            3, X, y, lambda x: x, random_key=1
+        )
+        coef2, *_ = generate_glm_hmm_initial_model_params(
+            3, X, y, lambda x: x, random_key=2
+        )
         assert not jnp.allclose(coef1, coef2)

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -467,6 +467,18 @@ class TestKMeansInitializerGLM:
         assert jnp.allclose(coef_r, coef_e)
         assert jnp.allclose(int_r, int_e)
 
+    def test_empty_state_raises(self, kmeans_mock):
+        """fit() raises when KMeans leaves a state with zero assigned samples."""
+        n_states, X, y, _, _ = kmeans_mock
+        initializer = KMeansInitializerGLM(
+            n_states, X, y, jnp.exp, "Poisson", random_key=0
+        )
+        # Force all samples into state 0 so states 1..n_states-1 are empty
+        labels = jnp.zeros(X.shape[0], dtype=int)
+        initializer.states = jax.nn.one_hot(labels, num_classes=n_states)
+        with pytest.raises(ValueError, match="0 samples to state"):
+            initializer.fit()
+
 
 # =============================================================================
 # Tests for setup_glm_hmm_initialization
@@ -748,3 +760,19 @@ class TestGenerateGLMHMMInitialParams:
             3, X, y, lambda x: x, random_key=2
         )
         assert not jnp.allclose(coef1, coef2)
+
+    def test_kmeans_glm_params_missing_observation_model_raises(self):
+        """kmeans glm_params_init without observation_model in kwargs raises early."""
+        init_funcs = setup_glm_hmm_initialization(glm_params_init="kmeans")
+        with pytest.raises(ValueError, match="observation_model"):
+            generate_glm_hmm_initial_model_params(
+                2, jnp.ones((10, 3)), jnp.ones(10), jnp.exp, init_funcs=init_funcs
+            )
+
+    def test_kmeans_scale_missing_observation_model_raises(self):
+        """kmeans scale_init without observation_model in kwargs raises early."""
+        init_funcs = setup_glm_hmm_initialization(scale_init="kmeans")
+        with pytest.raises(ValueError, match="observation_model"):
+            generate_glm_hmm_initial_model_params(
+                2, jnp.ones((10, 3)), jnp.ones(10), jnp.exp, init_funcs=init_funcs
+            )

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -754,7 +754,7 @@ class TestGenerateGLMHMMInitialParams:
 
 
 class TestValidateCustomGLMParamsOutput:
-    """Test _validate_custom_glm_params_output directly."""
+    """Test custom GLM params output validation via generate_glm_hmm_initial_params."""
 
     @pytest.mark.parametrize("n_neurons", [1, 3])
     def test_valid_output(self, n_neurons):
@@ -769,7 +769,11 @@ class TestValidateCustomGLMParamsOutput:
             coef = jnp.zeros((n_features, n_neurons, n_states))
             intercept = jnp.zeros((n_neurons, n_states))
 
-        _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
+        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return coef, intercept
+
+        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
+        generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     @pytest.mark.parametrize("n_neurons", [1, 3])
     def test_wrong_coef_shape_raises(self, n_neurons):
@@ -779,8 +783,12 @@ class TestValidateCustomGLMParamsOutput:
         coef = jnp.zeros((n_features + 1, n_states))  # wrong n_features
         intercept = jnp.zeros((n_neurons, n_states) if n_neurons > 1 else (n_states,))
 
+        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return coef, intercept
+
+        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(ValueError, match="mis-shaped"):
-            _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     @pytest.mark.parametrize("n_neurons", [1, 3])
     def test_wrong_intercept_shape_raises(self, n_neurons):
@@ -794,28 +802,36 @@ class TestValidateCustomGLMParamsOutput:
         )
         intercept = jnp.zeros(n_states + 1)  # wrong shape
 
+        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return coef, intercept
+
+        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(ValueError, match="incorrect shape"):
-            _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     def test_wrong_coef_type_raises(self):
         n_states, n_features = 3, 5
         X = jnp.ones((10, n_features))
         y = jnp.ones(10)
 
+        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return "not_an_array", jnp.zeros(n_states)
+
+        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(TypeError, match="did not return a pytree of arrays"):
-            _validate_custom_glm_params_output(
-                ("not_an_array", jnp.zeros(n_states)), n_states, X, y
-            )
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     def test_wrong_intercept_type_raises(self):
         n_states, n_features = 3, 5
         X = jnp.ones((10, n_features))
         y = jnp.ones(10)
 
+        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return jnp.zeros((n_features, n_states)), "not_an_array"
+
+        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(TypeError, match="did not return an array"):
-            _validate_custom_glm_params_output(
-                (jnp.zeros((n_features, n_states)), "not_an_array"), n_states, X, y
-            )
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     def test_error_message_shows_shapes(self):
         """Error message includes both actual and expected shapes."""
@@ -824,15 +840,15 @@ class TestValidateCustomGLMParamsOutput:
         y = jnp.ones(10)
         coef = jnp.zeros((n_features + 2, n_states))
 
+        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return coef, jnp.zeros(n_states)
+
+        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(ValueError, match="Actual shapes"):
-            _validate_custom_glm_params_output(
-                (coef, jnp.zeros(n_states)), n_states, X, y
-            )
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
         with pytest.raises(ValueError, match="Expected shapes"):
-            _validate_custom_glm_params_output(
-                (coef, jnp.zeros(n_states)), n_states, X, y
-            )
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
 
 # =============================================================================

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -857,32 +857,56 @@ class TestValidateCustomGLMParamsOutput:
 
 
 class TestValidateCustomScaleOutput:
-    """Test _validate_custom_scale_output directly."""
+    """Test custom scale output validation via generate_glm_hmm_initial_params."""
 
     @pytest.mark.parametrize("n_neurons", [1, 3])
     def test_valid_output(self, n_neurons):
         n_states = 3
+        X = jnp.ones((10, 5))
         y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
         scale = jnp.ones((n_states, n_neurons) if n_neurons > 1 else (n_states,))
-        _validate_custom_scale_output(scale, n_states, y)
+
+        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return scale
+
+        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
+        generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     @pytest.mark.parametrize("n_neurons", [1, 3])
     def test_wrong_shape_raises(self, n_neurons):
         n_states = 3
+        X = jnp.ones((10, 5))
         y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
         scale = jnp.ones(n_states + 1)
 
+        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return scale
+
+        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
         with pytest.raises(ValueError, match="incorrect shape"):
-            _validate_custom_scale_output(scale, n_states, y)
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     def test_wrong_type_raises(self):
+        n_states = 3
+        X = jnp.ones((10, 5))
+        y = jnp.ones(10)
+
+        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return "not_an_array"
+
+        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
         with pytest.raises(TypeError, match="must return an array"):
-            _validate_custom_scale_output("not_an_array", 3, jnp.ones(10))
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
 
     def test_error_message_shows_expected_shape(self):
         n_states = 3
+        X = jnp.ones((10, 5))
         y = jnp.ones(10)
         scale = jnp.ones(n_states + 2)
 
+        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
+            return scale
+
+        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
         with pytest.raises(ValueError, match=rf"\({n_states},\)"):
-            _validate_custom_scale_output(scale, n_states, y)
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -14,7 +14,7 @@ from nemos.glm_hmm.initialize_parameters import (
     GLM_INIT_FUNCS,
     KMeansInitializerGLM,
     constant_scale_init,
-    generate_glm_hmm_initial_params,
+    generate_glm_hmm_initial_model_params,
     kmeans_glm_params_init,
     kmeans_scale_init,
     random_glm_params_init,
@@ -574,12 +574,12 @@ class TestSetupGLMHMMInitializationKwargs:
 
 
 # =============================================================================
-# Tests for generate_glm_hmm_initial_params
+# Tests for generate_glm_hmm_initial_model_params
 # =============================================================================
 
 
 class TestGenerateGLMHMMInitialParams:
-    """Test generate_glm_hmm_initial_params function."""
+    """Test generate_glm_hmm_initial_model_params function."""
 
     @pytest.mark.parametrize("n_states", [1, 2, 3, 5])
     @pytest.mark.parametrize("n_neurons", [1, 3])
@@ -589,7 +589,7 @@ class TestGenerateGLMHMMInitialParams:
         y = jnp.ones((50, n_neurons)) if n_neurons > 1 else jnp.ones(50)
 
         coef, intercept, scale, initial_probs, transition_matrix = (
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp)
+            generate_glm_hmm_initial_model_params(n_states, X, y, jnp.exp)
         )
 
         if n_neurons == 1:
@@ -608,7 +608,7 @@ class TestGenerateGLMHMMInitialParams:
             assert isinstance(arr, jnp.ndarray)
 
     def test_returns_five_elements(self):
-        result = generate_glm_hmm_initial_params(
+        result = generate_glm_hmm_initial_model_params(
             2, jnp.ones((10, 3)), jnp.ones(10), lambda x: x
         )
         assert isinstance(result, tuple)
@@ -627,7 +627,7 @@ class TestGenerateGLMHMMInitialParams:
     )
     def test_init_funcs_key_validation(self, init_funcs, expectation):
         with expectation:
-            generate_glm_hmm_initial_params(
+            generate_glm_hmm_initial_model_params(
                 3,
                 jnp.ones((10, 5)),
                 jnp.ones(10),
@@ -639,7 +639,7 @@ class TestGenerateGLMHMMInitialParams:
         X = jnp.ones((50, 5))
         y = jnp.full(50, 2.0)
         coef, intercept, scale, initial_probs, transition_matrix = (
-            generate_glm_hmm_initial_params(3, X, y, lambda x: x)
+            generate_glm_hmm_initial_model_params(3, X, y, lambda x: x)
         )
         assert jnp.abs(coef).max() < 0.01
         assert jnp.allclose(intercept, 2.0)
@@ -651,6 +651,6 @@ class TestGenerateGLMHMMInitialParams:
         """Different random keys produce different GLM coefficient initializations."""
         X = jnp.ones((50, 5))
         y = jnp.ones(50)
-        coef1, *_ = generate_glm_hmm_initial_params(3, X, y, lambda x: x, random_key=1)
-        coef2, *_ = generate_glm_hmm_initial_params(3, X, y, lambda x: x, random_key=2)
+        coef1, *_ = generate_glm_hmm_initial_model_params(3, X, y, lambda x: x, random_key=1)
+        coef2, *_ = generate_glm_hmm_initial_model_params(3, X, y, lambda x: x, random_key=2)
         assert not jnp.allclose(coef1, coef2)

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -11,7 +11,6 @@ import pytest
 from nemos.glm import GLM
 from nemos.glm_hmm.initialize_parameters import (
     DEFAULT_INIT_FUNCTIONS_GLMHMM,
-    GLM_INIT_FUNCS,
     KMeansInitializerGLM,
     constant_scale_init,
     generate_glm_hmm_initial_model_params,
@@ -22,10 +21,6 @@ from nemos.glm_hmm.initialize_parameters import (
 )
 from nemos.glm_hmm.validation import GLMHMMValidator
 from nemos.hmm.hmm import BaseHMM
-from nemos.hmm.initialize_parameters import (
-    sticky_transition_proba_init,
-    uniform_initial_proba_init,
-)
 from nemos.inverse_link_function_utils import resolve_inverse_link_function
 
 # =============================================================================
@@ -35,17 +30,20 @@ from nemos.inverse_link_function_utils import resolve_inverse_link_function
 
 class MockGLMHMM(BaseHMM):
     _validator_class = GLMHMMValidator
-    _default_init_dict = DEFAULT_INIT_FUNCTIONS_GLMHMM
+    _model_default_init_dict = DEFAULT_INIT_FUNCTIONS_GLMHMM
 
-    def __init__(self, n_states, initialization_funcs=None):
+    def __init__(
+        self, n_states, hmm_initialization_funcs=None, model_initialization_funcs=None
+    ):
         BaseHMM.__init__(
-            self, n_states=n_states, initialization_funcs=initialization_funcs
+            self, n_states=n_states, hmm_initialization_funcs=hmm_initialization_funcs
         )
+        self.model_initialization_funcs = model_initialization_funcs
         self.coef_ = self.intercept_ = self.scale_ = None
 
-    def setup(self, **kwargs):
-        self._initialization_funcs = setup_glm_hmm_initialization(
-            init_funcs=self._initialization_funcs,
+    def _model_setup(self, **kwargs):
+        self._model_initialization_funcs = setup_glm_hmm_initialization(
+            init_funcs=self._model_initialization_funcs,
         )
 
     def _check_model_is_fit(self):
@@ -432,7 +430,9 @@ class TestKMeansInitializerGLM:
 
     def test_glm_params_output_shape(self, kmeans_mock):
         n_states, X, y, n_features, _ = kmeans_mock
-        initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=0)
+        initializer = KMeansInitializerGLM(
+            n_states, X, y, jnp.exp, "Poisson", random_key=0
+        )
         coef, intercept = initializer.glm_params()
         assert coef.shape == (n_features, n_states)
         assert intercept.shape == (n_states,)
@@ -446,16 +446,20 @@ class TestKMeansInitializerGLM:
     def test_scale_output_shape(self, kmeans_mock):
         """Poisson GLM has fixed scale=1, so scale() returns ones without fitting."""
         n_states, X, y, _, expected_shape = kmeans_mock
-        initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=0)
+        initializer = KMeansInitializerGLM(
+            n_states, X, y, jnp.exp, "Poisson", random_key=0
+        )
         scale = initializer.scale()
         assert scale.shape == expected_shape
 
     def test_shared_initializer(self, kmeans_mock):
         """Providing a pre-built initializer skips creating a new one."""
         n_states, X, y, _, _ = kmeans_mock
-        initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=7)
+        initializer = KMeansInitializerGLM(
+            n_states, X, y, jnp.exp, "Poisson", random_key=7
+        )
         result = kmeans_glm_params_init(
-            n_states, X, y, jnp.exp, initializer=initializer
+            n_states, X, y, jnp.exp, "Poisson", initializer=initializer
         )
         expected = initializer.glm_params()
         coef_r, int_r = result
@@ -576,7 +580,9 @@ class TestSetupGLMHMMInitialization:
 
     def test_unknown_init_funcs_key(self):
         with pytest.raises(KeyError, match="Unexpected or unknown keys"):
-            MockGLMHMM(n_states=2, initialization_funcs={"totally_invalid_key": None})
+            MockGLMHMM(
+                n_states=2, model_initialization_funcs={"totally_invalid_key": None}
+            )
 
     @pytest.mark.parametrize(
         "key, init_str, kwargs_key, kwargs_val",
@@ -602,7 +608,9 @@ class TestSetupGLMHMMInitialization:
         first = setup_glm_hmm_initialization(**{key: init_str, kwargs_key: kwargs_val})
         second = setup_glm_hmm_initialization(
             **{key: init_str},
-            init_funcs={k: v for k, v in first.items() if k in GLM_INIT_FUNCS},
+            init_funcs={
+                k: v for k, v in first.items() if k in DEFAULT_INIT_FUNCTIONS_GLMHMM
+            },
         )
         assert first[kwargs_key] == kwargs_val
         assert second[kwargs_key] == {}
@@ -612,19 +620,19 @@ class TestSetupGLMHMMInitialization:
         init_funcs = setup_glm_hmm_initialization()
         assert init_funcs == DEFAULT_INIT_FUNCTIONS_GLMHMM
 
-    def test_hmm_params_delegated(self):
-        """HMM init functions (initial_proba, transition_proba) are set correctly."""
-        init_funcs = setup_glm_hmm_initialization(
-            initial_proba_init="uniform",
-            transition_proba_init="sticky",
-        )
-        assert init_funcs["initial_proba_init"] == uniform_initial_proba_init
-        assert init_funcs["transition_proba_init"] == sticky_transition_proba_init
+    # def test_hmm_params_delegated(self):
+    #     """HMM init functions (initial_proba, transition_proba) are set correctly."""
+    #     init_funcs = setup_glm_hmm_initialization(
+    #         initial_proba_init="uniform",
+    #         transition_proba_init="sticky",
+    #     )
+    #     assert init_funcs["initial_proba_init"] == uniform_initial_proba_init
+    #     assert init_funcs["transition_proba_init"] == sticky_transition_proba_init
 
 
 @pytest.mark.parametrize(
     "func_name",
-    ["glm_params_init", "scale_init", "initial_proba_init", "transition_proba_init"],
+    ["glm_params_init", "scale_init"],
 )
 class TestSetupGLMHMMInitializationKwargs:
     """Test kwargs validation in setup_glm_hmm_initialization via mock registries."""
@@ -715,7 +723,9 @@ class TestGenerateGLMHMMInitialParams:
 
     def test_init_funcs_unknown_key_raises(self):
         with pytest.raises(KeyError, match="Unexpected or unknown keys"):
-            MockGLMHMM(n_states=2, initialization_funcs={"totally_invalid_key": None})
+            MockGLMHMM(
+                n_states=2, model_initialization_funcs={"totally_invalid_key": None}
+            )
 
     def test_none_init_funcs_uses_defaults(self):
         X = jnp.ones((50, 5))

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -9,12 +9,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from nemos.glm import GLM
 from nemos.glm_hmm.initialize_parameters import (
     DEFAULT_INIT_FUNCTIONS_GLMHMM,
     GLM_INIT_FUCS,
     KMeansInitializerGLM,
-    _validate_custom_glm_params_output,
-    _validate_custom_scale_output,
     constant_scale_init,
     generate_glm_hmm_initial_params,
     kmeans_glm_params_init,
@@ -309,55 +308,46 @@ class TestConstantScaleInitialization:
 # =============================================================================
 
 
-@pytest.fixture(scope="module")
-def kmeans_glm_data():
-    """Simple clustered data for KMeans GLM initialization tests."""
-    rng = np.random.default_rng(0)
+@pytest.fixture
+def kmeans_mock(monkeypatch):
+    """Patch GLM.fit to avoid slow JAX optimization. Uses small data so sklearn KMeans is fast."""
     n_states = 3
-    n_samples = 300
+    n_samples = 30
     n_features = 4
+
+    rng = np.random.default_rng(0)
     X = rng.standard_normal((n_samples, n_features))
-    y = rng.poisson(5, n_samples).astype(float)
-    y_pop = rng.poisson(5, (n_samples, 2)).astype(float)
-    return n_states, X, y, y_pop
+    y = np.ones(n_samples)
+
+    def fake_glm_fit(self, X, y, **kwargs):
+        n_feat = X.shape[1]
+        self.coef_ = jnp.zeros(n_feat)
+        self.intercept_ = jnp.array([0.0])
+
+    monkeypatch.setattr(GLM, "fit", fake_glm_fit)
+    return n_states, X, y, n_features
 
 
 class TestKMeansInitializerGLM:
     """Test KMeans-based GLM parameter initialization."""
 
-    @pytest.mark.parametrize("n_neurons", [1, 2])
-    def test_glm_params_output_shape(self, kmeans_glm_data, n_neurons):
-        n_states, X, y, y_pop = kmeans_glm_data
-        obs = y_pop if n_neurons > 1 else y
-
-        initializer = KMeansInitializerGLM(n_states, X, obs, jnp.exp, random_key=0)
+    def test_glm_params_output_shape(self, kmeans_mock):
+        n_states, X, y, n_features = kmeans_mock
+        initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=0)
         coef, intercept = initializer.glm_params()
+        assert coef.shape == (n_features, n_states)
+        assert intercept.shape == (n_states,)
 
-        if n_neurons == 1:
-            assert coef.shape == (X.shape[1], n_states)
-            assert intercept.shape == (n_states,)
-        else:
-            assert coef.shape == (X.shape[1], n_neurons, n_states)
-            assert intercept.shape == (n_neurons, n_states)
-
-    @pytest.mark.parametrize("n_neurons", [1, 2])
-    def test_scale_output_shape(self, kmeans_glm_data, n_neurons):
+    def test_scale_output_shape(self, kmeans_mock):
         """Poisson GLM has fixed scale=1, so scale() returns ones without fitting."""
-        n_states, X, y, y_pop = kmeans_glm_data
-        obs = y_pop if n_neurons > 1 else y
-
-        initializer = KMeansInitializerGLM(n_states, X, obs, jnp.exp, random_key=0)
+        n_states, X, y, _ = kmeans_mock
+        initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=0)
         scale = initializer.scale()
+        assert scale.shape == (n_states,)
 
-        if n_neurons == 1:
-            assert scale.shape == (n_states,)
-        else:
-            assert scale.shape == (n_states, n_neurons)
-
-    def test_shared_initializer(self, kmeans_glm_data):
-        """Providing a pre-built initializer skips refitting."""
-        n_states, X, y, _ = kmeans_glm_data
-
+    def test_shared_initializer(self, kmeans_mock):
+        """Providing a pre-built initializer skips creating a new one."""
+        n_states, X, y, _ = kmeans_mock
         initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=7)
         result = kmeans_glm_params_init(
             n_states, X, y, jnp.exp, initializer=initializer
@@ -367,18 +357,6 @@ class TestKMeansInitializerGLM:
         coef_e, int_e = expected
         assert jnp.allclose(coef_r, coef_e)
         assert jnp.allclose(int_r, int_e)
-
-    def test_different_random_keys_give_different_results(self, kmeans_glm_data):
-        n_states, X, y, _ = kmeans_glm_data
-
-        init1 = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=1)
-        init2 = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=2)
-
-        coef1, _ = init1.glm_params()
-        coef2, _ = init2.glm_params()
-        # KMeans with different seeds may produce different state assignments
-        # sorted coefficients should still differ unless by chance
-        assert not jnp.allclose(jnp.sort(coef1.ravel()), jnp.sort(coef2.ravel()))
 
 
 # =============================================================================
@@ -648,52 +626,18 @@ class TestGenerateGLMHMMInitialParams:
         assert jnp.allclose(initial_probs, 1.0 / 3)
         assert jnp.allclose(jnp.diag(transition_matrix), 0.95)
 
-    def test_random_key_splitting(self):
-        """All outputs differ from each other — each init function gets a distinct subkey."""
-        n_states = 3
-        n_features = 5
-        X = jnp.ones((100, n_features))
-        y = jnp.ones(100)
-
-        fixed_shape = (10,)
-
-        def rand_glm(n_states, X, y, inverse_link_function, random_key):
-            k1, k2 = jax.random.split(random_key)
-            return jax.random.normal(k1, fixed_shape), jax.random.normal(
-                k2, fixed_shape
-            )
-
-        def rand_scale(n_states, X, y, inverse_link_function, random_key):
-            return jax.random.normal(random_key, fixed_shape)
-
-        def rand_initial(n_states, X, y, random_key):
-            return jax.random.normal(random_key, fixed_shape)
-
-        def rand_transition(n_states, X, y, random_key):
-            return jax.random.normal(random_key, fixed_shape)
-
-        init_funcs = setup_glm_hmm_initialization(
-            glm_params_init=rand_glm,
-            scale_init=rand_scale,
-            initial_proba_init=rand_initial,
-            transition_proba_init=rand_transition,
-        )
-
-        coef, intercept, scale, initial_probs, transition_matrix = (
-            generate_glm_hmm_initial_params(
-                n_states, X, y, lambda x: x, init_funcs=init_funcs
-            )
-        )
-
-        for p1, p2 in itertools.combinations(
-            [coef, intercept, scale, initial_probs, transition_matrix], 2
-        ):
-            assert not jnp.allclose(p1, p2)
+    def test_random_key_affects_output(self):
+        """Different random keys produce different GLM coefficient initializations."""
+        X = jnp.ones((50, 5))
+        y = jnp.ones(50)
+        coef1, *_ = generate_glm_hmm_initial_params(3, X, y, lambda x: x, random_key=1)
+        coef2, *_ = generate_glm_hmm_initial_params(3, X, y, lambda x: x, random_key=2)
+        assert not jnp.allclose(coef1, coef2)
 
     @pytest.mark.parametrize(
-        "custom_func, custom_flag, expectation",
+        "custom_func, custom_flag, expectation, X",
         [
-            # Valid coef+intercept
+            # Valid coef+intercept, plain array X
             (
                 lambda n_states, X, y, inverse_link_function, random_key: (
                     jnp.zeros((X.shape[1], n_states)),
@@ -701,6 +645,7 @@ class TestGenerateGLMHMMInitialParams:
                 ),
                 "glm_params_init_custom",
                 does_not_raise(),
+                jnp.ones((10, 5)),
             ),
             # Wrong coef shape
             (
@@ -710,6 +655,7 @@ class TestGenerateGLMHMMInitialParams:
                 ),
                 "glm_params_init_custom",
                 pytest.raises(ValueError, match="mis-shaped"),
+                jnp.ones((10, 5)),
             ),
             # Wrong intercept shape
             (
@@ -719,6 +665,7 @@ class TestGenerateGLMHMMInitialParams:
                 ),
                 "glm_params_init_custom",
                 pytest.raises(ValueError, match="incorrect shape"),
+                jnp.ones((10, 5)),
             ),
             # Wrong coef type
             (
@@ -728,6 +675,7 @@ class TestGenerateGLMHMMInitialParams:
                 ),
                 "glm_params_init_custom",
                 pytest.raises(TypeError, match="did not return a pytree of arrays"),
+                jnp.ones((10, 5)),
             ),
             # Wrong intercept type
             (
@@ -737,6 +685,7 @@ class TestGenerateGLMHMMInitialParams:
                 ),
                 "glm_params_init_custom",
                 pytest.raises(TypeError, match="did not return an array"),
+                jnp.ones((10, 5)),
             ),
             # Valid scale
             (
@@ -745,6 +694,7 @@ class TestGenerateGLMHMMInitialParams:
                 ),
                 "scale_init_custom",
                 does_not_raise(),
+                jnp.ones((10, 5)),
             ),
             # Wrong scale shape
             (
@@ -753,21 +703,45 @@ class TestGenerateGLMHMMInitialParams:
                 ),
                 "scale_init_custom",
                 pytest.raises(ValueError, match="incorrect shape"),
+                jnp.ones((10, 5)),
             ),
             # Wrong scale type
             (
                 lambda n_states, X, y, inverse_link_function, random_key: "not_an_array",
                 "scale_init_custom",
                 pytest.raises(TypeError, match="must return an array"),
+                jnp.ones((10, 5)),
+            ),
+            # Valid pytree coef: dict X with matching dict coef and correct leaf shapes
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    {k: jnp.zeros((v.shape[1], n_states)) for k, v in X.items()},
+                    jnp.zeros(n_states),
+                ),
+                "glm_params_init_custom",
+                does_not_raise(),
+                {"feature_a": jnp.ones((10, 3)), "feature_b": jnp.ones((10, 2))},
+            ),
+            # Wrong pytree structure: dict X but plain-array coef
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    jnp.zeros((5, n_states)),
+                    jnp.zeros(n_states),
+                ),
+                "glm_params_init_custom",
+                pytest.raises(ValueError, match="tree structure"),
+                {"feature_a": jnp.ones((10, 3))},
             ),
         ],
     )
-    def test_validate_custom_func_output(self, custom_func, custom_flag, expectation):
+    def test_validate_custom_func_output(
+        self, custom_func, custom_flag, expectation, X
+    ):
         func_key = custom_flag.replace("_custom", "")
         with expectation:
             generate_glm_hmm_initial_params(
                 3,
-                jnp.ones((10, 5)),
+                X,
                 jnp.ones(10),
                 lambda x: x,
                 init_funcs={func_key: custom_func, custom_flag: True},

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -31,43 +31,64 @@ from nemos.inverse_link_function_utils import resolve_inverse_link_function
 # =============================================================================
 
 
-# GLM-type templates: 5 mandatory params (used for glm_params_init and scale_init)
-def _glm_template_no_extra(n_states, X, y, inverse_link_function, random_key):
+# GLM-type templates: 6 mandatory params
+# (n_states, X, y, inverse_link_function, is_new_session, random_key)
+def _glm_template_no_extra(
+    n_states, X, y, inverse_link_function, is_new_session, random_key
+):
     pass
 
 
 def _glm_template_one_extra(
-    n_states, X, y, inverse_link_function, random_key, param1=None
+    n_states, X, y, inverse_link_function, is_new_session, random_key, param1=None
 ):
     pass
 
 
 def _glm_template_two_extra(
-    n_states, X, y, inverse_link_function, random_key, param1=None, param2=None
+    n_states,
+    X,
+    y,
+    inverse_link_function,
+    is_new_session,
+    random_key,
+    param1=None,
+    param2=None,
 ):
     pass
 
 
 def _glm_template_special(
-    n_states, X, y, inverse_link_function, random_key, my_special_param=None
+    n_states,
+    X,
+    y,
+    inverse_link_function,
+    is_new_session,
+    random_key,
+    my_special_param=None,
 ):
     pass
 
 
-# HMM-type templates: 4 mandatory params (used for initial_proba_init and transition_proba_init)
-def _hmm_template_no_extra(n_states, X, y, random_key):
+# HMM-type templates: 5 mandatory params
+# (n_states, X, y, is_new_session, random_key)
+def _hmm_template_no_extra(n_states, X, y, is_new_session, random_key):
     pass
 
 
-def _hmm_template_one_extra(n_states, X, y, random_key, param1=None):
+def _hmm_template_one_extra(n_states, X, y, is_new_session, random_key, param1=None):
     pass
 
 
-def _hmm_template_two_extra(n_states, X, y, random_key, param1=None, param2=None):
+def _hmm_template_two_extra(
+    n_states, X, y, is_new_session, random_key, param1=None, param2=None
+):
     pass
 
 
-def _hmm_template_special(n_states, X, y, random_key, my_special_param=None):
+def _hmm_template_special(
+    n_states, X, y, is_new_session, random_key, my_special_param=None
+):
     pass
 
 
@@ -411,7 +432,7 @@ class TestSetupGLMHMMInitialization:
         "init_func, expectation",
         [
             (
-                lambda n_states, X, y, inverse_link_function, random_key: (
+                lambda n_states, X, y, inverse_link_function, is_new_session, random_key: (
                     jnp.zeros((1, n_states)),
                     jnp.zeros(n_states),
                 ),
@@ -432,7 +453,7 @@ class TestSetupGLMHMMInitialization:
         "init_func, expectation",
         [
             (
-                lambda n_states, X, y, inverse_link_function, random_key: jnp.ones(
+                lambda n_states, X, y, inverse_link_function, is_new_session, random_key: jnp.ones(
                     n_states
                 ),
                 does_not_raise(),
@@ -449,7 +470,8 @@ class TestSetupGLMHMMInitialization:
             assert init_funcs["scale_init"] == init_func
 
     @pytest.mark.parametrize(
-        "kwarg_name", ["n_states", "X", "y", "inverse_link_function", "random_key"]
+        "kwarg_name",
+        ["n_states", "X", "y", "inverse_link_function", "is_new_session", "random_key"],
     )
     def test_glm_params_init_kwargs_reserved(self, kwarg_name):
         with pytest.raises(
@@ -458,7 +480,8 @@ class TestSetupGLMHMMInitialization:
             setup_glm_hmm_initialization(glm_params_init_kwargs={kwarg_name: 123})
 
     @pytest.mark.parametrize(
-        "kwarg_name", ["n_states", "X", "y", "inverse_link_function", "random_key"]
+        "kwarg_name",
+        ["n_states", "X", "y", "inverse_link_function", "is_new_session", "random_key"],
     )
     def test_scale_init_kwargs_reserved(self, kwarg_name):
         with pytest.raises(
@@ -523,7 +546,6 @@ class TestSetupGLMHMMInitializationKwargs:
 
     def test_none_returns_empty_kwargs(self, func_name, recwarn):
         mock_registry = _get_mock_registry("one_extra")
-        # inject a mock function then check kwargs validation
         init_funcs = setup_glm_hmm_initialization(
             **{func_name: mock_registry[func_name]}
         )
@@ -632,298 +654,3 @@ class TestGenerateGLMHMMInitialParams:
         coef1, *_ = generate_glm_hmm_initial_params(3, X, y, lambda x: x, random_key=1)
         coef2, *_ = generate_glm_hmm_initial_params(3, X, y, lambda x: x, random_key=2)
         assert not jnp.allclose(coef1, coef2)
-
-    @pytest.mark.parametrize(
-        "custom_func, custom_flag, expectation, X",
-        [
-            # Valid coef+intercept, plain array X
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: (
-                    jnp.zeros((X.shape[1], n_states)),
-                    jnp.zeros(n_states),
-                ),
-                "glm_params_init_custom",
-                does_not_raise(),
-                jnp.ones((10, 5)),
-            ),
-            # Wrong coef shape
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: (
-                    jnp.zeros((X.shape[1] + 1, n_states)),
-                    jnp.zeros(n_states),
-                ),
-                "glm_params_init_custom",
-                pytest.raises(ValueError, match="mis-shaped"),
-                jnp.ones((10, 5)),
-            ),
-            # Wrong intercept shape
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: (
-                    jnp.zeros((X.shape[1], n_states)),
-                    jnp.zeros(n_states + 1),
-                ),
-                "glm_params_init_custom",
-                pytest.raises(ValueError, match="incorrect shape"),
-                jnp.ones((10, 5)),
-            ),
-            # Wrong coef type
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: (
-                    "not_an_array",
-                    jnp.zeros(n_states),
-                ),
-                "glm_params_init_custom",
-                pytest.raises(TypeError, match="did not return a pytree of arrays"),
-                jnp.ones((10, 5)),
-            ),
-            # Wrong intercept type
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: (
-                    jnp.zeros((X.shape[1], n_states)),
-                    "not_an_array",
-                ),
-                "glm_params_init_custom",
-                pytest.raises(TypeError, match="did not return an array"),
-                jnp.ones((10, 5)),
-            ),
-            # Valid scale
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: jnp.ones(
-                    n_states
-                ),
-                "scale_init_custom",
-                does_not_raise(),
-                jnp.ones((10, 5)),
-            ),
-            # Wrong scale shape
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: jnp.ones(
-                    n_states + 1
-                ),
-                "scale_init_custom",
-                pytest.raises(ValueError, match="incorrect shape"),
-                jnp.ones((10, 5)),
-            ),
-            # Wrong scale type
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: "not_an_array",
-                "scale_init_custom",
-                pytest.raises(TypeError, match="must return an array"),
-                jnp.ones((10, 5)),
-            ),
-            # Valid pytree coef: dict X with matching dict coef and correct leaf shapes
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: (
-                    {k: jnp.zeros((v.shape[1], n_states)) for k, v in X.items()},
-                    jnp.zeros(n_states),
-                ),
-                "glm_params_init_custom",
-                does_not_raise(),
-                {"feature_a": jnp.ones((10, 3)), "feature_b": jnp.ones((10, 2))},
-            ),
-            # Wrong pytree structure: dict X but plain-array coef
-            (
-                lambda n_states, X, y, inverse_link_function, random_key: (
-                    jnp.zeros((5, n_states)),
-                    jnp.zeros(n_states),
-                ),
-                "glm_params_init_custom",
-                pytest.raises(TypeError, match="tree structure"),
-                {"feature_a": jnp.ones((10, 3))},
-            ),
-        ],
-    )
-    def test_validate_custom_func_output(
-        self, custom_func, custom_flag, expectation, X
-    ):
-        func_key = custom_flag.replace("_custom", "")
-        with expectation:
-            generate_glm_hmm_initial_params(
-                3,
-                X,
-                jnp.ones(10),
-                lambda x: x,
-                init_funcs={func_key: custom_func, custom_flag: True},
-            )
-
-
-# =============================================================================
-# Tests for _validate_custom_glm_params_output
-# =============================================================================
-
-
-class TestValidateCustomGLMParamsOutput:
-    """Test custom GLM params output validation via generate_glm_hmm_initial_params."""
-
-    @pytest.mark.parametrize("n_neurons", [1, 3])
-    def test_valid_output(self, n_neurons):
-        n_states, n_features = 3, 5
-        X = jnp.ones((10, n_features))
-        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
-
-        if n_neurons == 1:
-            coef = jnp.zeros((n_features, n_states))
-            intercept = jnp.zeros(n_states)
-        else:
-            coef = jnp.zeros((n_features, n_neurons, n_states))
-            intercept = jnp.zeros((n_neurons, n_states))
-
-        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return coef, intercept
-
-        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
-        generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
-
-    @pytest.mark.parametrize("n_neurons", [1, 3])
-    def test_wrong_coef_shape_raises(self, n_neurons):
-        n_states, n_features = 3, 5
-        X = jnp.ones((10, n_features))
-        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
-        coef = jnp.zeros((n_features + 1, n_states))  # wrong n_features
-        intercept = jnp.zeros((n_neurons, n_states) if n_neurons > 1 else (n_states,))
-
-        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return coef, intercept
-
-        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
-        with pytest.raises(ValueError, match="mis-shaped"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-    @pytest.mark.parametrize("n_neurons", [1, 3])
-    def test_wrong_intercept_shape_raises(self, n_neurons):
-        n_states, n_features = 3, 5
-        X = jnp.ones((10, n_features))
-        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
-        coef = jnp.zeros(
-            (n_features, n_neurons, n_states)
-            if n_neurons > 1
-            else (n_features, n_states)
-        )
-        intercept = jnp.zeros(n_states + 1)  # wrong shape
-
-        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return coef, intercept
-
-        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
-        with pytest.raises(ValueError, match="incorrect shape"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-    def test_wrong_coef_type_raises(self):
-        n_states, n_features = 3, 5
-        X = jnp.ones((10, n_features))
-        y = jnp.ones(10)
-
-        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return "not_an_array", jnp.zeros(n_states)
-
-        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
-        with pytest.raises(TypeError, match="did not return a pytree of arrays"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-    def test_wrong_intercept_type_raises(self):
-        n_states, n_features = 3, 5
-        X = jnp.ones((10, n_features))
-        y = jnp.ones(10)
-
-        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return jnp.zeros((n_features, n_states)), "not_an_array"
-
-        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
-        with pytest.raises(TypeError, match="did not return an array"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-    def test_error_message_shows_shapes(self):
-        """Error message includes both actual and expected shapes."""
-        n_states, n_features = 3, 5
-        X = jnp.ones((10, n_features))
-        y = jnp.ones(10)
-        coef = jnp.zeros((n_features + 2, n_states))
-
-        def custom_init(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return coef, jnp.zeros(n_states)
-
-        init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
-        with pytest.raises(ValueError, match="Actual shapes"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-        with pytest.raises(ValueError, match="Expected shapes"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-
-# =============================================================================
-# Tests for _validate_custom_scale_output
-# =============================================================================
-
-
-class TestValidateCustomScaleOutput:
-    """Test custom scale output validation via generate_glm_hmm_initial_params."""
-
-    @pytest.mark.parametrize("n_neurons", [1, 3])
-    def test_valid_output(self, n_neurons):
-        n_states = 3
-        X = jnp.ones((10, 5))
-        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
-        scale = jnp.ones((n_states, n_neurons) if n_neurons > 1 else (n_states,))
-
-        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return scale
-
-        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
-        generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
-
-    @pytest.mark.parametrize("n_neurons", [1, 3])
-    def test_wrong_shape_raises(self, n_neurons):
-        n_states = 3
-        X = jnp.ones((10, 5))
-        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
-        scale = jnp.ones(n_states + 1)
-
-        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return scale
-
-        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
-        with pytest.raises(ValueError, match="incorrect shape"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-    def test_wrong_type_raises(self):
-        n_states = 3
-        X = jnp.ones((10, 5))
-        y = jnp.ones(10)
-
-        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return "not_an_array"
-
-        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
-        with pytest.raises(TypeError, match="must return an array"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )
-
-    def test_error_message_shows_expected_shape(self):
-        n_states = 3
-        X = jnp.ones((10, 5))
-        y = jnp.ones(10)
-        scale = jnp.ones(n_states + 2)
-
-        def custom_scale(n_states, X, y, inverse_link_function, random_key, **kwargs):
-            return scale
-
-        init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
-        with pytest.raises(ValueError, match=rf"\({n_states},\)"):
-            generate_glm_hmm_initial_params(
-                n_states, X, y, jnp.exp, init_funcs=init_funcs
-            )

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -11,7 +11,7 @@ import pytest
 from nemos.glm import GLM
 from nemos.glm_hmm.initialize_parameters import (
     DEFAULT_INIT_FUNCTIONS_GLMHMM,
-    GLM_INIT_FUCS,
+    GLM_INIT_FUNCS,
     KMeansInitializerGLM,
     constant_scale_init,
     generate_glm_hmm_initial_params,
@@ -494,7 +494,7 @@ class TestSetupGLMHMMInitialization:
         first = setup_glm_hmm_initialization(**{key: init_str, kwargs_key: kwargs_val})
         second = setup_glm_hmm_initialization(
             **{key: init_str},
-            init_funcs={k: v for k, v in first.items() if k in GLM_INIT_FUCS},
+            init_funcs={k: v for k, v in first.items() if k in GLM_INIT_FUNCS},
         )
         assert first[kwargs_key] == kwargs_val
         assert second[kwargs_key] == {}

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -1,0 +1,898 @@
+"""Tests for glm_hmm/initialize_parameters.py"""
+
+import itertools
+from contextlib import nullcontext as does_not_raise
+from unittest.mock import create_autospec
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from nemos.glm_hmm.initialize_parameters import (
+    DEFAULT_INIT_FUNCTIONS_GLMHMM,
+    GLM_INIT_FUCS,
+    KMeansInitializerGLM,
+    _validate_custom_glm_params_output,
+    _validate_custom_scale_output,
+    constant_scale_init,
+    generate_glm_hmm_initial_params,
+    kmeans_glm_params_init,
+    kmeans_scale_init,
+    random_glm_params_init,
+    setup_glm_hmm_initialization,
+)
+from nemos.hmm.initialize_parameters import (
+    sticky_transition_proba_init,
+    uniform_initial_proba_init,
+)
+from nemos.inverse_link_function_utils import resolve_inverse_link_function
+
+# =============================================================================
+# Mock infrastructure
+# =============================================================================
+
+
+# GLM-type templates: 5 mandatory params (used for glm_params_init and scale_init)
+def _glm_template_no_extra(n_states, X, y, inverse_link_function, random_key):
+    pass
+
+
+def _glm_template_one_extra(
+    n_states, X, y, inverse_link_function, random_key, param1=None
+):
+    pass
+
+
+def _glm_template_two_extra(
+    n_states, X, y, inverse_link_function, random_key, param1=None, param2=None
+):
+    pass
+
+
+def _glm_template_special(
+    n_states, X, y, inverse_link_function, random_key, my_special_param=None
+):
+    pass
+
+
+# HMM-type templates: 4 mandatory params (used for initial_proba_init and transition_proba_init)
+def _hmm_template_no_extra(n_states, X, y, random_key):
+    pass
+
+
+def _hmm_template_one_extra(n_states, X, y, random_key, param1=None):
+    pass
+
+
+def _hmm_template_two_extra(n_states, X, y, random_key, param1=None, param2=None):
+    pass
+
+
+def _hmm_template_special(n_states, X, y, random_key, my_special_param=None):
+    pass
+
+
+_GLM_TEMPLATES = {
+    "no_extra": _glm_template_no_extra,
+    "one_extra": _glm_template_one_extra,
+    "two_extra": _glm_template_two_extra,
+    "special": _glm_template_special,
+}
+_HMM_TEMPLATES = {
+    "no_extra": _hmm_template_no_extra,
+    "one_extra": _hmm_template_one_extra,
+    "two_extra": _hmm_template_two_extra,
+    "special": _hmm_template_special,
+}
+
+_GLM_FUNC_NAMES = {"glm_params_init", "scale_init"}
+_ALL_FUNC_NAMES = [
+    "glm_params_init",
+    "scale_init",
+    "initial_proba_init",
+    "transition_proba_init",
+]
+
+MOCK_VALID_KWARGS = {
+    "one_extra": {"param1": 0.5},
+    "two_extra": {"param1": 0.5, "param2": 0.5},
+}
+
+
+def _get_mock(func_name, template_type):
+    """Get a mock with the correct signature for the given function name."""
+    templates = _GLM_TEMPLATES if func_name in _GLM_FUNC_NAMES else _HMM_TEMPLATES
+    return create_autospec(templates[template_type], return_value=None)
+
+
+def _get_mock_registry(template_type="one_extra"):
+    """Get a mock registry where all functions share the same template type."""
+    return {fn: _get_mock(fn, template_type) for fn in _ALL_FUNC_NAMES}
+
+
+# =============================================================================
+# Tests for random_glm_params_init
+# =============================================================================
+
+
+class TestRandomGLMParamsInitialization:
+    """Test random initialization of GLM parameters for GLM-HMM."""
+
+    @pytest.mark.parametrize("n_states", [1, 2, 3])
+    @pytest.mark.parametrize(
+        "n_samples, n_features, n_neurons",
+        [
+            (100, 5, 1),
+            (100, 5, 3),
+            (50, 10, 1),
+        ],
+    )
+    def test_expected_output_shape(self, n_states, n_samples, n_features, n_neurons):
+        X = jnp.ones((n_samples, n_features))
+        y = jnp.ones((n_samples, n_neurons)) if n_neurons > 1 else jnp.ones(n_samples)
+        inverse_link = lambda x: x
+
+        coef, intercept = random_glm_params_init(
+            n_states, X, y, inverse_link, random_key=jax.random.PRNGKey(123)
+        )
+
+        if n_neurons == 1:
+            assert coef.shape == (n_features, n_states)
+            assert intercept.shape == (n_states,)
+        else:
+            assert coef.shape == (n_features, n_neurons, n_states)
+            assert intercept.shape == (n_neurons, n_states)
+
+    @pytest.mark.parametrize(
+        "X, y",
+        [
+            (np.ones((100, 5)), np.ones(100)),
+            (jnp.ones((100, 5)), jnp.ones(100)),
+        ],
+    )
+    def test_expected_output_type(self, X, y):
+        coef, intercept = random_glm_params_init(
+            2, X, y, lambda x: x, random_key=jax.random.PRNGKey(123)
+        )
+        assert isinstance(coef, jnp.ndarray)
+        assert isinstance(intercept, jnp.ndarray)
+
+    def test_randomization(self):
+        """Different seeds give different coef but identical intercept."""
+        X = jnp.ones((100, 5))
+        y = jnp.ones(100)
+        inverse_link = lambda x: x
+
+        coef1, intercept1 = random_glm_params_init(
+            3, X, y, inverse_link, random_key=jax.random.PRNGKey(41)
+        )
+        coef2, intercept2 = random_glm_params_init(
+            3, X, y, inverse_link, random_key=jax.random.PRNGKey(42)
+        )
+
+        assert not jnp.allclose(coef1, coef2)
+        assert jnp.allclose(intercept1, intercept2)
+
+    @pytest.mark.parametrize("std_dev", [0.0, 1.0])
+    def test_std_dev_param(self, std_dev):
+        X = jnp.ones((10, 2))
+        y = jnp.ones((10, 3))
+        coef, _ = random_glm_params_init(
+            4, X, y, lambda x: x, random_key=jax.random.PRNGKey(123), std_dev=std_dev
+        )
+        if std_dev == 0.0:
+            assert jnp.all(coef == 0)
+
+    def test_coef_magnitude(self):
+        """Default std_dev produces small coefficients."""
+        X = jnp.ones((100, 5))
+        y = jnp.ones(100)
+        coef, _ = random_glm_params_init(
+            3, X, y, lambda x: x, random_key=jax.random.PRNGKey(123)
+        )
+        assert jnp.abs(coef).max() < 0.01
+
+    def test_intercept_matches_mean_rate(self):
+        """Intercept initialized to match mean rate of y (identity link)."""
+        y_mean = 2.5
+        y = jnp.full(100, y_mean)
+        _, intercept = random_glm_params_init(
+            3, jnp.ones((100, 5)), y, lambda x: x, random_key=jax.random.PRNGKey(123)
+        )
+        assert jnp.allclose(intercept, y_mean)
+
+    def test_intercept_tiled_across_states(self):
+        """All states get the same intercept value."""
+        _, intercept = random_glm_params_init(
+            3,
+            jnp.ones((100, 5)),
+            jnp.array([1.0, 2.0, 3.0] * 33 + [1.0]),
+            lambda x: x,
+            random_key=jax.random.PRNGKey(123),
+        )
+        assert jnp.allclose(intercept[0], intercept)
+
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_inverse_link_function_usage(self, n_neurons):
+        """Exp inverse link → intercept = log(mean(y))."""
+        y = jnp.full((100, n_neurons) if n_neurons > 1 else 100, 10.0)
+        _, intercept = random_glm_params_init(
+            2,
+            jnp.ones((100, 5)),
+            y,
+            jax.nn.softplus,
+            random_key=jax.random.PRNGKey(123),
+        )
+        link_func = resolve_inverse_link_function(jax.nn.softplus, None)
+        assert jnp.allclose(intercept, link_func(10.0))
+
+
+# =============================================================================
+# Tests for constant_scale_init
+# =============================================================================
+
+
+class TestConstantScaleInitialization:
+    """Test constant initialization for scale parameters."""
+
+    @pytest.mark.parametrize("n_states", [1, 2, 3, 5])
+    @pytest.mark.parametrize("n_samples, n_neurons", [(100, 1), (100, 3), (50, 10)])
+    def test_expected_output_shape(self, n_states, n_samples, n_neurons):
+        X = jnp.ones((n_samples, 5))
+        y = jnp.ones((n_samples, n_neurons)) if n_neurons > 1 else jnp.ones(n_samples)
+
+        scale = constant_scale_init(
+            n_states, X, y, lambda x: x, random_key=jax.random.PRNGKey(124)
+        )
+
+        if n_neurons == 1:
+            assert scale.shape == (n_states,)
+        else:
+            assert scale.shape == (n_neurons, n_states)
+
+    @pytest.mark.parametrize(
+        "X, y",
+        [
+            (np.ones((100, 5)), np.ones(100)),
+            (jnp.ones((100, 5)), jnp.ones(100)),
+        ],
+    )
+    def test_expected_output_type(self, X, y):
+        scale = constant_scale_init(
+            2, X, y, lambda x: x, random_key=jax.random.PRNGKey(124)
+        )
+        assert isinstance(scale, jnp.ndarray)
+
+    @pytest.mark.parametrize("n_states", [1, 3, 5])
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_default_value_is_one(self, n_states, n_neurons):
+        y = jnp.ones((100, n_neurons)) if n_neurons > 1 else jnp.ones(100)
+        scale = constant_scale_init(
+            n_states,
+            jnp.ones((100, 5)),
+            y,
+            lambda x: x,
+            random_key=jax.random.PRNGKey(124),
+        )
+        assert jnp.all(scale == 1.0)
+
+    @pytest.mark.parametrize("scale_val", [0.5, 1.0, 2.0, 10.0])
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_custom_scale_value(self, scale_val, n_neurons):
+        y = jnp.ones((100, n_neurons)) if n_neurons > 1 else jnp.ones(100)
+        scale = constant_scale_init(
+            3,
+            jnp.ones((100, 5)),
+            y,
+            lambda x: x,
+            random_key=jax.random.PRNGKey(124),
+            scale_val=scale_val,
+        )
+        assert jnp.all(scale == scale_val)
+
+    def test_deterministic(self):
+        """Output is identical regardless of random key."""
+        X = jnp.ones((100, 5))
+        y = jnp.ones(100)
+        scale1 = constant_scale_init(
+            3, X, y, lambda x: x, random_key=jax.random.PRNGKey(1)
+        )
+        scale2 = constant_scale_init(
+            3, X, y, lambda x: x, random_key=jax.random.PRNGKey(999)
+        )
+        assert jnp.array_equal(scale1, scale2)
+
+
+# =============================================================================
+# Tests for KMeansInitializerGLM
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def kmeans_glm_data():
+    """Simple clustered data for KMeans GLM initialization tests."""
+    rng = np.random.default_rng(0)
+    n_states = 3
+    n_samples = 300
+    n_features = 4
+    X = rng.standard_normal((n_samples, n_features))
+    y = rng.poisson(5, n_samples).astype(float)
+    y_pop = rng.poisson(5, (n_samples, 2)).astype(float)
+    return n_states, X, y, y_pop
+
+
+class TestKMeansInitializerGLM:
+    """Test KMeans-based GLM parameter initialization."""
+
+    @pytest.mark.parametrize("n_neurons", [1, 2])
+    def test_glm_params_output_shape(self, kmeans_glm_data, n_neurons):
+        n_states, X, y, y_pop = kmeans_glm_data
+        obs = y_pop if n_neurons > 1 else y
+
+        initializer = KMeansInitializerGLM(n_states, X, obs, jnp.exp, random_key=0)
+        coef, intercept = initializer.glm_params()
+
+        if n_neurons == 1:
+            assert coef.shape == (X.shape[1], n_states)
+            assert intercept.shape == (n_states,)
+        else:
+            assert coef.shape == (X.shape[1], n_neurons, n_states)
+            assert intercept.shape == (n_neurons, n_states)
+
+    @pytest.mark.parametrize("n_neurons", [1, 2])
+    def test_scale_output_shape(self, kmeans_glm_data, n_neurons):
+        """Poisson GLM has fixed scale=1, so scale() returns ones without fitting."""
+        n_states, X, y, y_pop = kmeans_glm_data
+        obs = y_pop if n_neurons > 1 else y
+
+        initializer = KMeansInitializerGLM(n_states, X, obs, jnp.exp, random_key=0)
+        scale = initializer.scale()
+
+        if n_neurons == 1:
+            assert scale.shape == (n_states,)
+        else:
+            assert scale.shape == (n_states, n_neurons)
+
+    def test_shared_initializer(self, kmeans_glm_data):
+        """Providing a pre-built initializer skips refitting."""
+        n_states, X, y, _ = kmeans_glm_data
+
+        initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=7)
+        result = kmeans_glm_params_init(
+            n_states, X, y, jnp.exp, initializer=initializer
+        )
+        expected = initializer.glm_params()
+        coef_r, int_r = result
+        coef_e, int_e = expected
+        assert jnp.allclose(coef_r, coef_e)
+        assert jnp.allclose(int_r, int_e)
+
+    def test_different_random_keys_give_different_results(self, kmeans_glm_data):
+        n_states, X, y, _ = kmeans_glm_data
+
+        init1 = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=1)
+        init2 = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=2)
+
+        coef1, _ = init1.glm_params()
+        coef2, _ = init2.glm_params()
+        # KMeans with different seeds may produce different state assignments
+        # sorted coefficients should still differ unless by chance
+        assert not jnp.allclose(jnp.sort(coef1.ravel()), jnp.sort(coef2.ravel()))
+
+
+# =============================================================================
+# Tests for setup_glm_hmm_initialization
+# =============================================================================
+
+
+class TestSetupGLMHMMInitialization:
+    """Test setup_glm_hmm_initialization for GLM-specific initialization functions."""
+
+    @pytest.mark.parametrize(
+        "init_str, expectation, method",
+        [
+            ("random", does_not_raise(), random_glm_params_init),
+            ("kmeans", does_not_raise(), kmeans_glm_params_init),
+            (None, does_not_raise(), DEFAULT_INIT_FUNCTIONS_GLMHMM["glm_params_init"]),
+            (
+                "invalid",
+                pytest.raises(ValueError, match="Invalid initialization"),
+                None,
+            ),
+            (
+                ["invalid"],
+                pytest.raises(TypeError, match="either a string or a callable"),
+                None,
+            ),
+        ],
+    )
+    def test_glm_params_init_str(self, init_str, expectation, method):
+        with expectation:
+            init_funcs = setup_glm_hmm_initialization(glm_params_init=init_str)
+            assert init_funcs["glm_params_init"] == method
+
+    @pytest.mark.parametrize(
+        "init_str, expectation, method",
+        [
+            ("constant", does_not_raise(), constant_scale_init),
+            ("kmeans", does_not_raise(), kmeans_scale_init),
+            (None, does_not_raise(), DEFAULT_INIT_FUNCTIONS_GLMHMM["scale_init"]),
+            (
+                "invalid",
+                pytest.raises(ValueError, match="Invalid initialization"),
+                None,
+            ),
+        ],
+    )
+    def test_scale_init_str(self, init_str, expectation, method):
+        with expectation:
+            init_funcs = setup_glm_hmm_initialization(scale_init=init_str)
+            assert init_funcs["scale_init"] == method
+
+    @pytest.mark.parametrize(
+        "init_func, expectation",
+        [
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    jnp.zeros((1, n_states)),
+                    jnp.zeros(n_states),
+                ),
+                does_not_raise(),
+            ),
+            (
+                lambda n_states: (jnp.zeros((1, n_states)), jnp.zeros(n_states)),
+                pytest.raises(ValueError, match="must have the parameters"),
+            ),
+        ],
+    )
+    def test_glm_params_init_custom(self, init_func, expectation):
+        with expectation:
+            init_funcs = setup_glm_hmm_initialization(glm_params_init=init_func)
+            assert init_funcs["glm_params_init"] == init_func
+
+    @pytest.mark.parametrize(
+        "init_func, expectation",
+        [
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: jnp.ones(
+                    n_states
+                ),
+                does_not_raise(),
+            ),
+            (
+                lambda n_states: jnp.ones(n_states),
+                pytest.raises(ValueError, match="must have the parameters"),
+            ),
+        ],
+    )
+    def test_scale_init_custom(self, init_func, expectation):
+        with expectation:
+            init_funcs = setup_glm_hmm_initialization(scale_init=init_func)
+            assert init_funcs["scale_init"] == init_func
+
+    @pytest.mark.parametrize(
+        "kwarg_name", ["n_states", "X", "y", "inverse_link_function", "random_key"]
+    )
+    def test_glm_params_init_kwargs_reserved(self, kwarg_name):
+        with pytest.raises(
+            ValueError, match=f"Keyword argument '{kwarg_name}' is reserved"
+        ):
+            setup_glm_hmm_initialization(glm_params_init_kwargs={kwarg_name: 123})
+
+    @pytest.mark.parametrize(
+        "kwarg_name", ["n_states", "X", "y", "inverse_link_function", "random_key"]
+    )
+    def test_scale_init_kwargs_reserved(self, kwarg_name):
+        with pytest.raises(
+            ValueError, match=f"Keyword argument '{kwarg_name}' is reserved"
+        ):
+            setup_glm_hmm_initialization(scale_init_kwargs={kwarg_name: 123})
+
+    def test_unknown_init_funcs_key(self):
+        with pytest.raises(KeyError, match="Unexpected or unknown keys"):
+            setup_glm_hmm_initialization(init_funcs={"totally_invalid_key": None})
+
+    @pytest.mark.parametrize(
+        "key, init_str, kwargs_key, kwargs_val",
+        [
+            (
+                "glm_params_init",
+                "random",
+                "glm_params_init_kwargs",
+                {"std_dev": 0.01},
+            ),
+            (
+                "scale_init",
+                "constant",
+                "scale_init_kwargs",
+                {"scale_val": 2.0},
+            ),
+        ],
+    )
+    def test_reset_kwargs_when_func_changes(
+        self, key, init_str, kwargs_key, kwargs_val
+    ):
+        """Providing a new init function resets its kwargs to {}."""
+        first = setup_glm_hmm_initialization(**{key: init_str, kwargs_key: kwargs_val})
+        second = setup_glm_hmm_initialization(
+            **{key: init_str},
+            init_funcs={k: v for k, v in first.items() if k in GLM_INIT_FUCS},
+        )
+        assert first[kwargs_key] == kwargs_val
+        assert second[kwargs_key] == {}
+
+    def test_default_initialization(self):
+        """No-arg call returns DEFAULT_INIT_FUNCTIONS_GLMHMM."""
+        init_funcs = setup_glm_hmm_initialization()
+        assert init_funcs == DEFAULT_INIT_FUNCTIONS_GLMHMM
+
+    def test_hmm_params_delegated(self):
+        """HMM init functions (initial_proba, transition_proba) are set correctly."""
+        init_funcs = setup_glm_hmm_initialization(
+            initial_proba_init="uniform",
+            transition_proba_init="sticky",
+        )
+        assert init_funcs["initial_proba_init"] == uniform_initial_proba_init
+        assert init_funcs["transition_proba_init"] == sticky_transition_proba_init
+
+
+@pytest.mark.parametrize(
+    "func_name",
+    ["glm_params_init", "scale_init", "initial_proba_init", "transition_proba_init"],
+)
+class TestSetupGLMHMMInitializationKwargs:
+    """Test kwargs validation in setup_glm_hmm_initialization via mock registries."""
+
+    def test_none_returns_empty_kwargs(self, func_name, recwarn):
+        mock_registry = _get_mock_registry("one_extra")
+        # inject a mock function then check kwargs validation
+        init_funcs = setup_glm_hmm_initialization(
+            **{func_name: mock_registry[func_name]}
+        )
+        assert init_funcs[func_name + "_kwargs"] == {}
+
+    @pytest.mark.parametrize(
+        "template_type, extra_kwargs",
+        [
+            ("one_extra", {"param1": 0.5}),
+            ("two_extra", {"param1": 0.5, "param2": 0.5}),
+        ],
+    )
+    def test_valid_kwargs_accepted(self, func_name, template_type, extra_kwargs):
+        mock_func = _get_mock(func_name, template_type)
+        init_funcs = setup_glm_hmm_initialization(
+            **{func_name: mock_func, func_name + "_kwargs": extra_kwargs}
+        )
+        assert init_funcs[func_name + "_kwargs"] == extra_kwargs
+
+    def test_invalid_kwarg_raises(self, func_name):
+        mock_func = _get_mock(func_name, "one_extra")
+        with pytest.raises(ValueError, match="Invalid keyword argument"):
+            setup_glm_hmm_initialization(
+                **{func_name: mock_func, func_name + "_kwargs": {"invalid_param": 0.5}}
+            )
+
+
+# =============================================================================
+# Tests for generate_glm_hmm_initial_params
+# =============================================================================
+
+
+class TestGenerateGLMHMMInitialParams:
+    """Test generate_glm_hmm_initial_params function."""
+
+    @pytest.mark.parametrize("n_states", [1, 2, 3, 5])
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_output_shapes_and_types(self, n_states, n_neurons):
+        n_features = 5
+        X = jnp.ones((50, n_features))
+        y = jnp.ones((50, n_neurons)) if n_neurons > 1 else jnp.ones(50)
+
+        coef, intercept, scale, initial_probs, transition_matrix = (
+            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp)
+        )
+
+        if n_neurons == 1:
+            assert coef.shape == (n_features, n_states)
+            assert intercept.shape == (n_states,)
+            assert scale.shape == (n_states,)
+        else:
+            assert coef.shape == (n_features, n_neurons, n_states)
+            assert intercept.shape == (n_neurons, n_states)
+            assert scale.shape == (n_neurons, n_states)
+
+        assert initial_probs.shape == (n_states,)
+        assert transition_matrix.shape == (n_states, n_states)
+
+        for arr in [coef, intercept, scale, initial_probs, transition_matrix]:
+            assert isinstance(arr, jnp.ndarray)
+
+    def test_returns_five_elements(self):
+        result = generate_glm_hmm_initial_params(
+            2, jnp.ones((10, 3)), jnp.ones(10), lambda x: x
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 5
+
+    @pytest.mark.parametrize(
+        "init_funcs, expectation",
+        [
+            ({}, does_not_raise()),
+            ({"glm_params_init": random_glm_params_init}, does_not_raise()),
+            (
+                {"totally_invalid_key": None},
+                pytest.raises(KeyError, match="Unexpected or unknown keys"),
+            ),
+        ],
+    )
+    def test_init_funcs_key_validation(self, init_funcs, expectation):
+        with expectation:
+            generate_glm_hmm_initial_params(
+                3,
+                jnp.ones((10, 5)),
+                jnp.ones(10),
+                lambda x: x,
+                init_funcs=init_funcs,
+            )
+
+    def test_none_init_funcs_uses_defaults(self):
+        X = jnp.ones((50, 5))
+        y = jnp.full(50, 2.0)
+        coef, intercept, scale, initial_probs, transition_matrix = (
+            generate_glm_hmm_initial_params(3, X, y, lambda x: x)
+        )
+        assert jnp.abs(coef).max() < 0.01
+        assert jnp.allclose(intercept, 2.0)
+        assert jnp.all(scale == 1.0)
+        assert jnp.allclose(initial_probs, 1.0 / 3)
+        assert jnp.allclose(jnp.diag(transition_matrix), 0.95)
+
+    def test_random_key_splitting(self):
+        """All outputs differ from each other — each init function gets a distinct subkey."""
+        n_states = 3
+        n_features = 5
+        X = jnp.ones((100, n_features))
+        y = jnp.ones(100)
+
+        fixed_shape = (10,)
+
+        def rand_glm(n_states, X, y, inverse_link_function, random_key):
+            k1, k2 = jax.random.split(random_key)
+            return jax.random.normal(k1, fixed_shape), jax.random.normal(
+                k2, fixed_shape
+            )
+
+        def rand_scale(n_states, X, y, inverse_link_function, random_key):
+            return jax.random.normal(random_key, fixed_shape)
+
+        def rand_initial(n_states, X, y, random_key):
+            return jax.random.normal(random_key, fixed_shape)
+
+        def rand_transition(n_states, X, y, random_key):
+            return jax.random.normal(random_key, fixed_shape)
+
+        init_funcs = setup_glm_hmm_initialization(
+            glm_params_init=rand_glm,
+            scale_init=rand_scale,
+            initial_proba_init=rand_initial,
+            transition_proba_init=rand_transition,
+        )
+
+        coef, intercept, scale, initial_probs, transition_matrix = (
+            generate_glm_hmm_initial_params(
+                n_states, X, y, lambda x: x, init_funcs=init_funcs
+            )
+        )
+
+        for p1, p2 in itertools.combinations(
+            [coef, intercept, scale, initial_probs, transition_matrix], 2
+        ):
+            assert not jnp.allclose(p1, p2)
+
+    @pytest.mark.parametrize(
+        "custom_func, custom_flag, expectation",
+        [
+            # Valid coef+intercept
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    jnp.zeros((X.shape[1], n_states)),
+                    jnp.zeros(n_states),
+                ),
+                "glm_params_init_custom",
+                does_not_raise(),
+            ),
+            # Wrong coef shape
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    jnp.zeros((X.shape[1] + 1, n_states)),
+                    jnp.zeros(n_states),
+                ),
+                "glm_params_init_custom",
+                pytest.raises(ValueError, match="mis-shaped"),
+            ),
+            # Wrong intercept shape
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    jnp.zeros((X.shape[1], n_states)),
+                    jnp.zeros(n_states + 1),
+                ),
+                "glm_params_init_custom",
+                pytest.raises(ValueError, match="incorrect shape"),
+            ),
+            # Wrong coef type
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    "not_an_array",
+                    jnp.zeros(n_states),
+                ),
+                "glm_params_init_custom",
+                pytest.raises(TypeError, match="did not return a pytree of arrays"),
+            ),
+            # Wrong intercept type
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: (
+                    jnp.zeros((X.shape[1], n_states)),
+                    "not_an_array",
+                ),
+                "glm_params_init_custom",
+                pytest.raises(TypeError, match="did not return an array"),
+            ),
+            # Valid scale
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: jnp.ones(
+                    n_states
+                ),
+                "scale_init_custom",
+                does_not_raise(),
+            ),
+            # Wrong scale shape
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: jnp.ones(
+                    n_states + 1
+                ),
+                "scale_init_custom",
+                pytest.raises(ValueError, match="incorrect shape"),
+            ),
+            # Wrong scale type
+            (
+                lambda n_states, X, y, inverse_link_function, random_key: "not_an_array",
+                "scale_init_custom",
+                pytest.raises(TypeError, match="must return an array"),
+            ),
+        ],
+    )
+    def test_validate_custom_func_output(self, custom_func, custom_flag, expectation):
+        func_key = custom_flag.replace("_custom", "")
+        with expectation:
+            generate_glm_hmm_initial_params(
+                3,
+                jnp.ones((10, 5)),
+                jnp.ones(10),
+                lambda x: x,
+                init_funcs={func_key: custom_func, custom_flag: True},
+            )
+
+
+# =============================================================================
+# Tests for _validate_custom_glm_params_output
+# =============================================================================
+
+
+class TestValidateCustomGLMParamsOutput:
+    """Test _validate_custom_glm_params_output directly."""
+
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_valid_output(self, n_neurons):
+        n_states, n_features = 3, 5
+        X = jnp.ones((10, n_features))
+        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
+
+        if n_neurons == 1:
+            coef = jnp.zeros((n_features, n_states))
+            intercept = jnp.zeros(n_states)
+        else:
+            coef = jnp.zeros((n_features, n_neurons, n_states))
+            intercept = jnp.zeros((n_neurons, n_states))
+
+        _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
+
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_wrong_coef_shape_raises(self, n_neurons):
+        n_states, n_features = 3, 5
+        X = jnp.ones((10, n_features))
+        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
+        coef = jnp.zeros((n_features + 1, n_states))  # wrong n_features
+        intercept = jnp.zeros((n_neurons, n_states) if n_neurons > 1 else (n_states,))
+
+        with pytest.raises(ValueError, match="mis-shaped"):
+            _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
+
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_wrong_intercept_shape_raises(self, n_neurons):
+        n_states, n_features = 3, 5
+        X = jnp.ones((10, n_features))
+        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
+        coef = jnp.zeros(
+            (n_features, n_neurons, n_states)
+            if n_neurons > 1
+            else (n_features, n_states)
+        )
+        intercept = jnp.zeros(n_states + 1)  # wrong shape
+
+        with pytest.raises(ValueError, match="incorrect shape"):
+            _validate_custom_glm_params_output((coef, intercept), n_states, X, y)
+
+    def test_wrong_coef_type_raises(self):
+        n_states, n_features = 3, 5
+        X = jnp.ones((10, n_features))
+        y = jnp.ones(10)
+
+        with pytest.raises(TypeError, match="did not return a pytree of arrays"):
+            _validate_custom_glm_params_output(
+                ("not_an_array", jnp.zeros(n_states)), n_states, X, y
+            )
+
+    def test_wrong_intercept_type_raises(self):
+        n_states, n_features = 3, 5
+        X = jnp.ones((10, n_features))
+        y = jnp.ones(10)
+
+        with pytest.raises(TypeError, match="did not return an array"):
+            _validate_custom_glm_params_output(
+                (jnp.zeros((n_features, n_states)), "not_an_array"), n_states, X, y
+            )
+
+    def test_error_message_shows_shapes(self):
+        """Error message includes both actual and expected shapes."""
+        n_states, n_features = 3, 5
+        X = jnp.ones((10, n_features))
+        y = jnp.ones(10)
+        coef = jnp.zeros((n_features + 2, n_states))
+
+        with pytest.raises(ValueError, match="Actual shapes"):
+            _validate_custom_glm_params_output(
+                (coef, jnp.zeros(n_states)), n_states, X, y
+            )
+
+        with pytest.raises(ValueError, match="Expected shapes"):
+            _validate_custom_glm_params_output(
+                (coef, jnp.zeros(n_states)), n_states, X, y
+            )
+
+
+# =============================================================================
+# Tests for _validate_custom_scale_output
+# =============================================================================
+
+
+class TestValidateCustomScaleOutput:
+    """Test _validate_custom_scale_output directly."""
+
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_valid_output(self, n_neurons):
+        n_states = 3
+        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
+        scale = jnp.ones((n_states, n_neurons) if n_neurons > 1 else (n_states,))
+        _validate_custom_scale_output(scale, n_states, y)
+
+    @pytest.mark.parametrize("n_neurons", [1, 3])
+    def test_wrong_shape_raises(self, n_neurons):
+        n_states = 3
+        y = jnp.ones((10, n_neurons)) if n_neurons > 1 else jnp.ones(10)
+        scale = jnp.ones(n_states + 1)
+
+        with pytest.raises(ValueError, match="incorrect shape"):
+            _validate_custom_scale_output(scale, n_states, y)
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(TypeError, match="must return an array"):
+            _validate_custom_scale_output("not_an_array", 3, jnp.ones(10))
+
+    def test_error_message_shows_expected_shape(self):
+        n_states = 3
+        y = jnp.ones(10)
+        scale = jnp.ones(n_states + 2)
+
+        with pytest.raises(ValueError, match=rf"\({n_states},\)"):
+            _validate_custom_scale_output(scale, n_states, y)

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -20,11 +20,47 @@ from nemos.glm_hmm.initialize_parameters import (
     random_glm_params_init,
     setup_glm_hmm_initialization,
 )
+from nemos.glm_hmm.validation import GLMHMMValidator
+from nemos.hmm.hmm import BaseHMM
 from nemos.hmm.initialize_parameters import (
     sticky_transition_proba_init,
     uniform_initial_proba_init,
 )
 from nemos.inverse_link_function_utils import resolve_inverse_link_function
+
+# =============================================================================
+# Minimal GLMHMM mock for key-validation tests (exercises initialization_funcs setter)
+# =============================================================================
+
+
+class MockGLMHMM(BaseHMM):
+    _validator_class = GLMHMMValidator
+    _default_init_dict = DEFAULT_INIT_FUNCTIONS_GLMHMM
+
+    def __init__(self, n_states, initialization_funcs=None):
+        BaseHMM.__init__(self, n_states=n_states, initialization_funcs=initialization_funcs)
+        self.coef_ = self.intercept_ = self.scale_ = None
+
+    def setup(self, **kwargs):
+        self._initialization_funcs = setup_glm_hmm_initialization(
+            init_funcs=self._initialization_funcs,
+        )
+
+    def _check_model_is_fit(self): pass
+    def _get_model_params(self): pass
+    def _set_model_params(self, params): pass
+    def _log_likelihood(self, params, X, y): pass
+    def _model_params_initialization(self, X, y, is_new_session, random_key=None): pass
+    def fit(self, *a, **kw): pass
+    def _initialize_optimizer_and_state(self, *a, **kw): pass
+    def _compute_loss(self, *a, **kw): pass
+    def _get_optimal_solver_params_config(self, *a, **kw): pass
+    def predict(self, *a, **kw): pass
+    def simulate(self, *a, **kw): pass
+    def save_params(self, *a, **kw): pass
+    def update(self, *a, **kw): pass
+    def score(self, *a, **kw): pass
+
 
 # =============================================================================
 # Mock infrastructure
@@ -491,7 +527,7 @@ class TestSetupGLMHMMInitialization:
 
     def test_unknown_init_funcs_key(self):
         with pytest.raises(KeyError, match="Unexpected or unknown keys"):
-            setup_glm_hmm_initialization(init_funcs={"totally_invalid_key": None})
+            MockGLMHMM(n_states=2, initialization_funcs={"totally_invalid_key": None})
 
     @pytest.mark.parametrize(
         "key, init_str, kwargs_key, kwargs_val",
@@ -588,8 +624,8 @@ class TestGenerateGLMHMMInitialParams:
         X = jnp.ones((50, n_features))
         y = jnp.ones((50, n_neurons)) if n_neurons > 1 else jnp.ones(50)
 
-        coef, intercept, scale, initial_probs, transition_matrix = (
-            generate_glm_hmm_initial_model_params(n_states, X, y, jnp.exp)
+        coef, intercept, scale = generate_glm_hmm_initial_model_params(
+            n_states, X, y, jnp.exp
         )
 
         if n_neurons == 1:
@@ -601,28 +637,21 @@ class TestGenerateGLMHMMInitialParams:
             assert intercept.shape == (n_neurons, n_states)
             assert scale.shape == (n_neurons, n_states)
 
-        assert initial_probs.shape == (n_states,)
-        assert transition_matrix.shape == (n_states, n_states)
-
-        for arr in [coef, intercept, scale, initial_probs, transition_matrix]:
+        for arr in [coef, intercept, scale]:
             assert isinstance(arr, jnp.ndarray)
 
-    def test_returns_five_elements(self):
+    def test_returns_three_elements(self):
         result = generate_glm_hmm_initial_model_params(
             2, jnp.ones((10, 3)), jnp.ones(10), lambda x: x
         )
         assert isinstance(result, tuple)
-        assert len(result) == 5
+        assert len(result) == 3
 
     @pytest.mark.parametrize(
         "init_funcs, expectation",
         [
             ({}, does_not_raise()),
             ({"glm_params_init": random_glm_params_init}, does_not_raise()),
-            (
-                {"totally_invalid_key": None},
-                pytest.raises(KeyError, match="Unexpected or unknown keys"),
-            ),
         ],
     )
     def test_init_funcs_key_validation(self, init_funcs, expectation):
@@ -635,17 +664,19 @@ class TestGenerateGLMHMMInitialParams:
                 init_funcs=init_funcs,
             )
 
+    def test_init_funcs_unknown_key_raises(self):
+        with pytest.raises(KeyError, match="Unexpected or unknown keys"):
+            MockGLMHMM(n_states=2, initialization_funcs={"totally_invalid_key": None})
+
     def test_none_init_funcs_uses_defaults(self):
         X = jnp.ones((50, 5))
         y = jnp.full(50, 2.0)
-        coef, intercept, scale, initial_probs, transition_matrix = (
-            generate_glm_hmm_initial_model_params(3, X, y, lambda x: x)
+        coef, intercept, scale = generate_glm_hmm_initial_model_params(
+            3, X, y, lambda x: x
         )
         assert jnp.abs(coef).max() < 0.01
         assert jnp.allclose(intercept, 2.0)
         assert jnp.all(scale == 1.0)
-        assert jnp.allclose(initial_probs, 1.0 / 3)
-        assert jnp.allclose(jnp.diag(transition_matrix), 0.95)
 
     def test_random_key_affects_output(self):
         """Different random keys produce different GLM coefficient initializations."""

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -1,6 +1,5 @@
 """Tests for glm_hmm/initialize_parameters.py"""
 
-import itertools
 from contextlib import nullcontext as does_not_raise
 from unittest.mock import create_autospec
 
@@ -729,7 +728,7 @@ class TestGenerateGLMHMMInitialParams:
                     jnp.zeros(n_states),
                 ),
                 "glm_params_init_custom",
-                pytest.raises(ValueError, match="tree structure"),
+                pytest.raises(TypeError, match="tree structure"),
                 {"feature_a": jnp.ones((10, 3))},
             ),
         ],
@@ -788,7 +787,9 @@ class TestValidateCustomGLMParamsOutput:
 
         init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(ValueError, match="mis-shaped"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
     @pytest.mark.parametrize("n_neurons", [1, 3])
     def test_wrong_intercept_shape_raises(self, n_neurons):
@@ -807,7 +808,9 @@ class TestValidateCustomGLMParamsOutput:
 
         init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(ValueError, match="incorrect shape"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
     def test_wrong_coef_type_raises(self):
         n_states, n_features = 3, 5
@@ -819,7 +822,9 @@ class TestValidateCustomGLMParamsOutput:
 
         init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(TypeError, match="did not return a pytree of arrays"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
     def test_wrong_intercept_type_raises(self):
         n_states, n_features = 3, 5
@@ -831,7 +836,9 @@ class TestValidateCustomGLMParamsOutput:
 
         init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(TypeError, match="did not return an array"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
     def test_error_message_shows_shapes(self):
         """Error message includes both actual and expected shapes."""
@@ -845,10 +852,14 @@ class TestValidateCustomGLMParamsOutput:
 
         init_funcs = setup_glm_hmm_initialization(glm_params_init=custom_init)
         with pytest.raises(ValueError, match="Actual shapes"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
         with pytest.raises(ValueError, match="Expected shapes"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
 
 # =============================================================================
@@ -884,7 +895,9 @@ class TestValidateCustomScaleOutput:
 
         init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
         with pytest.raises(ValueError, match="incorrect shape"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
     def test_wrong_type_raises(self):
         n_states = 3
@@ -896,7 +909,9 @@ class TestValidateCustomScaleOutput:
 
         init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
         with pytest.raises(TypeError, match="must return an array"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )
 
     def test_error_message_shows_expected_shape(self):
         n_states = 3
@@ -909,4 +924,6 @@ class TestValidateCustomScaleOutput:
 
         init_funcs = setup_glm_hmm_initialization(scale_init=custom_scale)
         with pytest.raises(ValueError, match=rf"\({n_states},\)"):
-            generate_glm_hmm_initial_params(n_states, X, y, jnp.exp, init_funcs=init_funcs)
+            generate_glm_hmm_initial_params(
+                n_states, X, y, jnp.exp, init_funcs=init_funcs
+            )

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -483,7 +483,7 @@ class TestSetupGLMHMMInitialization:
             ("kmeans", does_not_raise(), kmeans_glm_params_init),
             (None, does_not_raise(), DEFAULT_INIT_FUNCTIONS_GLMHMM["glm_params_init"]),
             (
-                "invalid",
+                "sticky",
                 pytest.raises(ValueError, match="Invalid initialization"),
                 None,
             ),
@@ -506,7 +506,7 @@ class TestSetupGLMHMMInitialization:
             ("kmeans", does_not_raise(), kmeans_scale_init),
             (None, does_not_raise(), DEFAULT_INIT_FUNCTIONS_GLMHMM["scale_init"]),
             (
-                "invalid",
+                "sticky",
                 pytest.raises(ValueError, match="Invalid initialization"),
                 None,
             ),
@@ -581,7 +581,7 @@ class TestSetupGLMHMMInitialization:
     def test_unknown_init_funcs_key(self):
         with pytest.raises(KeyError, match="Unexpected or unknown keys"):
             MockGLMHMM(
-                n_states=2, model_initialization_funcs={"totally_invalid_key": None}
+                n_states=2, model_initialization_funcs={"initial_proba_init": None}
             )
 
     @pytest.mark.parametrize(
@@ -724,7 +724,7 @@ class TestGenerateGLMHMMInitialParams:
     def test_init_funcs_unknown_key_raises(self):
         with pytest.raises(KeyError, match="Unexpected or unknown keys"):
             MockGLMHMM(
-                n_states=2, model_initialization_funcs={"totally_invalid_key": None}
+                n_states=2, model_initialization_funcs={"transition_proba_init": None}
             )
 
     def test_none_init_funcs_uses_defaults(self):

--- a/tests/test_glm_hmm_initialization.py
+++ b/tests/test_glm_hmm_initialization.py
@@ -394,45 +394,65 @@ class TestConstantScaleInitialization:
 
 
 @pytest.fixture
-def kmeans_mock(monkeypatch):
+def kmeans_mock(monkeypatch, request):
     """Patch GLM.fit to avoid slow JAX optimization. Uses small data so sklearn KMeans is fast."""
     n_states = 3
     n_samples = 30
     n_features = 4
+    n_neurons = getattr(request, "param", 1)
 
     rng = np.random.default_rng(0)
     X = rng.standard_normal((n_samples, n_features))
-    y = np.ones(n_samples)
+    if n_neurons == 1:
+        y = np.ones(n_samples)
 
-    def fake_glm_fit(self, X, y, **kwargs):
-        n_feat = X.shape[1]
-        self.coef_ = jnp.zeros(n_feat)
-        self.intercept_ = jnp.array([0.0])
+        def fake_glm_fit(self, X, y, **kwargs):
+            n_feat = X.shape[1]
+            self.coef_ = jnp.zeros(n_feat)
+            self.intercept_ = jnp.array([0.0])
+
+        expected_scale_shape = (n_states,)
+
+    else:
+        y = np.ones((n_samples, n_neurons))
+
+        def fake_glm_fit(self, X, y, **kwargs):
+            n_feat = X.shape[1]
+            self.coef_ = jnp.zeros((n_feat, n_neurons))
+            self.intercept_ = jnp.array([0.0] * n_neurons)
+
+        expected_scale_shape = (n_neurons, n_states)
 
     monkeypatch.setattr(GLM, "fit", fake_glm_fit)
-    return n_states, X, y, n_features
+    return n_states, X, y, n_features, expected_scale_shape
 
 
 class TestKMeansInitializerGLM:
     """Test KMeans-based GLM parameter initialization."""
 
     def test_glm_params_output_shape(self, kmeans_mock):
-        n_states, X, y, n_features = kmeans_mock
+        n_states, X, y, n_features, _ = kmeans_mock
         initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=0)
         coef, intercept = initializer.glm_params()
         assert coef.shape == (n_features, n_states)
         assert intercept.shape == (n_states,)
 
+    @pytest.mark.parametrize(
+        "kmeans_mock",
+        [1, 5],
+        indirect=True,
+        ids=["n_neurons=1", "n_neurons=5"],
+    )
     def test_scale_output_shape(self, kmeans_mock):
         """Poisson GLM has fixed scale=1, so scale() returns ones without fitting."""
-        n_states, X, y, _ = kmeans_mock
+        n_states, X, y, _, expected_shape = kmeans_mock
         initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=0)
         scale = initializer.scale()
-        assert scale.shape == (n_states,)
+        assert scale.shape == expected_shape
 
     def test_shared_initializer(self, kmeans_mock):
         """Providing a pre-built initializer skips creating a new one."""
-        n_states, X, y, _ = kmeans_mock
+        n_states, X, y, _, _ = kmeans_mock
         initializer = KMeansInitializerGLM(n_states, X, y, jnp.exp, random_key=7)
         result = kmeans_glm_params_init(
             n_states, X, y, jnp.exp, initializer=initializer

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -1,12 +1,14 @@
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Tuple, Union
+from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pynapple as nap
 import pytest
+import sklearn.cluster
 
 from nemos.base_validator import RegressorValidator
 from nemos.hmm.hmm import BaseHMM
@@ -758,17 +760,31 @@ class TestHMMInitialParams:
             transition_proba_init="kmeans",
             param_init="kmeans",
         )
-        model._model_specific_initialization(jnp.zeros((10, 10)), jnp.zeros(10), None)
-        assert id(
-            model.hmm_initialization_funcs["initial_proba_init_kwargs"]["initializer"]
-        ) == id(
-            model.hmm_initialization_funcs["transition_proba_init_kwargs"][
-                "initializer"
-            ]
-        )
-        assert id(
-            model.hmm_initialization_funcs["initial_proba_init_kwargs"]["initializer"]
-        ) == id(model.model_initialization_funcs["param_init_kwargs"]["initializer"])
+        original_fit = sklearn.cluster.KMeans.fit
+        # use mock fit to assert that kmeans is only called once at initializer construction
+        with patch.object(
+            sklearn.cluster.KMeans, "fit", autospec=True, side_effect=original_fit
+        ) as mock_fit:
+            model._model_specific_initialization(
+                jnp.zeros((10, 10)), jnp.zeros(10), None
+            )
+            assert id(
+                model.hmm_initialization_funcs["initial_proba_init_kwargs"][
+                    "initializer"
+                ]
+            ) == id(
+                model.hmm_initialization_funcs["transition_proba_init_kwargs"][
+                    "initializer"
+                ]
+            )
+            assert id(
+                model.hmm_initialization_funcs["initial_proba_init_kwargs"][
+                    "initializer"
+                ]
+            ) == id(
+                model.model_initialization_funcs["param_init_kwargs"]["initializer"]
+            )
+            assert mock_fit.call_count == 1
 
     @pytest.mark.parametrize(
         "key, value, expectation",

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -78,6 +78,11 @@ class MockHMMValidator(HMMValidator[MockHMMUserParams, MockHMMParams]):
 
 class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams, INITIALIZATION_FN_DICT]):
     _validator_class = MockHMMValidator
+    _model_default_init_dict = {
+        "param_init": None,
+        "param_init_kwargs": {},
+        "param_init_custom": False,
+    }
 
     def __init__(
         self,
@@ -89,7 +94,7 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams, INITIALIZATION_FN_DICT])
         maxiter: int = 1000,
         tol: float = 1e-8,
         seed=jax.random.PRNGKey(123),
-        initialization_funcs: INITIALIZATION_FN_DICT = None,
+        hmm_initialization_funcs: INITIALIZATION_FN_DICT = None,
         model_initialization_funcs: INITIALIZATION_FN_DICT = None,
     ):
         BaseHMM.__init__(
@@ -100,27 +105,17 @@ class MockHMM(BaseHMM[MockHMMParams, MockHMMUserParams, INITIALIZATION_FN_DICT])
             maxiter=maxiter,
             tol=tol,
             seed=seed,
-            initialization_funcs=initialization_funcs,
+            hmm_initialization_funcs=hmm_initialization_funcs,
         )
         self.param_: jnp.ndarray | None = None
-        self.model_initialization_funcs = {}
+        self.model_initialization_funcs = model_initialization_funcs
 
-    def setup(
+    def _model_setup(
         self,
-        initial_proba_init: Optional[str | Callable] = None,
-        initial_proba_init_kwargs: Optional[dict] = None,
-        transition_proba_init: Optional[str | Callable] = None,
-        transition_proba_init_kwargs: Optional[dict] = None,
         param_init: Optional[str | Callable] = None,
         param_init_kwargs: Optional[dict] = None,
     ):
-        BaseHMM.setup(
-            self,
-            initial_proba_init=initial_proba_init,
-            initial_proba_init_kwargs=initial_proba_init_kwargs,
-            transition_proba_init=transition_proba_init,
-            transition_proba_init_kwargs=transition_proba_init_kwargs,
-        )
+        self._model_use_kmeans = {"param_init": param_init == "kmeans"}
 
     def _check_model_is_fit(self):
         if self.param_ is None:
@@ -362,7 +357,7 @@ class TestHMMInit:
     def test_initialization_funcs_none_uses_defaults(self):
         """Test that no setting uses default initialization functions."""
         model = MockHMM(n_states=2)
-        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
 
     def test_initialization_funcs_modified(self):
         """Test that modified initialization funcs are preserved."""
@@ -374,8 +369,8 @@ class TestHMMInit:
             "initial_proba_init": custom_func,
             "initial_proba_init_kwargs": {"extra_arg": "value"},
         }
-        model = MockHMM(n_states=2, initialization_funcs=init_funcs)
-        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS | init_funcs
+        model = MockHMM(n_states=2, hmm_initialization_funcs=init_funcs)
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS | init_funcs
 
     @pytest.mark.parametrize(
         "init_funcs, expectation",
@@ -393,7 +388,7 @@ class TestHMMInit:
     def test_initialization_funcs_invalid_key_via_init(self, init_funcs, expectation):
         """Test that invalid/misspelled keys raise KeyError when passed via constructor."""
         with expectation:
-            MockHMM(n_states=2, initialization_funcs=init_funcs)
+            MockHMM(n_states=2, hmm_initialization_funcs=init_funcs)
 
     @pytest.mark.parametrize(
         "init_funcs, expectation",
@@ -412,7 +407,7 @@ class TestHMMInit:
         """Test that invalid/misspelled keys raise KeyError when assigned via setter."""
         model = MockHMM(n_states=2)
         with expectation:
-            model.initialization_funcs = init_funcs
+            model.hmm_initialization_funcs = init_funcs
 
     # -------------------------------------------------------------------------
     # Default values tests
@@ -440,9 +435,9 @@ class TestHMMSetup:
     def test_setup_with_no_input(self):
         """Test that setup leaves everything as default."""
         model = MockHMM(n_states=3)
-        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
         model.setup()
-        assert model.initialization_funcs == DEFAULT_INIT_FUNCTIONS
+        assert model.hmm_initialization_funcs == DEFAULT_INIT_FUNCTIONS
 
     @pytest.mark.parametrize(
         "func_name, func, kwargs, expectation",
@@ -493,19 +488,26 @@ class TestHMMSetup:
         with expectation:
             if func_name == "custom":
                 model.setup(initial_proba_init=func, initial_proba_init_kwargs=kwargs)
-                assert model.initialization_funcs["initial_proba_init_custom"] is True
+                assert (
+                    model.hmm_initialization_funcs["initial_proba_init_custom"] is True
+                )
             else:
                 model.setup(
                     initial_proba_init=func_name, initial_proba_init_kwargs=kwargs
                 )
-                assert model.initialization_funcs["initial_proba_init_custom"] is False
+                assert (
+                    model.hmm_initialization_funcs["initial_proba_init_custom"] is False
+                )
 
-            assert model.initialization_funcs["initial_proba_init"] == func
+            assert model.hmm_initialization_funcs["initial_proba_init"] == func
 
             if kwargs is None:
-                assert model.initialization_funcs["initial_proba_init_kwargs"] == {}
+                assert model.hmm_initialization_funcs["initial_proba_init_kwargs"] == {}
             else:
-                assert model.initialization_funcs["initial_proba_init_kwargs"] == kwargs
+                assert (
+                    model.hmm_initialization_funcs["initial_proba_init_kwargs"]
+                    == kwargs
+                )
 
     @pytest.mark.parametrize(
         "func_name, func, kwargs, expectation",
@@ -560,23 +562,28 @@ class TestHMMSetup:
                     transition_proba_init=func, transition_proba_init_kwargs=kwargs
                 )
                 assert (
-                    model.initialization_funcs["transition_proba_init_custom"] is True
+                    model.hmm_initialization_funcs["transition_proba_init_custom"]
+                    is True
                 )
             else:
                 model.setup(
                     transition_proba_init=func_name, transition_proba_init_kwargs=kwargs
                 )
                 assert (
-                    model.initialization_funcs["transition_proba_init_custom"] is False
+                    model.hmm_initialization_funcs["transition_proba_init_custom"]
+                    is False
                 )
 
-            assert model.initialization_funcs["transition_proba_init"] == func
+            assert model.hmm_initialization_funcs["transition_proba_init"] == func
 
             if kwargs is None:
-                assert model.initialization_funcs["transition_proba_init_kwargs"] == {}
+                assert (
+                    model.hmm_initialization_funcs["transition_proba_init_kwargs"] == {}
+                )
             else:
                 assert (
-                    model.initialization_funcs["transition_proba_init_kwargs"] == kwargs
+                    model.hmm_initialization_funcs["transition_proba_init_kwargs"]
+                    == kwargs
                 )
 
     def test_setup_set_all(self):
@@ -596,7 +603,7 @@ class TestHMMSetup:
         )
         expected_funcs = DEFAULT_INIT_FUNCTIONS | init_funcs
         assert all(
-            model.initialization_funcs[key] == expected_funcs[key]
+            model.hmm_initialization_funcs[key] == expected_funcs[key]
             for key in expected_funcs
         )
 
@@ -612,12 +619,12 @@ class TestHMMSetup:
         model.setup(initial_proba_init="kmeans")
         # updated
         assert (
-            model.initialization_funcs["initial_proba_init"]
+            model.hmm_initialization_funcs["initial_proba_init"]
             == init_funcs["initial_proba_init"]
         )
         # default
         assert all(
-            model.initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
+            model.hmm_initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
             for key in [
                 "initial_proba_init_kwargs",
                 "transition_proba_init",
@@ -628,7 +635,7 @@ class TestHMMSetup:
         model.setup(initial_proba_init_kwargs={"minimum_prob": 0.01})
         # updated
         assert all(
-            model.initialization_funcs[key] == init_funcs[key]
+            model.hmm_initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
                 "initial_proba_init_kwargs",
@@ -636,7 +643,7 @@ class TestHMMSetup:
         )
         # default
         assert all(
-            model.initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
+            model.hmm_initialization_funcs[key] == DEFAULT_INIT_FUNCTIONS[key]
             for key in [
                 "transition_proba_init",
                 "transition_proba_init_kwargs",
@@ -646,7 +653,7 @@ class TestHMMSetup:
         model.setup(transition_proba_init="kmeans")
         # updated
         assert all(
-            model.initialization_funcs[key] == init_funcs[key]
+            model.hmm_initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
                 "initial_proba_init_kwargs",
@@ -655,14 +662,14 @@ class TestHMMSetup:
         )
         # default
         assert (
-            model.initialization_funcs["transition_proba_init_kwargs"]
+            model.hmm_initialization_funcs["transition_proba_init_kwargs"]
             == DEFAULT_INIT_FUNCTIONS["transition_proba_init_kwargs"]
         )
 
         model.setup(transition_proba_init_kwargs={"minimum_prob": 0.01})
         # updated
         assert all(
-            model.initialization_funcs[key] == init_funcs[key]
+            model.hmm_initialization_funcs[key] == init_funcs[key]
             for key in [
                 "initial_proba_init",
                 "initial_proba_init_kwargs",
@@ -676,9 +683,9 @@ class TestHMMSetup:
         """Test that kwargs are reset if method is set to something else."""
         model = MockHMM(n_states=3)
         model.setup(**{key: "kmeans", key + "_kwargs": {"minimum_prob": 0.01}})
-        assert model.initialization_funcs[key + "_kwargs"] == {"minimum_prob": 0.01}
+        assert model.hmm_initialization_funcs[key + "_kwargs"] == {"minimum_prob": 0.01}
         model.setup(**{key: "random"})
-        assert model.initialization_funcs[key + "_kwargs"] == {}
+        assert model.hmm_initialization_funcs[key + "_kwargs"] == {}
 
 
 class TestHMMInitialParams:
@@ -742,6 +749,26 @@ class TestHMMInitialParams:
             model_params.hmm_params.log_transition_prob,
             jnp.log(DEFAULT_INIT_FUNCTIONS["transition_proba_init"](3)),
         )
+
+    def test__kmeans_setup_initializer(self):
+        """Verify setter is stored and is the same for hmm and model params."""
+        model = MockHMM(n_states=3)
+        model.setup(
+            initial_proba_init="kmeans",
+            transition_proba_init="kmeans",
+            param_init="kmeans",
+        )
+        model._model_specific_initialization(jnp.zeros((10, 10)), jnp.zeros(10), None)
+        assert id(
+            model.hmm_initialization_funcs["initial_proba_init_kwargs"]["initializer"]
+        ) == id(
+            model.hmm_initialization_funcs["transition_proba_init_kwargs"][
+                "initializer"
+            ]
+        )
+        assert id(
+            model.hmm_initialization_funcs["initial_proba_init_kwargs"]["initializer"]
+        ) == id(model.model_initialization_funcs["param_init_kwargs"]["initializer"])
 
     @pytest.mark.parametrize(
         "key, value, expectation",

--- a/tests/test_hmm_base_class.py
+++ b/tests/test_hmm_base_class.py
@@ -786,6 +786,17 @@ class TestHMMInitialParams:
             )
             assert mock_fit.call_count == 1
 
+    def test_kmeans_inconsistent_kwargs_raises(self):
+        """_kmeans_resolve_model_kwargs raises when the same kwarg has conflicting values."""
+        model = MockHMM(n_states=3)
+        use_kmeans = {"param_a": True, "param_b": True}
+        init_funcs = {
+            "param_a_kwargs": {"minimum_prob": 0.01},
+            "param_b_kwargs": {"minimum_prob": 0.05},
+        }
+        with pytest.raises(ValueError, match="Inconsistent KMeans init arg"):
+            model._kmeans_resolve_model_kwargs(use_kmeans, init_funcs)
+
     @pytest.mark.parametrize(
         "key, value, expectation",
         [

--- a/tests/test_hmm_initialization.py
+++ b/tests/test_hmm_initialization.py
@@ -1,11 +1,13 @@
 """Tests for hmm/initialize_parameters.py"""
 
 from contextlib import nullcontext as does_not_raise
+from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import sklearn.cluster
 from sklearn.datasets import make_blobs
 
 from nemos.hmm.initialize_parameters import (
@@ -370,23 +372,34 @@ class TestKMeansInitialization:
         n_states = 5
         X, _, y, _, is_new_session, _, _ = generate_kmeans_data(n_states)
         default_initializer = KMeansInitializer(n_states, X, y, is_new_session)
-        used_initializer = KMeansInitializer(
-            n_states, X, y, is_new_session, random_key=jax.random.PRNGKey(2)
-        )
-        # initial probability
-        init_prob = kmeans_initial_proba_init(
-            n_states, X, y, is_new_session, initializer=used_initializer
-        )
-        assert not jnp.allclose(init_prob, default_initializer.initial_probability())
-        assert jnp.allclose(init_prob, used_initializer.initial_probability())
-        # transition probability
-        transition_prob = kmeans_transition_proba_init(
-            n_states, X, y, is_new_session, initializer=used_initializer
-        )
-        assert not jnp.allclose(
-            transition_prob, default_initializer.transition_probability()
-        )
-        assert jnp.allclose(transition_prob, used_initializer.transition_probability())
+
+        original_fit = sklearn.cluster.KMeans.fit
+        # use mock fit to assert that kmeans is only called once at initializer construction
+        with patch.object(
+            sklearn.cluster.KMeans, "fit", autospec=True, side_effect=original_fit
+        ) as mock_fit:
+            used_initializer = KMeansInitializer(
+                n_states, X, y, is_new_session, random_key=jax.random.PRNGKey(2)
+            )
+            # initial probability
+            init_prob = kmeans_initial_proba_init(
+                n_states, X, y, is_new_session, initializer=used_initializer
+            )
+            assert not jnp.allclose(
+                init_prob, default_initializer.initial_probability()
+            )
+            assert jnp.allclose(init_prob, used_initializer.initial_probability())
+            # transition probability
+            transition_prob = kmeans_transition_proba_init(
+                n_states, X, y, is_new_session, initializer=used_initializer
+            )
+            assert not jnp.allclose(
+                transition_prob, default_initializer.transition_probability()
+            )
+            assert jnp.allclose(
+                transition_prob, used_initializer.transition_probability()
+            )
+            assert mock_fit.call_count == 1
 
 
 class TestSetupHMMInitialization:


### PR DESCRIPTION
## Summary

Adds the GLM-HMM parameter initialization layer (`glm_hmm/initialize_parameters.py`), modeled after the HMM initialization design in the base PR. Provides GLM-specific initialization for coefficients, intercept, and scale; extends `KMeansInitializer` with a GLM-aware subclass; wires up a unified `setup_glm_hmm_initialization` / `generate_glm_hmm_initial_params` API; ships accompanying validation and tests. Several HMM-base-class utilities were extended to support GLM-specific protocols and key sets.

## Motivation

The HMM initialization infrastructure (base PR) provides `setup_hmm_initialization` and `generate_hmm_initial_params` for initial/transition probabilities, but GLM-HMM also needs per-state GLM parameters (coef, intercept) and scale. Reusing as much of the HMM machinery as possible (key registry, kwargs validation, KMeans initializer) avoids duplicating logic and keeps the two layers consistent.

## Description of the Changes and Rationale

### New file: `src/nemos/glm_hmm/initialize_parameters.py`

| Component | Description |
|---|---|
| `InitFunctionGLM` | Protocol for GLM init functions; extends `InitFunctionHMM` signature with `inverse_link_function` (4th arg, required) and `is_new_session` (5th arg, optional). |
| `random_glm_params_init` | Random small coefficients + intercept matching the mean firing rate. Decorated with `@cast_to_jax(dtype=None)` to preserve integer PRNG keys. |
| `KMeansInitializerGLM` | Inherits `KMeansInitializer`; adds `glm_params()` (fits per-state GLM after KMeans assignment) and `scale()` (extracts fitted scale, short-circuiting for fixed-scale observation models via `has_fixed_scale`). Supports pytree `X` and population `y`. |
| `kmeans_glm_params_init` | Instantiates `KMeansInitializerGLM` if no `initializer` is supplied, then returns `glm_params()`. |
| `kmeans_scale_init` | Same pattern for scale, reusing the same `KMeansInitializerGLM` instance when the caller supplies one. |
| `constant_scale_init` | Fills scale to a user-specified constant (default 1.0). Default scale initializer. |
| `GLM_INIT_FUNCS` | Registry dict (keys: `glm_params_init`, `scale_init`, plus `_kwargs` and `_custom` flags) mirroring the HMM dict layout. |
| `AVAIL_INIT_FUNCTIONS_GLM` | Available string aliases: `"random"`, `"kmeans"` for params; `"constant"`, `"kmeans"` for scale. |
| `_validate_custom_glm_init_func` | Validates a custom callable against `InitFunctionGLM`. Required because `_validate_custom_init_func` in the HMM module is hardcoded to `InitFunctionHMM`, which lacks `inverse_link_function`. |
| `_glm_resolve_init_funcs` | Dispatches to `_validate_custom_glm_init_func` for callables; passes `protocol=InitFunctionGLM` to `_validate_init_funcs_kwargs` for string lookups. Mirrors `_resolve_init_funcs` but for GLM keys. |
| `setup_glm_hmm_initialization` | Validates and stores GLM-specific init functions, delegating HMM-probability setup to `setup_hmm_initialization`. |
| `generate_glm_hmm_initial_params` | Splits the random key into three independent subkeys (GLM params, scale, HMM probs) and calls each init function in sequence. Returns `(coef, intercept, scale, initial_probs, transition_matrix)`. |

### Changes to `src/nemos/hmm/initialize_parameters.py`

- `_validate_init_funcs_keys`: accepts optional `default_init_dict` so the GLM-HMM layer can validate its own key set without coupling to `DEFAULT_INIT_FUNCTIONS`.
- `_resolve_init_funcs`: accepts `available_init_funcs` for the same reason.
- `_validate_init_funcs_kwargs`: accepts a `protocol` argument so GLM init functions are validated against `InitFunctionGLM` rather than `InitFunctionHMM`.
- `generate_hmm_initial_params`: return type annotated as `HMMUserParams`; random key split changed from 2 to 1 (see Open Question 1); added `_validate_custom_init_output` call for custom `transition_proba_init` functions.
- `InitFunctionHMM`: `random_key` annotation changed from `jax.random.PRNGKey` to `jax.Array`.

### Changes to `src/nemos/hmm/hmm.py`

`_hmm_params_initialization` updated to unpack the return of `generate_hmm_initial_params` as `hmm_params, _` (see Open Question 2).

### Changes to `src/nemos/glm_hmm/algorithm_configs.py`

Extracted `has_fixed_scale(observation_model)` helper; replaced the two inline `type(observation_model) in _NO_SCALE` checks with calls to it. Used in `KMeansInitializerGLM.scale()` to short-circuit fitting for fixed-scale observation models.

### Changes to `src/nemos/type_casting.py`

`cast_to_jax` extended to a decorator factory: `@cast_to_jax` (plain, `dtype=float`) and `@cast_to_jax(dtype=None)` (keep original dtypes). The `dtype=None` form is needed by `random_glm_params_init` and `constant_scale_init` so that integer PRNG keys are not promoted to float.

### Changes to `src/nemos/validation.py`

`_suggest_keys` type hint widened from `List[str]` to `Collection[str]` to accept dict key views.

### Changes to `scripts/check_parameter_naming.py`

Added valid name pairs introduced by this module: `glm_params_init`/`glm_params_init_kwargs`, `scale_init_kwargs`/`solver_init_kwargs`, and `_func`/`func`/`funcs`.

### New test file: `tests/test_glm_hmm_initialization.py`

Covers:
- `random_glm_params_init`: output shapes (single/population, varying states), output types, randomization across seeds, `std_dev` parameter, intercept-to-mean-rate correctness.
- `KMeansInitializerGLM` and `kmeans_glm_params_init`/`kmeans_scale_init`: shape correctness, reuse of a shared `initializer`, fixed-scale short-circuit.
- `setup_glm_hmm_initialization` and `generate_glm_hmm_initial_params`: valid/invalid key detection, reserved-param rejection, custom function validation (signature check against `InitFunctionGLM`), all four init-function slots (individually, in pairs, all at once, mixed).
- Mock templates use `create_autospec` with 6 mandatory params for GLM functions (`n_states, X, y, inverse_link_function, is_new_session, random_key`) and 5 for HMM functions. Parametrized at class level over function name.

## Open Questions for the Reviewers

- **`_validate_custom_glm_init_func` / `_glm_resolve_init_funcs` duplication**: These are local GLM-side copies of `_validate_custom_init_func` / `_resolve_init_funcs` from the HMM module, with `InitFunctionGLM` substituted. The cleaner alternative would be to make the originals accept `protocol` and `available_init_funcs` arguments (as `_validate_init_funcs_kwargs` and `_resolve_init_funcs` already do in part) and call them directly. Worth unifying?


