### PR TITLE
Remove public `compute_loss`

### DIFF
--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -496,50 +496,6 @@ class BaseRegressor(
             f"{self.__class__.__name__} does not implement `_compute_loss`."
         )
 
-    @cast_to_jax
-    def compute_loss(
-        self,
-        params: UserProvidedParamsT,
-        X: DESIGN_INPUT_TYPE,
-        y: jnp.ndarray,
-        *args,
-        **kwargs,
-    ) -> jnp.ndarray:
-        """Compute the loss function for the model.
-
-        This method validates inputs and converts user-provided parameters to the internal
-        representation before computing the loss.
-
-        Parameters
-        ----------
-        params
-            Parameter tuple of (coefficients, intercept).
-        X
-            Input data, array of shape ``(n_time_bins, n_features)`` or pytree of same.
-        y
-            Target data, array of shape ``(n_time_bins,)`` for single neuron models or
-            ``(n_time_bins, n_neurons)`` for population models.
-        *args
-            Additional positional arguments passed to the model-specific loss function.
-        **kwargs
-            Additional keyword arguments passed to the model-specific loss function.
-
-        Returns
-        -------
-        loss
-            The loss value (negative log-likelihood).
-
-        Raises
-        ------
-        ValueError
-            If inputs or parameters have incompatible shapes or invalid values.
-        """
-        self._validator.validate_inputs(X, y)
-        params = self._validator.validate_and_cast_params(params)
-        self._validator.validate_consistency(params, X, y)
-        X, y = self._preprocess_inputs(X, y)
-        return self._compute_loss(params, X, y, *args, **kwargs)
-
     @abc.abstractmethod
     def update(
         self,

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -113,49 +113,6 @@ class ClassifierMixin:
         else:
             self._label_encoder.reset()
 
-    def compute_loss(
-        self,
-        params,
-        X,
-        y,
-        *args,
-        **kwargs,
-    ):
-        """
-        Compute the loss function for the model.
-
-        This method validates inputs, encodes class labels to internal indices,
-        and computes the loss (negative log-likelihood).
-
-        Parameters
-        ----------
-        params
-            Parameter tuple of (coefficients, intercept).
-        X
-            Input data, array of shape ``(n_time_bins, n_features)`` or pytree of same.
-        y
-            Target class labels in the same format as ``classes_``.
-        *args
-            Additional positional arguments passed to the model-specific loss function.
-        **kwargs
-            Additional keyword arguments passed to the model-specific loss function.
-
-        Returns
-        -------
-        loss
-            The loss value (negative log-likelihood).
-
-        Raises
-        ------
-        RuntimeError
-            If ``classes_`` has not been set.
-        ValueError
-            If inputs or parameters have incompatible shapes or invalid values.
-        """
-        self._label_encoder.check_classes_is_set("compute_loss")
-        y = self._label_encoder.encode(y)
-        return super().compute_loss(params, X, y, *args, **kwargs)
-
     @property
     def n_classes(self):
         """Number of classes."""

--- a/tests/test_fista_adjoint.py
+++ b/tests/test_fista_adjoint.py
@@ -73,7 +73,7 @@ def test_glm_passes_adjoint_to_optimistix_config(
         solver_name=solver_name,
         solver_kwargs={"adjoint": adjoint},
     )
-    solver_adapter = glm._instantiate_solver(glm.compute_loss, None)
+    solver_adapter = glm._instantiate_solver(glm._compute_loss, None)
 
     assert isinstance(solver_adapter.config.adjoint, type(adjoint))
 
@@ -105,7 +105,7 @@ def test_fista_while_loop_kind_matches_adjoint(
         solver_name=solver_name,
         solver_kwargs={"adjoint": adjoint},
     )
-    fista_solver = glm._instantiate_solver(glm.compute_loss, None)
+    fista_solver = glm._instantiate_solver(glm._compute_loss, None)
 
     assert fista_solver.while_loop_kind == expected_kind
 
@@ -134,7 +134,7 @@ def test_fista_explicit_while_loop_kind_overrides_adjoint(
         solver_name=solver_name,
         solver_kwargs={"adjoint": adjoint, "while_loop_kind": while_loop_kind},
     )
-    fista_solver = glm._instantiate_solver(glm.compute_loss, None)
+    fista_solver = glm._instantiate_solver(glm._compute_loss, None)
 
     assert fista_solver.while_loop_kind == while_loop_kind
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -4282,29 +4282,6 @@ class TestClassifierGLM:
         pred = model.predict(X)
         assert jnp.array_equal(pred_nc, nc_labels[pred])
 
-    def test_compute_loss_with_labels(
-        self, inv_link, glm_type, model_instantiation, request
-    ):
-        """Test that compute_loss works with custom labels."""
-        X, y, model, true_params, _ = request.getfixturevalue(
-            glm_type + model_instantiation
-        )
-        model = deepcopy(model)
-        model.coef_ = true_params.coef
-        model.intercept_ = true_params.intercept
-
-        # Compute loss with default labels
-        model.set_classes(np.arange(model.n_classes))
-        loss_default = model.compute_loss((model.coef_, model.intercept_), X, y)
-
-        # Compute loss with string labels
-        label = np.array([chr(i) for i in range(ord("a"), ord("a") + model.n_classes)])
-        model.set_classes(label)
-        y_label = model._label_encoder.decode(y)
-        loss_label = model.compute_loss((model.coef_, model.intercept_), X, y_label)
-
-        assert jnp.allclose(loss_default, loss_label)
-
     @pytest.mark.parametrize("return_type", ["proba", "log-proba"])
     def test_predict_proba_with_labels(
         self, inv_link, glm_type, model_instantiation, request, return_type


### PR DESCRIPTION
Instead of making a custom override of `compute_loss` for HMM models, we're opting to remove the public method `compute_loss` completely. Any advanced need for access to this can use the private `_compute_loss` instead.