### PR TITLE
Mask fix

### DIFF
--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -27,7 +27,6 @@ from . import solvers, tree_utils, utils
 from ._regularizer_builder import AVAILABLE_REGULARIZERS, instantiate_regularizer
 from .base_class import Base
 from .base_validator import RegressorValidator
-from .glm.params import GLMParams
 from .pytrees import FeaturePytree
 from .regularizer import GroupLasso, Regularizer
 from .solvers import SolverProtocol, SolverSpec
@@ -640,10 +639,36 @@ class BaseRegressor(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParamsT]):
                     "Mask has not been set. Defaulting to a single group for all parameters. "
                     "Please see the documentation on GroupLasso regularization for defining a mask."
                 )
+            elif self.regularizer.mask is not None:
+                import equinox as eqx
 
-            if isinstance(self.regularizer.mask, jnp.ndarray):
-                # Wrap into a GLM param structure.
-                self.regularizer.mask = GLMParams(self.regularizer.mask, None)
+                model_pars = self._validator.get_empty_params(data, y)
+                # Skip if mask is already in the internal structured format.
+                if not isinstance(self.regularizer.mask, type(model_pars)):
+                    select_subtrees = (
+                        model_pars.regularizable_subtrees()
+                        if hasattr(model_pars, "regularizable_subtrees")
+                        else [lambda p: p]
+                    )
+                    if len(select_subtrees) == 1:
+                        # Single regularizable param: mask matches its pytree structure (e.g. coef_).
+                        mask_list = [self.regularizer.mask]
+                    else:
+                        mask_list = list(self.regularizer.mask)
+                        if len(mask_list) != len(select_subtrees):
+                            raise ValueError(
+                                f"{type(self).__name__} has {len(select_subtrees)} regularizable "
+                                f"parameters but {len(mask_list)} masks were provided."
+                            )
+                    struct = jax.tree_util.tree_structure(model_pars)
+                    mask_tree = jax.tree_util.tree_unflatten(
+                        struct, [None] * struct.num_leaves
+                    )
+                    for where, m in zip(select_subtrees, mask_list):
+                        mask_tree = eqx.tree_at(
+                            where, mask_tree, m, is_leaf=lambda x: x is None
+                        )
+                    self.regularizer.mask = mask_tree
 
         return data, y, *args
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,7 @@ def mock_glm_fit(monkeypatch):
         else:
             self.coef_ = jnp.zeros((n_features, y_arr.shape[1]))
             self.intercept_ = jnp.zeros(y_arr.shape[1])
