### PR TITLE
fix sklean compat

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,9 +18,12 @@ build:
       # Skip files referencing to sklearn docs, which uses Text fragment URLs (#:~:text=)
       # that are not recognized as valid anchors by htmlproofer yet, see issue below
       # https://github.com/gjtorikian/html-proofer/issues/849
-      - htmlproofer $READTHEDOCS_OUTPUT/html --checks Links,Scripts,Images --ignore-urls "https://fonts.gstatic.com,/scikit-learn\.org/,https://celltypes.brain-map.org/experiment/electrophysiology/478498617,https://www.jneurosci.org/content/25/47/11003,https://www.nature.com/articles/s41467-017-01908-3,https://doi.org/10.1038/s41467-017-01908-3,https://www.taylorfrancis.com/books/mono/10.4324/9780203774441/applied-multiple-regression-correlation-analysis-behavioral-sciences-jacob-cohen-patricia-cohen-stephen-west-leona-aiken" --assume-extension --check-external-hash --ignore-status-codes 400,403,302,0,503 --ignore-files "/.+\/_static\/.+/","/.+\/stubs\/.+/","/.+\/tutorials/plot_02_head_direction.+/","/.+\/how_to_guide\/plot_06_sklearn_pipeline_cv_demo.+/","/.+\/tutorials\/plot_03_grid_cells.+/","/.+\/tutorials\/plot_06_calcium_imaging.+/"
+      # --allow-missing-href: scikit-learn >= 1.9 renders the estimator HTML repr with an
+      # href-less "?" doc-link anchor for estimators it cannot resolve a doc URL for (e.g.
+      # nemos models), which htmlproofer flags as "'a' tag is missing a reference".
+      - htmlproofer $READTHEDOCS_OUTPUT/html --checks Links,Scripts,Images --allow-missing-href --ignore-urls "https://fonts.gstatic.com,/scikit-learn\.org/,https://celltypes.brain-map.org/experiment/electrophysiology/478498617,https://www.jneurosci.org/content/25/47/11003,https://www.nature.com/articles/s41467-017-01908-3,https://doi.org/10.1038/s41467-017-01908-3,https://www.taylorfrancis.com/books/mono/10.4324/9780203774441/applied-multiple-regression-correlation-analysis-behavioral-sciences-jacob-cohen-patricia-cohen-stephen-west-leona-aiken" --assume-extension --check-external-hash --ignore-status-codes 400,403,302,0,503 --ignore-files "/.+\/_static\/.+/","/.+\/stubs\/.+/","/.+\/tutorials/plot_02_head_direction.+/","/.+\/how_to_guide\/plot_06_sklearn_pipeline_cv_demo.+/","/.+\/tutorials\/plot_03_grid_cells.+/","/.+\/tutorials\/plot_06_calcium_imaging.+/"
       # therefore for this file I am not checking the figures.
-      - htmlproofer $READTHEDOCS_OUTPUT/html/tutorials/plot_02_head_direction.html  --checks Links,Scripts --ignore-urls "https://www.jneurosci.org/content/25/47/11003" --ignore-status-codes 400
+      - htmlproofer $READTHEDOCS_OUTPUT/html/tutorials/plot_02_head_direction.html  --checks Links,Scripts --allow-missing-href --ignore-urls "https://www.jneurosci.org/content/25/47/11003" --ignore-status-codes 400
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -403,7 +403,7 @@ class TransformerBasis:
         By default, scikit-learn tries to clone the object by calling __init__ using the output of get_params,
         which fails in our case.
 
-        For more info: https://scikit-learn.org/stable/developers/develop.html#cloningi
+        For more info: https://scikit-learn.org/stable/developers/develop.html#cloning
         """
         cloned = (
             self.basis.__sklearn_clone__()

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -381,7 +381,7 @@ class TransformerBasis:
         ValueError('Only setting basis or existing attributes of basis is allowed. Attempt to set `rand_atrr`.')
         """
         # allow self.basis = basis and other attrs of self to be retrievable
-        if name in ["basis", "_wrapped_methods", "_basis"]:
+        if name in ["basis", "_wrapped_methods", "_basis", "_parent_callback_ctx"]:
             super().__setattr__(name, value)
         # allow changing existing attributes of self.basis
         elif hasattr(self.basis, name):

--- a/src/nemos/basis/_transformer_basis.py
+++ b/src/nemos/basis/_transformer_basis.py
@@ -403,7 +403,7 @@ class TransformerBasis:
         By default, scikit-learn tries to clone the object by calling __init__ using the output of get_params,
         which fails in our case.
 
-        For more info: https://scikit-learn.org/stable/developers/develop.html#cloning
+        For more info: https://scikit-learn.org/stable/developers/develop.html#cloningi
         """
         cloned = (
             self.basis.__sklearn_clone__()


### PR DESCRIPTION
After release of scikit-learn `v1.1.9`, the internal machinery of sklearn sets a new attribute as part of a pipleline.

```python
sub_estimator._parent_callback_ctx = self
```
Our transformer basis only allows a selected number of attributes to be set. This new attribute needs to be added to the settable once. 
