### PR TITLE
Compute optimal SVRG params if inv link is given as "softplus"

### DIFF
--- a/src/nemos/solvers/_compute_defaults.py
+++ b/src/nemos/solvers/_compute_defaults.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
 
 import jax
 
+from ..inverse_link_function_utils import softplus
 from ..observation_models import PoissonObservations
 from ..regularizer import Ridge
 from ._svrg_defaults import (
@@ -62,7 +63,7 @@ def glm_compute_optimal_stepsize_configs(
         compute_optimal_params = svrg_optimal_batch_and_stepsize
 
     # get the smoothness parameter compute function
-    if model.inverse_link_function is jax.nn.softplus and isinstance(
+    if model.inverse_link_function in (jax.nn.softplus, softplus) and isinstance(
         model.observation_model, PoissonObservations
     ):
         compute_smoothness = glm_softplus_poisson_l_max_and_l

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -3284,6 +3284,7 @@ class TestPoissonGLM:
     )
     @pytest.mark.parametrize("batch_size", [None, 1, 10])
     @pytest.mark.parametrize("stepsize", [None, 0.01])
+    @pytest.mark.parametrize("inverse_link_function", [jax.nn.softplus, "softplus"])
     @pytest.mark.solver_related
     def test_glm_optimal_config_set_initial_state(
         self,
@@ -3292,14 +3293,13 @@ class TestPoissonGLM:
         stepsize,
         reg,
         obs,
+        inverse_link_function,
         request,
         glm_class_type,
         model_instantiation_type,
         reg_setup,
     ):
-        """
-        Test special initialization of Poisson GLM + softmax inverse link function for SVRG and ProxSVRG.
-        """
+        """Test special initialization of Poisson GLM + softplus inverse link function for SVRG and ProxSVRG."""
         glm_class = request.getfixturevalue(glm_class_type)
         X, y, _, true_params, _ = request.getfixturevalue(
             model_instantiation_type + reg_setup
@@ -3312,7 +3312,7 @@ class TestPoissonGLM:
                 reg = nmo.regularizer.GroupLasso()
         model = glm_class(
             solver_name=solver_name,
-            inverse_link_function=jax.nn.softplus,
+            inverse_link_function=inverse_link_function,
             solver_kwargs=dict(batch_size=batch_size, stepsize=stepsize),
             observation_model=obs,
             regularizer=reg,
@@ -3333,6 +3333,49 @@ class TestPoissonGLM:
         else:
             assert isinstance(solver.batch_size, int)
             assert solver.batch_size > 0
+
+    @pytest.mark.parametrize(
+        "solver_name, regularizer",
+        [("SVRG", "UnRegularized"), ("ProxSVRG", "Lasso")],
+    )
+    @pytest.mark.parametrize(
+        "inverse_link_function, has_defaults",
+        [(jax.nn.softplus, True), ("softplus", True), (jax.numpy.exp, False)],
+    )
+    @pytest.mark.solver_related
+    def test_svrg_defaults_detect_softplus_string_and_callable(
+        self,
+        solver_name,
+        regularizer,
+        inverse_link_function,
+        has_defaults,
+        glm_class_type,
+        request,
+    ):
+        """Test Poisson SVRG defaults handle both softplus specifications."""
+        glm_class = request.getfixturevalue(glm_class_type)
+        X = jnp.array([[1.0, 2.0], [3.0, 1.0], [2.0, 4.0], [5.0, 3.0]])
+        y = jnp.array([1.0, 2.0, 3.0, 4.0])
+        if glm_class_type == "population_glm_class":
+            y = y[:, None]
+        model = glm_class(
+            solver_name=solver_name,
+            inverse_link_function=inverse_link_function,
+            observation_model=nmo.observation_models.PoissonObservations(),
+            regularizer=regularizer,
+            regularizer_strength=None if regularizer == "UnRegularized" else 1.0,
+        )
+
+        solver_kwargs = model._optimize_solver_params(X, y)
+
+        if has_defaults:
+            assert isinstance(solver_kwargs["batch_size"], int)
+            assert solver_kwargs["batch_size"] > 0
+            assert isinstance(solver_kwargs["stepsize"], float)
+            assert solver_kwargs["stepsize"] > 0
+        else:
+            assert "batch_size" not in solver_kwargs
+            assert "stepsize" not in solver_kwargs
 
     @pytest.mark.parametrize(
         "regularizer, expected_type_convexity",
@@ -3356,7 +3399,11 @@ class TestPoissonGLM:
     )
     @pytest.mark.parametrize(
         "inv_link_func, expected_type_link",
-        [(jax.nn.softplus, Callable), (jax.numpy.exp, type(None))],
+        [
+            (jax.nn.softplus, Callable),
+            ("softplus", Callable),
+            (jax.numpy.exp, type(None)),
+        ],
     )
     def test_optimal_config_outputs(
         self,


### PR DESCRIPTION
Step size and batch size can be optimized for GLMs fitted with SVRG if the observation model is Poisson and the inverse link is softplus.

This was only done if the inverse link was specified as `jax.nn.softplus`. If the user specified the same with `"softplus"`, that got resolved to the wrapped `inverse_link_function_utils.softplus` and this calculation was skipped.

This fix just adds that function to the if statement.