+        self.scale_ = jnp.ones_like(self.intercept_)
         return self
 
     monkeypatch.setattr(nmo.glm.GLM, "fit", _fit)

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2425,16 +2425,16 @@ def _make_valid_group_mask(n_groups, n_features):
             id="list_mask-list_X",
         ),
         pytest.param(
-                lambda arr, _: nmo.glm.params.GLMParams(
-                    coef=jnp.asarray(arr), intercept=None
-                ),
-                lambda X: X,
-                # already-structured GLMParams: coef slot is unchanged, same 2-D array
-                lambda coef, n_groups, n_features: (
-                    hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
-                ),
-                id="already_structured_glmparams_mask",
+            lambda arr, _: nmo.glm.params.GLMParams(
+                coef=jnp.asarray(arr), intercept=None
             ),
+            lambda X: X,
+            # already-structured GLMParams: coef slot is unchanged, same 2-D array
+            lambda coef, n_groups, n_features: (
+                hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
+            ),
+            id="already_structured_glmparams_mask",
+        ),
     ],
 )
 def test_grouplasso_mask_wrapping_and_refit(
@@ -2464,9 +2464,9 @@ def test_grouplasso_mask_wrapping_and_refit(
     model.fit(X, y)
 
     # After first fit, mask must be wrapped into the internal GLMParams structure.
-    assert isinstance(model.regularizer.mask, nmo.glm.params.GLMParams), (
-        "mask must be a GLMParams pytree after fit"
-    )
+    assert isinstance(
+        model.regularizer.mask, nmo.glm.params.GLMParams
+    ), "mask must be a GLMParams pytree after fit"
     assert model.regularizer.mask.intercept is None
     assert check_coef(model.regularizer.mask.coef, n_groups, n_features)
     mask_coef_after_first = model.regularizer.mask.coef

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2390,6 +2390,98 @@ def test_grouplasso_fit_twice_different_pytree_structure():
     model.fit(X_dict, y)
 
 
+def _make_valid_group_mask(n_groups, n_features):
+    """Binary group mask: each group owns a contiguous slice of features."""
+    mask = np.zeros((n_groups, n_features))
+    split = n_features // n_groups
+    for i in range(n_groups):
+        start = i * split
+        end = (i + 1) * split if i < n_groups - 1 else n_features
+        mask[i, start:end] = 1.0
+    return mask
+
+
+@pytest.mark.parametrize(
+    "make_mask, make_X, check_coef",
+    [
+        pytest.param(
+            lambda arr, _: arr,
+            lambda X: X,
+            # flat array: coef slot should be a single 2-D array (n_groups, n_features)
+            lambda coef, n_groups, n_features: (
+                hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
+            ),
+            id="flat_array_mask-2d_X",
+        ),
+        pytest.param(
+            lambda arr, _: [arr],
+            lambda X: [X],
+            # list mask with list X: coef slot should be a list of one 2-D array
+            lambda coef, n_groups, n_features: (
+                isinstance(coef, list)
+                and len(coef) == 1
+                and coef[0].shape == (n_groups, n_features)
+            ),
+            id="list_mask-list_X",
+        ),
+        pytest.param(
+                lambda arr, _: nmo.glm.params.GLMParams(
+                    coef=jnp.asarray(arr), intercept=None
+                ),
+                lambda X: X,
+                # already-structured GLMParams: coef slot is unchanged, same 2-D array
+                lambda coef, n_groups, n_features: (
+                    hasattr(coef, "shape") and coef.shape == (n_groups, n_features)
+                ),
+                id="already_structured_glmparams_mask",
+            ),
+    ],
+)
+def test_grouplasso_mask_wrapping_and_refit(
+    make_mask, make_X, check_coef, mock_optimizer_run
+):
+    """User-provided mask wraps into GLMParams on first fit; re-fit leaves it unchanged.
+
+    Regression test for three mask formats:
+    - flat array: mask has same shape as coef_ (mirrors X).
+    - list of one array: mask mirrors list-structured X.
+    - already-structured GLMParams: isinstance guard prevents double-wrapping.
+    """
+    rng = np.random.default_rng(0)
+    n_samples, n_features, n_groups = 50, 4, 2
+    X_arr = rng.standard_normal((n_samples, n_features))
+    y = rng.poisson(1, size=n_samples)
+
+    mask_arr = _make_valid_group_mask(n_groups, n_features)
+    mask = make_mask(mask_arr, n_features)
+    X = make_X(X_arr)
+
+    model = nmo.glm.GLM(
+        regularizer=nmo.regularizer.GroupLasso(mask=mask),
+        regularizer_strength=1.0,
+    )
+
+    model.fit(X, y)
+
+    # After first fit, mask must be wrapped into the internal GLMParams structure.
+    assert isinstance(model.regularizer.mask, nmo.glm.params.GLMParams), (
+        "mask must be a GLMParams pytree after fit"
+    )
+    assert model.regularizer.mask.intercept is None
+    assert check_coef(model.regularizer.mask.coef, n_groups, n_features)
+    mask_coef_after_first = model.regularizer.mask.coef
+
+    # Re-fit: isinstance guard must prevent double-wrapping; coef content unchanged.
+    model.fit(X, y)
+    assert isinstance(model.regularizer.mask, nmo.glm.params.GLMParams)
+    assert model.regularizer.mask.intercept is None
+    jax.tree_util.tree_map(
+        lambda a, b: np.testing.assert_array_equal(a, b),
+        mask_coef_after_first,
+        model.regularizer.mask.coef,
+    )
+
+
 @pytest.mark.parametrize(
     "model_instantiation",
     [


### PR DESCRIPTION
Fix some GLM dependent code in BaseRegressor. Now, if a user defines a regularization mask matching the user parameter structure, that mask gets converted to the model parameter structure as part of pre-processing, using model independent machinery.