### PR TITLE
Add a fit intercept parameter

### DIFF
--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -151,6 +151,7 @@ VALID_PAIRS = [
     {"X_test", "y_test"},
     {"basis_coeff", "basis_col"},
     {"n_classes", "n_passes"},
+    {"true_intercept", "fit_intercept"},
 ]
 
 

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -364,6 +364,8 @@ class BaseRegressor(
         self._optimizer_init_state = None
         self._optimizer_update = None
         self._optimizer_run = None
+        # the frozen partition was captured against the now-stale solver
+        self._frozen_params = None
 
     def _partition_active(
         self, params: ModelParamsT

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -117,9 +117,8 @@ class BaseRegressor(
     # overwrite this in subclasses if their objective functions return aux
     _has_aux: bool = False
 
-    # set of active parameters.
-    _active_params: Optional[ModelParamsT] = None
-    _frozen_params: Optional[ModelParamsT] = None
+    # set of fixed parameters.
+    _fix_params: Optional[ModelParamsT] = None
 
     def __init__(
         self,
@@ -365,7 +364,7 @@ class BaseRegressor(
         self._optimizer_update = None
         self._optimizer_run = None
         # the frozen partition was captured against the now-stale solver
-        self._frozen_params = None
+        self._fix_params = None
 
     def _partition_active(
         self, params: ModelParamsT
@@ -384,12 +383,10 @@ class BaseRegressor(
             A tuple containing the active and frozen parameter trees.
 
         """
-        if self._active_params is None:
-            struct = jax.tree_util.tree_structure(params)
-            return params, jax.tree_util.tree_unflatten(
-                struct, [None] * struct.num_leaves
-            )
-        return eqx.partition(params, self._active_params)
+        active = jax.tree_util.tree_map(
+            lambda x: x is None, self._fix_params, is_leaf=lambda x: x is None
+        )
+        return eqx.partition(params, active)
 
     def _run_optimizer(
         self,
@@ -432,12 +429,12 @@ class BaseRegressor(
             ``(params, state, aux)`` with the frozen parameters recombined into
             ``params``.
         """
-        active, self._frozen_params = self._partition_active(init_params)
+        active, self._fix_params = self._partition_active(init_params)
         self._initialize_optimizer_and_state(
-            active, X, y, frozen_params=self._frozen_params
+            active, X, y, frozen_params=self._fix_params
         )
         params, state, aux = run(active)
-        return eqx.combine(params, self._frozen_params), state, aux
+        return eqx.combine(params, self._fix_params), state, aux
 
     def _normalize_user_params(
         self,
@@ -929,9 +926,9 @@ class BaseRegressor(
         init_params = self._validator.validate_and_cast_params(init_params)
         self._validator.validate_consistency(init_params, X=X, y=y)
         X, y = self._preprocess_inputs(X, y, drop_nans=True)
-        active, self._frozen_params = self._partition_active(init_params)
+        active, self._fix_params = self._partition_active(init_params)
         state = self._initialize_optimizer_and_state(
-            active, X, y, frozen_params=self._frozen_params
+            active, X, y, frozen_params=self._fix_params
         )
         return state
 

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -117,7 +117,7 @@ class BaseRegressor(
     # overwrite this in subclasses if their objective functions return aux
     _has_aux: bool = False
 
-    # set of fixed parameters.
+    # user setting: fixed-parameter spec (array leaf = fixed value, None leaf = learn).
     _fix_params: Optional[ModelParamsT] = None
 
     def __init__(
@@ -363,8 +363,6 @@ class BaseRegressor(
         self._optimizer_init_state = None
         self._optimizer_update = None
         self._optimizer_run = None
-        # the frozen partition was captured against the now-stale solver
-        self._fix_params = None
 
     def _partition_active(
         self, params: ModelParamsT
@@ -383,58 +381,33 @@ class BaseRegressor(
             A tuple containing the active and frozen parameter trees.
 
         """
-        active = jax.tree_util.tree_map(
+        return eqx.partition(params, self._active_filter_spec())
+
+    def _active_filter_spec(self) -> Any:
+        """Boolean filter spec (tree-prefix) marking the actively optimized leaves.
+
+        Derived from ``_fix_params`` alone: a leaf is active iff the spec holds
+        ``None`` there. Subclasses fold model-specific settings in (e.g. the GLM
+        freezes the intercept when ``fit_intercept=False``).
+        """
+        return jax.tree_util.tree_map(
             lambda x: x is None, self._fix_params, is_leaf=lambda x: x is None
         )
-        return eqx.partition(params, active)
 
-    def _run_optimizer(
-        self,
-        init_params: ModelParamsT,
-        X: DESIGN_INPUT_TYPE,
-        y: jnp.ndarray,
-        run: Callable[[ModelParamsT], Tuple[ModelParamsT, Any, Any]],
-    ) -> Tuple[ModelParamsT, Any, Any]:
-        """Optimize the active parameters and recombine the frozen ones.
+    def _frozen_values(
+        self, X: DESIGN_INPUT_TYPE, y: jnp.ndarray
+    ) -> Optional[ModelParamsT]:
+        """Values the frozen leaves are pinned to, implied by the model settings.
 
-        Shared spine for the run-to-completion entry points (``fit`` and
-        ``stochastic_fit``). It splits ``init_params`` into the active subtree the
-        solver optimizes and the frozen subtree held fixed (see
-        :meth:`_partition_active`), initializes the solver on the active subtree with a
-        loss closed over the frozen values, runs the optimization, and recombines the
-        frozen values into the returned parameters.
-
-        Keeping this in one place guarantees that both entry points partition, run, and
-        recombine identically; the only difference between them is the optimization loop
-        itself, which is supplied as ``run``. This is what makes freezing (e.g.
-        ``fit_intercept=False``) behave the same for full-batch and stochastic fits.
-
-        Parameters
-        ----------
-        init_params :
-            The complete (active + frozen) initial parameters.
-        X :
-            Input predictors, forwarded to solver initialization.
-        y :
-            Target data, forwarded to solver initialization.
-        run :
-            Callable invoked with the active parameters, returning
-            ``(params, state, aux)``. Wraps ``self._optimizer_run`` for full-batch fits
-            or the solver's stochastic loop for ``stochastic_fit``. It is called after
-            the solver has been initialized, so ``self._solver`` is available inside it.
-
-        Returns
-        -------
-        :
-            ``(params, state, aux)`` with the frozen parameters recombined into
-            ``params``.
+        Complement of :meth:`_active_filter_spec`: the spec marks *which* leaves are
+        actively optimized, this returns *what* the remaining leaves are held at
+        (tree-prefix with ``None`` on active leaves; ``None`` when nothing is frozen).
+        Derived from ``_fix_params`` alone here — its array leaves are the fixed
+        values. Subclasses fold model-specific settings in (e.g. the GLM pins the
+        intercept at zero when ``fit_intercept=False``); ``X`` and ``y`` let them
+        infer the shape of a pinned leaf.
         """
-        active, self._fix_params = self._partition_active(init_params)
-        self._initialize_optimizer_and_state(
-            active, X, y, frozen_params=self._fix_params
-        )
-        params, state, aux = run(active)
-        return eqx.combine(params, self._fix_params), state, aux
+        return self._fix_params
 
     def _normalize_user_params(
         self,
@@ -926,10 +899,8 @@ class BaseRegressor(
         init_params = self._validator.validate_and_cast_params(init_params)
         self._validator.validate_consistency(init_params, X=X, y=y)
         X, y = self._preprocess_inputs(X, y, drop_nans=True)
-        active, self._fix_params = self._partition_active(init_params)
-        state = self._initialize_optimizer_and_state(
-            active, X, y, frozen_params=self._fix_params
-        )
+        active, frozen = self._partition_active(init_params)
+        state = self._initialize_optimizer_and_state(active, X, y, frozen_params=frozen)
         return state
 
     def _optimize_solver_params(self, X: DESIGN_INPUT_TYPE, y: jnp.ndarray) -> dict:

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -10,6 +10,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Any, Callable, Generic, Optional, Tuple, Type, Union
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -115,6 +116,10 @@ class BaseRegressor(
 
     # overwrite this in subclasses if their objective functions return aux
     _has_aux: bool = False
+
+    # set of active parameters.
+    _active_params: Optional[ModelParamsT] = None
+    _frozen_params: Optional[ModelParamsT] = None
 
     def __init__(
         self,
@@ -360,6 +365,130 @@ class BaseRegressor(
         self._optimizer_update = None
         self._optimizer_run = None
 
+    def _partition_active(
+        self, params: ModelParamsT
+    ) -> Tuple[ModelParamsT, ModelParamsT]:
+        """
+        Compute active and frozen parameter trees.
+
+        Parameters
+        ----------
+        params:
+            The model parameters.
+
+        Returns
+        -------
+        :
+            A tuple containing the active and frozen parameter trees.
+
+        """
+        if self._active_params is None:
+            struct = jax.tree_util.tree_structure(params)
+            return params, jax.tree_util.tree_unflatten(
+                struct, [None] * struct.num_leaves
+            )
+        return eqx.partition(params, self._active_params)
+
+    def _run_optimizer(
+        self,
+        init_params: ModelParamsT,
+        X: DESIGN_INPUT_TYPE,
+        y: jnp.ndarray,
+        run: Callable[[ModelParamsT], Tuple[ModelParamsT, Any, Any]],
+    ) -> Tuple[ModelParamsT, Any, Any]:
+        """Optimize the active parameters and recombine the frozen ones.
+
+        Shared spine for the run-to-completion entry points (``fit`` and
+        ``stochastic_fit``). It splits ``init_params`` into the active subtree the
+        solver optimizes and the frozen subtree held fixed (see
+        :meth:`_partition_active`), initializes the solver on the active subtree with a
+        loss closed over the frozen values, runs the optimization, and recombines the
+        frozen values into the returned parameters.
+
+        Keeping this in one place guarantees that both entry points partition, run, and
+        recombine identically; the only difference between them is the optimization loop
+        itself, which is supplied as ``run``. This is what makes freezing (e.g.
+        ``fit_intercept=False``) behave the same for full-batch and stochastic fits.
+
+        Parameters
+        ----------
+        init_params :
+            The complete (active + frozen) initial parameters.
+        X :
+            Input predictors, forwarded to solver initialization.
+        y :
+            Target data, forwarded to solver initialization.
+        run :
+            Callable invoked with the active parameters, returning
+            ``(params, state, aux)``. Wraps ``self._optimizer_run`` for full-batch fits
+            or the solver's stochastic loop for ``stochastic_fit``. It is called after
+            the solver has been initialized, so ``self._solver`` is available inside it.
+
+        Returns
+        -------
+        :
+            ``(params, state, aux)`` with the frozen parameters recombined into
+            ``params``.
+        """
+        active, self._frozen_params = self._partition_active(init_params)
+        self._initialize_optimizer_and_state(
+            active, X, y, frozen_params=self._frozen_params
+        )
+        params, state, aux = run(active)
+        return eqx.combine(params, self._frozen_params), state, aux
+
+    def _normalize_user_params(
+        self,
+        init_params: UserProvidedParamsT,
+        X: DESIGN_INPUT_TYPE,
+        y: jnp.ndarray,
+    ) -> UserProvidedParamsT:
+        """Complete a user-provided parameter set before validation.
+
+        User-facing entry points (``fit``, ``initialize_optimizer_and_state``) accept
+        parameters in a convenient, possibly *incomplete* form: leaves that the model
+        will not learn may be omitted (passed as ``None``) so the user does not have to
+        supply a value for something that is held fixed. This hook is the single seam
+        where such input is turned into a complete, concrete parameter set, filling in
+        the omitted leaves with their fixed defaults (and warning if the user supplied a
+        value for a leaf that will not be estimated).
+
+        It is separate from the other parameter-processing steps because it is the only
+        one allowed to *change values*, and the only one that is inherently model
+        specific:
+
+        - ``_normalize_user_params`` (this method): inject defaults for omitted/fixed
+          leaves, coerce/override, warn. Model specific — the base class does not know
+          which leaves a subclass can leave unset (e.g. the GLM intercept when
+          ``fit_intercept=False``), so it is a no-op here and subclasses override it.
+        - ``validate_and_cast_params``: validate structure/dtype/shape and cast the
+          user tuple to a ``ModelParams`` pytree. Assumes a *complete* set of concrete
+          arrays, which is why normalization must run first.
+        - ``validate_consistency``: check the parameters against the data (feature and
+          output dimensions).
+        - ``_partition_active``: split the concrete parameters into the active subtree
+          the solver optimizes and the frozen subtree recombined afterwards. The fixed
+          values injected here are what end up in the frozen subtree.
+
+        Running order is therefore: normalize -> validate/cast -> check consistency ->
+        partition. The default implementation returns ``init_params`` unchanged.
+
+        Parameters
+        ----------
+        init_params :
+            User-provided parameters, in the model's user-facing format.
+        X :
+            Input predictors, used to infer the shape/default of any omitted leaf.
+        y :
+            Target data, used to infer the shape/default of any omitted leaf.
+
+        Returns
+        -------
+        :
+            The parameters with any omitted fixed leaves filled in.
+        """
+        return init_params
+
     def _instantiate_solver(
         self,
         loss,
@@ -368,6 +497,7 @@ class BaseRegressor(
         solver_kwargs: Optional[dict] = None,
         regularizer: Optional[Regularizer] = None,
         regularizer_strength: Optional[Any] = None,
+        frozen_params: Optional[ModelParamsT] = None,
     ) -> SolverProtocol:
         """
         Instantiate the solver with the provided loss function.
@@ -399,6 +529,8 @@ class BaseRegressor(
             Optional regularizer, default is self.regularizer.
         regularizer_strength:
             Optional regularization strength, default is self.regularizer_strength.
+        frozen_params:
+            Set of fixed parameters that will be combined with actively learned ``init_params``.
 
         Returns
         -------
@@ -423,8 +555,17 @@ class BaseRegressor(
 
         self._check_solver_kwargs(solver_cls, solver_kwargs)
 
+        if frozen_params is not None:
+
+            def _loss(params, *args, **kwargs):
+                params = eqx.combine(params, frozen_params)
+                return loss(params, *args, **kwargs)
+
+        else:
+            _loss = loss
+
         solver = solver_cls(
-            loss,
+            _loss,
             regularizer,
             regularizer_strength,
             has_aux=self._has_aux,
@@ -736,7 +877,8 @@ class BaseRegressor(
         init_params: ModelParamsT,
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
-    ) -> SolverState:
+        frozen_params: Optional[ModelParamsT] = None,
+    ) -> Tuple[SolverState, ModelParamsT, ModelParamsT]:
         """Initialize the optimizer and the state of the optimizer for running fit and update."""
         pass
 
@@ -773,10 +915,15 @@ class BaseRegressor(
             If inputs or parameters have incompatible shapes or invalid values.
         """
         self._validator.validate_inputs(X, y)
+        init_params = self._normalize_user_params(init_params, X, y)
         init_params = self._validator.validate_and_cast_params(init_params)
         self._validator.validate_consistency(init_params, X=X, y=y)
         X, y = self._preprocess_inputs(X, y, drop_nans=True)
-        return self._initialize_optimizer_and_state(init_params, X, y)
+        active, self._frozen_params = self._partition_active(init_params)
+        state = self._initialize_optimizer_and_state(
+            active, X, y, frozen_params=self._frozen_params
+        )
+        return state
 
     def _optimize_solver_params(self, X: DESIGN_INPUT_TYPE, y: jnp.ndarray) -> dict:
         """

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -546,16 +546,8 @@ class BaseRegressor(
         )
 
         if isinstance(solver, Newton):
-            # tree_leaves skips None leaves, so this is empty when nothing is frozen
-            if frozen_params is not None and jax.tree_util.tree_leaves(frozen_params):
-                raise ValueError(
-                    "The Newton solver does not support frozen parameters (e.g. "
-                    "`fit_intercept=False`): its Hessian is computed on the full "
-                    "parameter set and is not partition-aware. Choose a first-order "
-                    "solver such as 'LBFGS'."
-                )
             solver.setup_hessian(
-                self._get_hess_fn(),
+                self._get_hess_fn(frozen=frozen_params),
                 self._hess_tag,
                 regularizer.resolve_hess_tag(init_params),
                 self._hess_property_override(),
@@ -571,7 +563,7 @@ class BaseRegressor(
 
         return solver
 
-    def _get_hess_fn(self) -> Callable:
+    def _get_hess_fn(self, frozen: Optional[ModelParamsT] = None) -> Optional[Callable]:
         return None
 
     @abc.abstractmethod

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -574,6 +574,14 @@ class BaseRegressor(
         )
 
         if isinstance(solver, Newton):
+            # tree_leaves skips None leaves, so this is empty when nothing is frozen
+            if frozen_params is not None and jax.tree_util.tree_leaves(frozen_params):
+                raise ValueError(
+                    "The Newton solver does not support frozen parameters (e.g. "
+                    "`fit_intercept=False`): its Hessian is computed on the full "
+                    "parameter set and is not partition-aware. Choose a first-order "
+                    "solver such as 'LBFGS'."
+                )
             solver.setup_hessian(
                 self._get_hess_fn(),
                 self._hess_tag,
@@ -878,7 +886,7 @@ class BaseRegressor(
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
         frozen_params: Optional[ModelParamsT] = None,
-    ) -> Tuple[SolverState, ModelParamsT, ModelParamsT]:
+    ) -> SolverState:
         """Initialize the optimizer and the state of the optimizer for running fit and update."""
         pass
 

--- a/src/nemos/callbacks.py
+++ b/src/nemos/callbacks.py
@@ -89,18 +89,18 @@ class TrainingContext:
         params: Any = None,
         state: Any = None,
         aux: Any = None,
-        epoch_idx: int | None = None,
+        pass_idx: int | None = None,
         batch_idx: int | None = None,
-        num_epochs: int = 0,
+        n_passes: int = 0,
         frozen: Any = None,
     ):
         self.model = model
         self.solver = solver
         self.state = state
         self.aux = aux
-        self.epoch_idx = epoch_idx
+        self.pass_idx = pass_idx
         self.batch_idx = batch_idx
-        self.num_epochs = num_epochs
+        self.n_passes = n_passes
         self.frozen = frozen
         self._stop_requested = False
         self._stop_reason = ""

--- a/src/nemos/callbacks.py
+++ b/src/nemos/callbacks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, Iterable, Union
@@ -147,6 +148,26 @@ class TrainingContext:
             should_stop=self.should_stop,
             stop_reason=self.stop_reason,
         )
+
+    def __repr__(self, N_CHAR_MAX: int = 700) -> str:
+        """Represent this context as a string.
+
+        Simple string representation, similar to that of a dataclass.
+        """
+        cls = self.__class__.__name__
+        parts = []
+        for name in inspect.signature(self.__init__).parameters:
+            value = getattr(self, name)
+            if value is None:
+                continue
+            parts.append(f"{name}={value}")
+        if not parts:
+            return f"{cls}()"
+        single_line = f"{cls}({', '.join(parts)})"
+        if len(single_line) <= N_CHAR_MAX:
+            return single_line
+        body = "".join(f"    {part},\n" for part in parts)
+        return f"{cls}(\n{body})"
 
 
 class Callback:

--- a/src/nemos/callbacks.py
+++ b/src/nemos/callbacks.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from typing import Any, Iterable, Union
 
+import equinox as eqx
 from numpy.typing import ArrayLike
 
 from .typing import DESIGN_INPUT_TYPE
@@ -45,7 +46,6 @@ class StochasticFitSummary:
     stop_reason: str = ""
 
 
-@dataclass
 class TrainingContext:
     """
     Mutable context object passed to callbacks during training.
@@ -60,7 +60,10 @@ class TrainingContext:
     solver :
         The solver instance running the optimization.
     params :
-        Current model parameters.
+        Current model parameters. Exposed as a read/write property: the training loop
+        assigns the actively optimized subtree (``ctx.params = ...``), and reading
+        ``ctx.params`` recombines the frozen subtree (see ``frozen``) so callbacks
+        always see the complete parameters.
     state :
         Current solver state.
     aux :
@@ -71,21 +74,47 @@ class TrainingContext:
         Current batch index within the pass.
     n_passes :
         Total number of passes requested.
+    frozen :
+        Parameter subtree held fixed during optimization (e.g. a zero intercept when
+        ``fit_intercept=False``). The solver optimizes only the active subtree; this is
+        recombined with it so callbacks always see the complete parameters. ``None``
+        when nothing is frozen.
     """
 
-    model: Any = None
-    solver: Any = None
-    params: Any = None
-    state: Any = None
-    aux: Any = None
-    pass_idx: int | None = None
-    batch_idx: int | None = None
-    n_passes: int = 0
+    def __init__(
+        self,
+        model: Any = None,
+        solver: Any = None,
+        params: Any = None,
+        state: Any = None,
+        aux: Any = None,
+        epoch_idx: int | None = None,
+        batch_idx: int | None = None,
+        num_epochs: int = 0,
+        frozen: Any = None,
+    ):
+        self.model = model
+        self.solver = solver
+        self.state = state
+        self.aux = aux
+        self.epoch_idx = epoch_idx
+        self.batch_idx = batch_idx
+        self.num_epochs = num_epochs
+        self.frozen = frozen
+        self._stop_requested = False
+        self._stop_reason = ""
+        self.params = params
 
-    # signals for stopping optimization,
-    # controlled through methods, not included in constructor
-    _stop_requested: bool = field(default=False, init=False, repr=False)
-    _stop_reason: str = field(default="", init=False, repr=False)
+    @property
+    def params(self) -> Any:
+        """Current parameters, with the frozen subtree recombined into the active one."""
+        if self.frozen is None:
+            return self._params
+        return eqx.combine(self._params, self.frozen)
+
+    @params.setter
+    def params(self, value: Any) -> None:
+        self._params = value
 
     def request_stop(self, reason: str = "") -> None:
         """

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -336,6 +336,12 @@ class ClassifierMixin:
         n_m1_classes = self._label_encoder.n_classes - 1
         params = self._get_model_params()
 
+        # The intercept consumes ``n_m1_classes`` degrees of freedom when estimated;
+        # a frozen intercept (``fit_intercept=False``) is None in the active tree and
+        # consumes none.
+        active, _ = self._partition_active(params)
+        intercept_dof = 0 if active.intercept is None else n_m1_classes
+
         # Infer n_neurons from coef shape:
         # ClassifierGLM: coef is (n_features, n_classes) -> n_neurons = 1
         # ClassifierPopulationGLM: coef is (n_features, n_neurons, n_classes) -> n_neurons = shape[1]
@@ -353,18 +359,18 @@ class ClassifierMixin:
                 lambda x: sum([jnp.sum(i, axis=(0, -1)) for i in x]),
                 params.coef,
             )
-            return jnp.atleast_1d(n_samples - resid_dof - n_m1_classes)
+            return jnp.atleast_1d(n_samples - resid_dof - intercept_dof)
 
         elif isinstance(self.regularizer, Ridge):
             # For Ridge, use total parameters
-            return (n_samples - n_m1_classes * n_features - n_m1_classes) * jnp.ones(
+            return (n_samples - n_m1_classes * n_features - intercept_dof) * jnp.ones(
                 n_neurons
             )
 
         else:
             # For UnRegularized, use the rank
             rank = jnp.linalg.matrix_rank(jnp.concatenate(x_leaf, axis=1))
-            return (n_samples - rank * n_m1_classes - n_m1_classes) * jnp.ones(
+            return (n_samples - rank * n_m1_classes - intercept_dof) * jnp.ones(
                 n_neurons
             )
 
@@ -598,6 +604,8 @@ class ClassifierGLM(ClassifierMixin, GLM):
         will result in non-identifiable coefficients, see note below.
     regularizer_strength
         The strength of the regularization.
+    fit_intercept
+        When True (default), an intercept term is fit. When False, only the coefficients are fit.
     solver_name
         The solver to use for optimization.
     solver_kwargs
@@ -739,6 +747,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
         inverse_link_function: Optional[Callable] = None,
         regularizer: Optional[Union[str, Regularizer]] = None,
         regularizer_strength: Any = None,
+        fit_intercept: bool = True,
         solver_name: str = None,
         solver_kwargs: dict = None,
     ):
@@ -751,6 +760,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
             inverse_link_function=inverse_link_function,
             regularizer=regularizer,
             regularizer_strength=regularizer_strength,
+            fit_intercept=fit_intercept,
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
         )
@@ -875,6 +885,8 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
         will result in non-identifiable coefficients, see note below.
     regularizer_strength
         The strength of the regularization.
+    fit_intercept
+        When True (default), an intercept term is fit. When False, only the coefficients are fit.
     solver_name
         The solver to use for optimization.
     solver_kwargs
@@ -1022,6 +1034,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
         inverse_link_function: Optional[Callable] = None,
         regularizer: Optional[Union[str, Regularizer]] = None,
         regularizer_strength: Any = None,
+        fit_intercept: bool = True,
         solver_name: str = None,
         solver_kwargs: dict = None,
         feature_mask: Optional[jnp.ndarray] = None,
@@ -1035,6 +1048,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
             inverse_link_function=inverse_link_function,
             regularizer=regularizer,
             regularizer_strength=regularizer_strength,
+            fit_intercept=fit_intercept,
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
             feature_mask=feature_mask,

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -973,7 +973,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
 
     Specify which features predict each neuron:
 
-    >>> feature_mask = jnp.array([[[1, 1, 1], [0, 0, 0]], [[1, 1, 1], [1, 1, 1]]])
+    >>> feature_mask = jnp.array([[1, 0], [1, 1]])
     >>> y = jnp.array([[0, 0], [0, 1], [1, 0], [1, 2], [2, 1], [2, 2]])
     >>> model = nmo.glm.ClassifierPopulationGLM(
     ...     n_classes=3,

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -331,7 +331,6 @@ class ClassifierMixin:
                     f"Type {type(n_samples)} provided instead!"
                 )
 
-        n_features = sum(x.shape[1] for x in x_leaf)
         # Effective degrees of freedom is n_classes - 1 due to probability simplex constraint
         n_m1_classes = self._label_encoder.n_classes - 1
         params = self._get_model_params()
@@ -355,18 +354,15 @@ class ClassifierMixin:
             )
             return jnp.atleast_1d(n_samples - resid_dof - n_m1_classes)
 
-        elif isinstance(self.regularizer, Ridge):
+        # each estimated feature costs one coefficient per free class
+        design = jnp.concatenate(x_leaf, axis=1)
+        if isinstance(self.regularizer, Ridge):
             # For Ridge, use total parameters
-            return (n_samples - n_m1_classes * n_features - n_m1_classes) * jnp.ones(
-                n_neurons
-            )
-
+            n_est = self._n_estimated_features(design)
         else:
             # For UnRegularized, use the rank
-            rank = jnp.linalg.matrix_rank(jnp.concatenate(x_leaf, axis=1))
-            return (n_samples - rank * n_m1_classes - n_m1_classes) * jnp.ones(
-                n_neurons
-            )
+            n_est = self._design_rank(design)
+        return (n_samples - n_est * n_m1_classes - n_m1_classes) * jnp.ones(n_neurons)
 
     def simulate(
         self,

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -1631,6 +1631,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         ... )
         >>> for key, value in model.get_params().items():
         ...     print(f"{key}: {value}")
+        fit_intercept: True
         inverse_link_function: <function one_over_x at ...>
         observation_model: GammaObservations()
         regularizer: Ridge()
@@ -1644,6 +1645,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         >>> # Model has the same parameters before and after load
         >>> for key, value in model.get_params().items():  # doctest: +ELLIPSIS
         ...     print(f"{key}: {value}")
+        fit_intercept: True
         inverse_link_function: <function one_over_x at ...>
         observation_model: GammaObservations()
         regularizer: Ridge()
@@ -1665,6 +1667,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         >>> # Now the loaded model will have the updated solver_name and solver_kwargs
         >>> for key, value in loaded_model.get_params().items():
         ...     print(f"{key}: {value}")
+        fit_intercept: True
         inverse_link_function: <function <lambda> at ...>
         observation_model: PoissonObservations()
         regularizer: UnRegularized()

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -35,7 +35,10 @@ from ..solvers._hess import (
 from ..type_casting import cast_to_jax, support_pynapple
 from ..typing import DESIGN_INPUT_TYPE, SolverState, StepResult
 from ..utils import _elementwise_derivative, format_repr
-from .initialize_parameters import initialize_intercept_matching_mean_rate
+from .initialize_parameters import (
+    initialize_constant_coef_matching_mean_rate,
+    initialize_intercept_matching_mean_rate,
+)
 from .params import GLMParams, GLMUserParams
 from .validation import (
     GLMValidator,
@@ -798,7 +801,14 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         """Initialize the parameters based on the structure and dimensions X and y.
 
         This method initializes the coefficients (spike basis coefficients) and intercepts (bias terms)
-        required for the GLM. The coefficients are initialized to zeros with dimensions based on the input X.
+        required for the GLM.
+
+        If ``fit_intercept==True``:
+            - The coefficients are initialized to zeros with dimensions based on the input X.
+        If ``fit_intercept==False``:
+            - The coefficients are initialized to a constant that minimizes the min squared error
+            between ``X @ coef`` and the linked mean firing rate (``log(mean(y))`` for a GLM with
+            exponential non-linearity).
         If X is a pytree of arrays, the coefficients retain the pytree structure with
         arrays of zeros shaped according to the features in X.
         If X is a simple ndarray, the coefficients are initialized as a 2D array. The intercepts are initialized
@@ -828,13 +838,21 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             data = X
 
         empty_params = self._validator.get_empty_params(data, y)
-
-        initial_intercept = initialize_intercept_matching_mean_rate(
-            self._inverse_link_function, y
-        )
-        initial_coef = jax.tree_util.tree_map(
-            lambda x: jnp.zeros(x.shape), empty_params.coef
-        )
+        if self._fit_intercept:
+            initial_intercept = initialize_intercept_matching_mean_rate(
+                self._inverse_link_function, y
+            )
+            initial_coef = jax.tree_util.tree_map(
+                lambda x: jnp.zeros(x.shape), empty_params.coef
+            )
+        else:
+            initial_intercept = jnp.zeros_like(empty_params.intercept)
+            initial_coef = initialize_constant_coef_matching_mean_rate(
+                self._inverse_link_function,
+                data,
+                y,
+                empty_params.coef,
+            )
 
         init_params = eqx.tree_at(
             lambda p: (p.coef, p.intercept),

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -60,6 +60,16 @@ REGRESSION_GLM_TYPES = Union[
 ]
 
 
+def _broadcast_mask_to(mask: jnp.ndarray, coef: jnp.ndarray) -> jnp.ndarray:
+    """Add trailing singleton axes so ``mask`` broadcasts against ``coef``.
+
+    The mask is spelled ``(n_features, n_neurons)``: it says which features reach which
+    neuron and knows nothing about axes the coefficients add beyond that (the classes of
+    a classifier). A no-op when the two already share a shape.
+    """
+    return mask.reshape(mask.shape + (1,) * (coef.ndim - mask.ndim))
+
+
 def _glm_hessian_block(
     X,
     eta,
@@ -1334,12 +1344,32 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             return n_samples - resid_dof - 1
 
         elif isinstance(self.regularizer, Ridge):
-            # for Ridge, use the tot parameters (X.shape[1] + intercept)
-            return (n_samples - X.shape[1] - 1) * jnp.ones_like(params.intercept)
+            # for Ridge, use the tot parameters (estimated features + intercept)
+            return (n_samples - self._n_estimated_features(X) - 1) * jnp.ones_like(
+                params.intercept
+            )
         else:
             # for UnRegularized, use the rank
-            rank = jnp.linalg.matrix_rank(X)
-            return (n_samples - rank - 1) * jnp.ones_like(params.intercept)
+            return (n_samples - self._design_rank(X) - 1) * jnp.ones_like(
+                params.intercept
+            )
+
+    def _n_estimated_features(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Count the coefficients the model estimates, as a scalar or one per neuron.
+
+        Every column of the design contributes a coefficient here. ``PopulationGLM``
+        overrides this: a masked-out feature is not estimated for that neuron.
+        """
+        return X.shape[1]
+
+    def _design_rank(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Rank of the design, as a scalar or one per neuron.
+
+        The rank, rather than the column count, is what an unpenalized fit consumes:
+        collinear columns share degrees of freedom. ``PopulationGLM`` overrides this to
+        take the rank per neuron, since the mask gives each neuron its own design.
+        """
+        return jnp.linalg.matrix_rank(X)
 
     def _initialize_optimizer_and_state(
         self,
@@ -1997,13 +2027,39 @@ class PopulationGLM(GLM):
             # then sum across all features and add the intercept, before
             # passing to the inverse link function
             tree_utils.pytree_map_and_reduce(
-                lambda x, w, m: jnp.einsum("ti, i...->t...", x, w * m),
+                lambda x, w, m: jnp.einsum(
+                    "ti, i...->t...", x, w * _broadcast_mask_to(m, w)
+                ),
                 sum,
                 X,
                 params.coef,
                 feature_mask,
             )
             + params.intercept
+        )
+
+    def _n_estimated_features(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Count the features the mask lets through, per neuron.
+
+        A masked-out coefficient contributes nothing to the rate and is never estimated,
+        so it must not be charged against the residual degrees of freedom.
+        """
+        if self._feature_mask is None:
+            return super()._n_estimated_features(X)
+        mask = jnp.concatenate(jax.tree_util.tree_leaves(self._feature_mask), axis=0)
+        return jnp.sum(mask, axis=0)
+
+    def _design_rank(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Rank of each neuron's own design, after its masked columns are dropped.
+
+        Zeroing the masked columns leaves the rank unchanged relative to deleting them,
+        so this stays a plain array op rather than a boolean index.
+        """
+        if self._feature_mask is None:
+            return super()._design_rank(X)
+        mask = jnp.concatenate(jax.tree_util.tree_leaves(self._feature_mask), axis=0)
+        return jax.vmap(lambda m: jnp.linalg.matrix_rank(X * m), in_axes=1, out_axes=0)(
+            mask
         )
 
     def _get_hess_fn(self):

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -196,6 +196,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         a warning will be raised and the strength will default to 1.0.
         For finer control, the user can pass a pytree that matches the
         parameter structure to regularize parameters differentially.
+    fit_intercept :
+        When True (default), an intercept term is fit. When False, only the coefficients are fit.
     solver_name :
         Solver to use for model optimization. Defines the optimization scheme and related parameters.
         The solver must be an appropriate match for the chosen regularizer.
@@ -340,6 +342,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         inverse_link_function: Optional[Callable] = None,
         regularizer: Optional[Union[str, Regularizer]] = None,
         regularizer_strength: Any = None,
+        fit_intercept: bool = True,
         solver_name: str = None,
         solver_kwargs: dict = None,
     ):
@@ -349,7 +352,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
         )
-
+        self.fit_intercept = fit_intercept
         self.observation_model = observation_model
         self.inverse_link_function = inverse_link_function
 
@@ -365,6 +368,16 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         self.dof_resid_ = None
         self.aux_ = None
         self._solver = None
+
+    @property
+    def fit_intercept(self) -> bool:
+        """Getter for ``fit_intercept`` property."""
+        return self._fit_intercept
+
+    @fit_intercept.setter
+    def fit_intercept(self, value):
+        """Setter for ``fit_intercept`` property."""
+        self._fit_intercept = bool(value)
 
     @property
     def solver(self):
@@ -1692,6 +1705,8 @@ class PopulationGLM(GLM):
         a warning will be raised and the strength will default to 1.0.
         For finer control, the user can pass a pytree that matches the
         parameter structure to regularize parameters differentially.
+    fit_intercept :
+        When True (default), an intercept term is fit. When False, only the coefficients are fit.
     solver_name :
         Solver to use for model optimization. Defines the optimization scheme and related parameters.
         The solver must be an appropriate match for the chosen regularizer.
@@ -1820,6 +1835,7 @@ class PopulationGLM(GLM):
         inverse_link_function: Optional[Callable] = None,
         regularizer: Union[str, Regularizer] = "UnRegularized",
         regularizer_strength: Any = None,
+        fit_intercept: bool = True,
         solver_name: str = None,
         solver_kwargs: dict = None,
         feature_mask: Optional[jnp.ndarray] = None,
@@ -1830,6 +1846,7 @@ class PopulationGLM(GLM):
             inverse_link_function=inverse_link_function,
             regularizer_strength=regularizer_strength,
             regularizer=regularizer,
+            fit_intercept=fit_intercept,
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
             **kwargs,

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -355,13 +355,13 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
         )
-        self.fit_intercept = fit_intercept
         self.observation_model = observation_model
         self.inverse_link_function = inverse_link_function
 
         self._validator = self._validator_class(
             extra_params=self._get_validator_extra_params()
         )
+        self.fit_intercept = fit_intercept
 
         # initialize to None fit output
         self.intercept_ = None
@@ -381,6 +381,9 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     def fit_intercept(self, value):
         """Setter for ``fit_intercept`` property."""
         self._fit_intercept = bool(value)
+        self._active_params = self._validator.to_model_params(
+            (True, self._fit_intercept)
+        )
 
     @property
     def solver(self):
@@ -865,6 +868,31 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         )
         return init_params
 
+    def _normalize_user_params(
+        self, init_params: GLMUserParams, X: DESIGN_INPUT_TYPE, y: jnp.ndarray
+    ) -> GLMUserParams:
+        """Fill the intercept when it is held fixed (``fit_intercept=False``).
+
+        When the intercept is not estimated the user may omit it (pass ``None`` as the
+        last element); it is replaced with zeros so downstream validation and
+        partitioning see a complete parameter set. A warning is emitted if the user
+        supplied an intercept, since it would be ignored. See
+        :meth:`nemos.base_regressor.BaseRegressor._normalize_user_params` for how this
+        fits the parameter-processing pipeline.
+        """
+        if not self._fit_intercept:
+            self._validator.check_user_params_structure(init_params)
+            if init_params[-1] is not None:
+                warnings.warn(
+                    "`fit_intercept=False`: the provided intercept is ignored and the "
+                    "intercept is held at zero. Set `fit_intercept=True` to estimate it.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            zeros = jnp.zeros_like(self._validator.get_empty_params(X, y).intercept)
+            init_params = tuple([*init_params[:-1], zeros])
+        return init_params
+
     @cast_to_jax
     def fit(
         self,
@@ -931,6 +959,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         if init_params is None:
             init_params = self._model_specific_initialization(X, y)
         else:
+            init_params = self._normalize_user_params(init_params, X, y)
             init_params = self._validator.validate_and_cast_params(init_params)
             self._validator.validate_consistency(init_params, X=X, y=y)
 
@@ -938,9 +967,11 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             getattr(self, "_feature_mask", None), init_params
         )
 
-        self._initialize_optimizer_and_state(init_params, data, y)
-
-        params, state, aux = self._optimizer_run(init_params, data, y)
+        # initialize the solver on the active parameters and run, holding the frozen
+        # parameters fixed (see BaseRegressor._run_optimizer).
+        params, state, aux = self._run_optimizer(
+            init_params, data, y, lambda active: self._optimizer_run(active, data, y)
+        )
 
         if tree_utils.pytree_map_and_reduce(
             lambda x: jnp.any(jnp.isnan(x)), any, params
@@ -976,7 +1007,6 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
                 "For the available options see the ``self.solver.__init__`` docstrings.",
                 RuntimeWarning,
             )
-
         self._set_model_params(params)
 
         self.dof_resid_ = self._estimate_resid_degrees_of_freedom(X)
@@ -1101,6 +1131,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         if init_params is None:
             init_params = self._model_specific_initialization(sample_X, sample_y)
         else:
+            init_params = self._normalize_user_params(init_params, sample_X, sample_y)
             init_params = self._validator.validate_and_cast_params(init_params)
             self._validator.validate_consistency(init_params, X=sample_X, y=sample_y)
 
@@ -1112,18 +1143,26 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         preprocessed_loader = _PreprocessedDataLoader(loader, self._preprocess_inputs)
 
         # TODO: Add a streaming version setting the right step- and batch size for SVRG that uses the full data
-        # Initialize solver (using preprocessed sample batch)
-        self._initialize_optimizer_and_state(init_params, sample_X, sample_y)
-        self._warn_about_estimated_svrg_settings()
+        # Run stochastic optimization on the active parameters, holding the frozen
+        # parameters fixed (see BaseRegressor._run_optimizer). The context is created
+        # here so it is available after the run (for the summary); ``frozen`` is set
+        # inside the closure so ``ctx.params`` exposes the complete parameters to
+        # callbacks. ``stochastic_run`` sets ``ctx.solver`` itself.
+        ctx = TrainingContext(model=self)
 
-        # Run stochastic optimization
-        ctx = TrainingContext(model=self, solver=self._solver)
-        params, state, aux = self._solver.stochastic_run(
-            init_params,
-            preprocessed_loader,
-            n_passes=n_passes,
-            callback=_normalize_callbacks(callbacks),
-            ctx=ctx,
+        def _stochastic_run(active):
+            ctx.frozen = self._frozen_params
+            self._warn_about_estimated_svrg_settings()
+            return self._solver.stochastic_run(
+                active,
+                preprocessed_loader,
+                n_passes=n_passes,
+                callback=_normalize_callbacks(callbacks),
+                ctx=ctx,
+            )
+
+        params, state, aux = self._run_optimizer(
+            init_params, sample_X, sample_y, _stochastic_run
         )
 
         if tree_utils.pytree_map_and_reduce(
@@ -1377,7 +1416,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         init_params: GLMParams,
         X: dict[str, jnp.ndarray] | jnp.ndarray,
         y: jnp.ndarray,
-    ) -> SolverState:
+        frozen_params: GLMParams = None,
+    ) -> Tuple[SolverState, GLMParams, GLMParams]:
         """Initialize the solver by instantiating its init_state, update and, run methods.
 
         This method also prepares the solver's state by using the initialized model parameters and data.
@@ -1412,7 +1452,10 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         opt_solver_kwargs = self._optimize_solver_params(X, y)
         #  set up the solver init/run/update attrs
         self._solver = self._instantiate_solver(
-            self._compute_loss, init_params=init_params, solver_kwargs=opt_solver_kwargs
+            self._compute_loss,
+            init_params=init_params,
+            solver_kwargs=opt_solver_kwargs,
+            frozen_params=frozen_params,
         )
         self._optimizer_init_state = self._solver.init_state
         self._optimizer_update = self._solver.update
@@ -1500,10 +1543,14 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         # should be fine
         params = self._validator.to_model_params(params)
 
+        active, _ = self._partition_active(params)
+
         # perform a one-step update
         updated_params, updated_state, aux = self._optimizer_update(
-            params, opt_state, data, y, *args, **kwargs
+            active, opt_state, data, y, *args, **kwargs
         )
+
+        updated_params = eqx.combine(updated_params, self._frozen_params)
 
         # store params and state
         self._set_model_params(updated_params)

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -315,14 +315,21 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     # semidefinite; a strictly positive-definite regularizer (e.g. Ridge) promotes
     # it to positive definite via ``combine_hessian_tags``.
     _hess_tag: HessianTag = HessianTag(structure=Full, property=PositiveSemiDefinite)
+    # default until the instance sets it; read during ``__init__`` before assignment
+    # (e.g. when solver-kwargs validation resolves the default solver).
+    _fit_intercept: bool = True
 
     def _resolve_default_solver(self) -> str:
         # Newton is the default for Ridge: the ridge penalty makes the penalized
         # Hessian positive definite, so the Cholesky-based Newton step is stable.
         # For other regularizers (e.g. UnRegularized, whose Hessian can be only
         # positive semidefinite) defer to the regularizer's own default.
-        if isinstance(self.regularizer, Ridge) and (
-            "Newton" in self.regularizer.allowed_solvers
+        # Newton's Hessian is not partition-aware, so a frozen intercept
+        # (``fit_intercept=False``) also defers to the regularizer default.
+        if (
+            self._fit_intercept
+            and isinstance(self.regularizer, Ridge)
+            and ("Newton" in self.regularizer.allowed_solvers)
         ):
             return "Newton"
         return super()._resolve_default_solver()
@@ -380,10 +387,14 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     @fit_intercept.setter
     def fit_intercept(self, value):
         """Setter for ``fit_intercept`` property."""
-        self._fit_intercept = bool(value)
-        self._active_params = self._validator.to_model_params(
-            (True, self._fit_intercept)
-        )
+        value = bool(value)
+        flipped = value != self._fit_intercept
+        self._fit_intercept = value
+        self._active_params = self._validator.to_model_params((True, value))
+        # only when the frozen set actually changes: the captured partition and the
+        # solver closed over the previous frozen values are then stale.
+        if flipped:
+            self._invalidate_solver()
 
     @property
     def solver(self):
@@ -1392,6 +1403,11 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
                 )
 
         params = self._get_model_params()
+        # count dof only over the parameters the solver estimates: frozen leaves
+        # (e.g. the intercept when ``fit_intercept=False``) are None in the active
+        # tree and consume no degrees of freedom.
+        active, _ = self._partition_active(params)
+        intercept_dof = 0 if active.intercept is None else 1
         # if the regularizer is lasso use the non-zero
         # coeff as an estimate of the dof
         # see https://arxiv.org/abs/0712.0881
@@ -1399,17 +1415,23 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             resid_dof = tree_utils.pytree_map_and_reduce(
                 lambda x: ~jnp.isclose(x, jnp.zeros_like(x)),
                 lambda x: sum([jnp.sum(i, axis=0) for i in x]),
-                params.coef,
+                active.coef,
             )
-            return n_samples - resid_dof - 1
+            return n_samples - resid_dof - intercept_dof
 
         elif isinstance(self.regularizer, Ridge):
-            # for Ridge, use the tot parameters (X.shape[1] + intercept)
-            return (n_samples - X.shape[1] - 1) * jnp.ones_like(params.intercept)
+            # for Ridge, use the total number of estimated parameters
+            # (active coefficients + intercept when it is fit)
+            n_coef = sum(
+                leaf.shape[0] for leaf in jax.tree_util.tree_leaves(active.coef)
+            )
+            return (n_samples - n_coef - intercept_dof) * jnp.ones_like(
+                params.intercept
+            )
         else:
             # for UnRegularized, use the rank
             rank = jnp.linalg.matrix_rank(X)
-            return (n_samples - rank - 1) * jnp.ones_like(params.intercept)
+            return (n_samples - rank - intercept_dof) * jnp.ones_like(params.intercept)
 
     def _initialize_optimizer_and_state(
         self,
@@ -1417,7 +1439,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         X: dict[str, jnp.ndarray] | jnp.ndarray,
         y: jnp.ndarray,
         frozen_params: GLMParams = None,
-    ) -> Tuple[SolverState, GLMParams, GLMParams]:
+    ) -> SolverState:
         """Initialize the solver by instantiating its init_state, update and, run methods.
 
         This method also prepares the solver's state by using the initialized model parameters and data.

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -318,6 +318,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     # default until the instance sets it; read during ``__init__`` before assignment
     # (e.g. when solver-kwargs validation resolves the default solver).
     _fit_intercept: bool = True
+    # full-structure all-None default so the partition helpers never see a bare None
+    _fix_params: GLMParams[None | jnp.ndarray] = GLMParams(None, None)
 
     def _resolve_default_solver(self) -> str:
         # Newton is the default for Ridge: the ridge penalty makes the penalized
@@ -394,6 +396,24 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         # solver closed over the previous frozen values are then stale.
         if flipped:
             self._invalidate_solver()
+
+    def _active_filter_spec(self) -> GLMParams[bool]:
+        active = super()._active_filter_spec()
+        # ``fit_intercept=False`` freezes the intercept at the value
+        # ``_normalize_user_params`` fills into the init params (zeros by default).
+        if not self._fit_intercept:
+            active = GLMParams(active.coef, False)
+        return active
+
+    def _frozen_values(self, X: DESIGN_INPUT_TYPE, y: jnp.ndarray) -> GLMParams:
+        frozen = super()._frozen_values(X, y)
+        # ``fit_intercept=False`` pins the intercept at zero; this is the single
+        # source of the pinned value (``_normalize_user_params`` fills it into
+        # omitted user input, ``update`` recombines it into the returned params).
+        if not self._fit_intercept:
+            zeros = jnp.zeros_like(self._validator.get_empty_params(X, y).intercept)
+            frozen = GLMParams(frozen.coef, zeros)
+        return frozen
 
     @property
     def solver(self):
@@ -899,7 +919,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
                     UserWarning,
                     stacklevel=2,
                 )
-            zeros = jnp.zeros_like(self._validator.get_empty_params(X, y).intercept)
+            zeros = self._frozen_values(X, y).intercept
             init_params = tuple([*init_params[:-1], zeros])
         return init_params
 
@@ -977,11 +997,12 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             getattr(self, "_feature_mask", None), init_params
         )
 
-        # initialize the solver on the active parameters and run, holding the frozen
-        # parameters fixed (see BaseRegressor._run_optimizer).
-        params, state, aux = self._run_optimizer(
-            init_params, data, y, lambda active: self._optimizer_run(active, data, y)
-        )
+        # optimize the active parameters with the loss closed over the frozen ones,
+        # then recombine
+        active, frozen = self._partition_active(init_params)
+        self._initialize_optimizer_and_state(active, data, y, frozen_params=frozen)
+        params, state, aux = self._optimizer_run(active, data, y)
+        params = eqx.combine(params, frozen)
 
         if tree_utils.pytree_map_and_reduce(
             lambda x: jnp.any(jnp.isnan(x)), any, params
@@ -1153,27 +1174,27 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         preprocessed_loader = _PreprocessedDataLoader(loader, self._preprocess_inputs)
 
         # TODO: Add a streaming version setting the right step- and batch size for SVRG that uses the full data
-        # Run stochastic optimization on the active parameters, holding the frozen
-        # parameters fixed (see BaseRegressor._run_optimizer). The context is created
-        # here so it is available after the run (for the summary); ``frozen`` is set
-        # inside the closure so ``ctx.params`` exposes the complete parameters to
-        # callbacks. ``stochastic_run`` sets ``ctx.solver`` itself.
+        # Run stochastic optimization on the active parameters with the loss closed
+        # over the frozen ones, then recombine. The context is created here so it is
+        # available after the run (for the summary); ``ctx.frozen`` lets ``ctx.params``
+        # expose the complete parameters to callbacks. ``stochastic_run`` sets
+        # ``ctx.solver`` itself.
         ctx = TrainingContext(model=self)
 
-        def _stochastic_run(active):
-            ctx.frozen = self._fix_params
-            self._warn_about_estimated_svrg_settings()
-            return self._solver.stochastic_run(
-                active,
-                preprocessed_loader,
-                n_passes=n_passes,
-                callback=_normalize_callbacks(callbacks),
-                ctx=ctx,
-            )
-
-        params, state, aux = self._run_optimizer(
-            init_params, sample_X, sample_y, _stochastic_run
+        active, frozen = self._partition_active(init_params)
+        self._initialize_optimizer_and_state(
+            active, sample_X, sample_y, frozen_params=frozen
         )
+        ctx.frozen = frozen
+        self._warn_about_estimated_svrg_settings()
+        params, state, aux = self._solver.stochastic_run(
+            active,
+            preprocessed_loader,
+            n_passes=n_passes,
+            callback=_normalize_callbacks(callbacks),
+            ctx=ctx,
+        )
+        params = eqx.combine(params, frozen)
 
         if tree_utils.pytree_map_and_reduce(
             lambda x: jnp.any(jnp.isnan(x)), any, params
@@ -1571,7 +1592,10 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             active, opt_state, data, y, *args, **kwargs
         )
 
-        updated_params = eqx.combine(updated_params, self._fix_params)
+        # the frozen leaves are pinned by the model settings — the same values the
+        # loss closure was built with — not by the params the caller passes in, so
+        # a frozen leaf may be omitted (None) in ``params``.
+        updated_params = eqx.combine(updated_params, self._frozen_values(X, y))
 
         # store params and state
         self._set_model_params(updated_params)

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -318,6 +318,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     # default until the instance sets it; read during ``__init__`` before assignment
     # (e.g. when solver-kwargs validation resolves the default solver).
     _fit_intercept: bool = True
+    _active_params: GLMParams = GLMParams(True, True)
 
     def _resolve_default_solver(self) -> str:
         # Newton is the default for Ridge: the ridge penalty makes the penalized
@@ -390,7 +391,9 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         value = bool(value)
         flipped = value != self._fit_intercept
         self._fit_intercept = value
-        self._active_params = self._validator.to_model_params((True, value))
+        self._active_params = self._validator.to_model_params(
+            (self._active_params.coef, value)
+        )
         # only when the frozen set actually changes: the captured partition and the
         # solver closed over the previous frozen values are then stale.
         if flipped:

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Literal, Optional, Tuple, Union
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, NDArray
 from sklearn.utils import InputTags, TargetTags
 
 from .. import observation_models as obs
@@ -336,12 +336,8 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         # Hessian positive definite, so the Cholesky-based Newton step is stable.
         # For other regularizers (e.g. UnRegularized, whose Hessian can be only
         # positive semidefinite) defer to the regularizer's own default.
-        # Newton's Hessian is not partition-aware, so a frozen intercept
-        # (``fit_intercept=False``) also defers to the regularizer default.
-        if (
-            self._fit_intercept
-            and isinstance(self.regularizer, Ridge)
-            and ("Newton" in self.regularizer.allowed_solvers)
+        if isinstance(self.regularizer, Ridge) and (
+            "Newton" in self.regularizer.allowed_solvers
         ):
             return "Newton"
         return super()._resolve_default_solver()
@@ -2040,6 +2036,9 @@ class PopulationGLM(GLM):
         self._feature_mask = self._validator.validate_and_cast_feature_mask(
             feature_mask
         )
+        # the loss and the Hessian read the mask at call time, so a solver built
+        # against the previous mask is stale.
+        self._invalidate_solver()
 
     @strip_metadata(arg_num=1, arg_name="y")
     def fit(
@@ -2193,24 +2192,34 @@ class PopulationGLM(GLM):
             mask
         )
 
-    def _get_hess_fn(self):
-        def per_neuron(params, X, y, mask):
+    def _get_hess_fn(self, frozen: Optional[GLMParams] = None) -> Callable:
+        # differentiating the combined loss with respect to the active subtree alone
+        # yields the active block of the Hessian directly, no slicing needed.
+        # ``batch_axes`` is prefix-spelled (one entry for all of ``coef``) while the
+        # filter spec is per-leaf, so expand before splitting the axes.
+        active_axis, frozen_axis = self._partition_active(
+            tree_utils.tree_broadcast_prefix(
+                self._hess_tag.batch_axes, self._active_filter_spec()
+            )
+        )
+
+        def per_neuron(params, X, y, mask, frozen_params):
             def loss(params):
+                params = eqx.combine(params, frozen_params)
                 rate = self._predict(params, X, feature_mask=mask)
                 return self._observation_model._negative_log_likelihood(y, rate)
 
             return jax.hessian(loss)(params)
 
         # the mask mirrors coef, so its neuron axis is coef's
-        return lambda params, X, y: jax.vmap(
-            per_neuron,
-            in_axes=(
-                self._hess_tag.batch_axes,
-                None,
-                1,
-                1,
-            ),
-        )(params, X, y, self._feature_mask)
+        vmap_per_neuron = jax.vmap(
+            per_neuron, in_axes=(active_axis, None, 1, 1, frozen_axis)
+        )
+
+        def hess_fn(params, X, y):
+            return vmap_per_neuron(params, X, y, self._feature_mask, frozen)
+
+        return hess_fn
 
     def __sklearn_clone__(self) -> PopulationGLM:
         """Clone the PopulationGLM, dropping feature_mask."""

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -318,7 +318,6 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     # default until the instance sets it; read during ``__init__`` before assignment
     # (e.g. when solver-kwargs validation resolves the default solver).
     _fit_intercept: bool = True
-    _active_params: GLMParams = GLMParams(True, True)
 
     def _resolve_default_solver(self) -> str:
         # Newton is the default for Ridge: the ridge penalty makes the penalized
@@ -391,9 +390,6 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         value = bool(value)
         flipped = value != self._fit_intercept
         self._fit_intercept = value
-        self._active_params = self._validator.to_model_params(
-            (self._active_params.coef, value)
-        )
         # only when the frozen set actually changes: the captured partition and the
         # solver closed over the previous frozen values are then stale.
         if flipped:
@@ -1165,7 +1161,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         ctx = TrainingContext(model=self)
 
         def _stochastic_run(active):
-            ctx.frozen = self._frozen_params
+            ctx.frozen = self._fix_params
             self._warn_about_estimated_svrg_settings()
             return self._solver.stochastic_run(
                 active,
@@ -1575,7 +1571,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             active, opt_state, data, y, *args, **kwargs
         )
 
-        updated_params = eqx.combine(updated_params, self._frozen_params)
+        updated_params = eqx.combine(updated_params, self._fix_params)
 
         # store params and state
         self._set_model_params(updated_params)

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -410,9 +410,16 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         # ``fit_intercept=False`` pins the intercept at zero; this is the single
         # source of the pinned value (``_normalize_user_params`` fills it into
         # omitted user input, ``update`` recombines it into the returned params).
-        if not self._fit_intercept:
+        if not self._fit_intercept and frozen.intercept is None:
             zeros = jnp.zeros_like(self._validator.get_empty_params(X, y).intercept)
             frozen = GLMParams(frozen.coef, zeros)
+        if frozen.coef is None:
+            frozen = eqx.tree_at(
+                lambda p: p.coef,
+                frozen,
+                jax.tree_util.tree_map(lambda _: None, X, is_leaf=lambda x: x is None),
+                is_leaf=lambda x: x is None,
+            )
         return frozen
 
     @property

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Literal, Optional, Tuple, Union
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 from sklearn.utils import InputTags, TargetTags
 
 from .. import observation_models as obs

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -1960,9 +1960,12 @@ class PopulationGLM(GLM):
     """
 
     _validator_class = PopulationGLMValidator
+    # positive semidefinite like the single-neuron GLM: the unpenalized block can be
+    # singular (a masked-out coefficient has no curvature). Ridge promotes it to
+    # positive definite through ``_hess_property_override``.
     _hess_tag: HessianTag = HessianTag(
         structure=BlockDiagonal,
-        property=PositiveDefinite,
+        property=PositiveSemiDefinite,
         batch_axes=GLMParams(1, 0),
     )
 

--- a/src/nemos/glm/initialize_parameters.py
+++ b/src/nemos/glm/initialize_parameters.py
@@ -177,11 +177,11 @@ def initialize_intercept_matching_mean_rate(
 
 def initialize_constant_coef_matching_mean_rate(
     inverse_link_function: Callable,
-    X: Union[dict, jnp.ndarray],
+    X: Union[Pytree, jnp.ndarray],
     y: jnp.ndarray,
     empty_coef: Union[Pytree, jnp.ndarray],
     eps: Optional[float] = None,
-) -> Union[dict, jnp.ndarray]:
+) -> Union[Pytree, jnp.ndarray]:
     r"""
     Initialize coefficients as a constant matching the mean rate, with no intercept.
 
@@ -255,4 +255,6 @@ def initialize_constant_coef_matching_mean_rate(
     scale = (jnp.sum(row_sum) + eps) / (jnp.sum(row_sum**2) + eps)
     const = eta_target * scale  # (n_out,)
 
-    return jax.tree_util.tree_map(lambda leaf: jnp.ones(leaf.shape) * const, empty_coef)
+    return jax.tree_util.tree_map(
+        lambda leaf: (jnp.ones_like(leaf) * const).astype(leaf.dtype), empty_coef
+    )

--- a/src/nemos/glm/initialize_parameters.py
+++ b/src/nemos/glm/initialize_parameters.py
@@ -255,6 +255,4 @@ def initialize_constant_coef_matching_mean_rate(
     scale = (jnp.sum(row_sum) + eps) / (jnp.sum(row_sum**2) + eps)
     const = eta_target * scale  # (n_out,)
 
-    return jax.tree_util.tree_map(
-        lambda leaf: (jnp.ones_like(leaf) * const).astype(leaf.dtype), empty_coef
-    )
+    return jax.tree_util.tree_map(lambda leaf: jnp.full_like(leaf, const), empty_coef)

--- a/src/nemos/glm/initialize_parameters.py
+++ b/src/nemos/glm/initialize_parameters.py
@@ -1,6 +1,6 @@
 """Initialization of GLM parameters."""
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import jax
 import jax.numpy as jnp
@@ -15,6 +15,7 @@ from ..inverse_link_function_utils import (
     norm_cdf,
     softplus,
 )
+from ..typing import Pytree
 from ..utils import one_over_x
 
 
@@ -172,3 +173,86 @@ def initialize_intercept_matching_mean_rate(
         raise non_finite_error
 
     return out
+
+
+def initialize_constant_coef_matching_mean_rate(
+    inverse_link_function: Callable,
+    X: Union[dict, jnp.ndarray],
+    y: jnp.ndarray,
+    empty_coef: Union[Pytree, jnp.ndarray],
+    eps: Optional[float] = None,
+) -> Union[dict, jnp.ndarray]:
+    r"""
+    Initialize coefficients as a constant matching the mean rate, with no intercept.
+
+    When the intercept is held fixed at zero, coefficients initialized to zero would
+    force the linear predictor to zero and, for example, imply an unreasonably high
+    firing rate for a Poisson GLM with an exponential link. Instead, this sets every
+    coefficient to a single constant ``c`` (per output), so that the linear predictor is
+
+    .. math::
+        \eta_t = \sum_j X_{tj}\, c = c\, s_t, \qquad s_t = \sum_j X_{tj},
+
+    where :math:`s_t` is the row-sum of the design matrix. The constant is chosen as the
+    least-squares projection of the uniform offset :math:`\eta^\star` (the value a free
+    intercept would take, i.e. the inverse link of the mean rate) onto :math:`s` (see Notes):
+
+    .. math::
+        c = \eta^\star\, \frac{\sum_t s_t + \varepsilon}{\sum_t s_t^2 + \varepsilon},
+
+    so the linear predictor stays close to :math:`\eta^\star` regardless of how large
+    ``c`` grows. :math:`\varepsilon` is the numerical precision, introduced to get finite
+    ``c`` even when :math:`s_t` is identically zero.
+
+    Parameters
+    ----------
+    inverse_link_function :
+        The inverse link function of the model.
+    X :
+        The design matrix, an array of shape ``(n_samples, n_features)`` or a pytree of
+        such arrays. NaNs are ignored when forming the row-sum.
+    y :
+        The neural activity, shape ``(n_samples,)`` for single-output regressors such as
+        ``GLM`` or ``(n_samples, n_neurons)`` for multi-output regressors such as
+        ``PopulationGLM``.
+    empty_coef :
+        A pytree matching the target coefficient structure and shapes (e.g. as returned
+        by the validator's ``get_empty_params``). Used only for its leaf shapes.
+    eps :
+        Stabilization added to both numerator and denominator. Defaults to the machine
+        epsilon of the row-sum dtype, which only intervenes when the design row-sums are
+        numerically zero and is otherwise negligible.
+
+    Returns
+    -------
+    :
+        The initialized coefficients, matching the structure and shapes of ``empty_coef``.
+
+    Notes
+    -----
+    The constant :math:`c \in \mathbb{R}` is the minimizer of
+
+    .. math::
+        \mathcal{L}(c) = \sum_t \left(c\, s_t - \eta^\star\right)^2,
+
+    where :math:`\eta^\star` is the linear-predictor value whose inverse link matches the
+    mean rate (:math:`\text{inverse\_link}(\eta^\star) = \bar{y}`), and
+    :math:`s_t = \sum_j X_{tj}` is the sum of the design over features. Setting
+    :math:`\mathcal{L}'(c) = 0` gives the closed form above (with the
+    :math:`\varepsilon` terms added for numerical stability). The problem is degenerate
+    only when :math:`s \equiv 0`, in which case no constant coefficient can inject an
+    offset and the :math:`\varepsilon` stabilization keeps :math:`c` finite.
+    """
+    # the linear-predictor target a free intercept would supply, shape (n_out,)
+    eta_target = initialize_intercept_matching_mean_rate(inverse_link_function, y)
+
+    # row-sum of the design across all features of all leaves, shape (n_samples,)
+    row_sum = sum(jnp.nansum(leaf, axis=1) for leaf in jax.tree_util.tree_leaves(X))
+
+    if eps is None:
+        eps = jnp.finfo(row_sum.dtype).eps
+
+    scale = (jnp.sum(row_sum) + eps) / (jnp.sum(row_sum**2) + eps)
+    const = eta_target * scale  # (n_out,)
+
+    return jax.tree_util.tree_map(lambda leaf: jnp.ones(leaf.shape) * const, empty_coef)

--- a/src/nemos/glm/validation.py
+++ b/src/nemos/glm/validation.py
@@ -275,7 +275,7 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
         )
 
         shape_match = pytree_map_and_reduce(
-            lambda fm, coef: fm.shape == coef.shape,
+            lambda fm, coef: fm.shape == self._expected_mask_shape(coef),
             all,
             feature_mask,
             params.coef,
@@ -283,11 +283,22 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
         if not shape_match:
             raise ValueError(
                 "The ``feature_mask`` must match the shape of the ``coef``, leaf by leaf. "
-                f"Expected {jax.tree_util.tree_map(lambda c: c.shape, params.coef)}, "
+                f"Expected "
+                f"{jax.tree_util.tree_map(lambda c: self._expected_mask_shape(c), params.coef)}, "
                 f"got {jax.tree_util.tree_map(lambda m: m.shape, feature_mask)} instead. "
                 "A pytree mask holding one entry per neuron is no longer accepted; broadcast "
                 "it to the shape of the coefficients."
             )
+
+    @staticmethod
+    def _expected_mask_shape(coef: jnp.ndarray) -> tuple[int, ...]:
+        """Shape a ``feature_mask`` leaf must have to mask ``coef``.
+
+        The mask selects features, so it carries one entry per coefficient the model
+        estimates. Subclasses whose coefficients carry an axis the mask does not
+        distinguish (the classes of a classifier) drop that axis here.
+        """
+        return coef.shape
 
     def get_empty_params(self, X, y) -> GLMParams:
         """Return the param shape given the input data."""
@@ -386,6 +397,19 @@ class ClassifierGLMValidator(GLMValidator):
     extra_params: Dict[Literal["n_classes"], int] = field(kw_only=True)
     expected_param_dims: Tuple[int] = (2, 1)
     model_class: str = "ClassifierGLM"
+
+    @staticmethod
+    def _expected_mask_shape(coef: jnp.ndarray) -> tuple[int, ...]:
+        """Drop the trailing class axis: a feature is masked for a neuron or not at all.
+
+        Coefficients carry a class axis, but nothing distinguishes the classes when
+        deciding whether a feature reaches a neuron, and a mask free to vary across
+        classes would make the per-neuron residual degrees of freedom ambiguous. The
+        mask is therefore ``(n_features, n_neurons)`` (or ``(n_features,)`` for the
+        single-neuron classifier) and broadcasts over classes at prediction time.
+        """
+        return coef.shape[:-1]
+
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
         *RegressorValidator.params_validation_sequence[:2],
         (

--- a/src/nemos/glm_hmm/glm_hmm.py
+++ b/src/nemos/glm_hmm/glm_hmm.py
@@ -1587,8 +1587,13 @@ class GLMHMM(
         init_params: ModelParamsT,
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
+        frozen_params: Optional[ModelParamsT] = None,
     ) -> SolverState:
-        """Initialize the optimizer and state of the model."""
+        """Initialize the optimizer and state of the model.
+
+        ``frozen_params`` is accepted for signature compatibility with the base
+        entry points but ignored: the GLM-HMM does not support parameter freezing.
+        """
         # glm params m-step setup
         is_population = y.ndim > 1
         m_step_update = prepare_mstep_update_fn(

--- a/src/nemos/io/io.py
+++ b/src/nemos/io/io.py
@@ -74,6 +74,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     ... )
     >>> for key, value in model.get_params().items():
     ...     print(f"{key}: {value}")
+    fit_intercept: True
     inverse_link_function: <function one_over_x at ...>
     observation_model: GammaObservations()
     regularizer: Ridge()
@@ -87,6 +88,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     >>> # Model has the same parameters before and after load
     >>> for key, value in model.get_params().items():  # doctest: +ELLIPSIS
     ...     print(f"{key}: {value}")
+    fit_intercept: True
     inverse_link_function: <function one_over_x at ...>
     observation_model: GammaObservations()
     regularizer: Ridge()
@@ -105,6 +107,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     >>> # Now the loaded model will have the updated solver_name and solver_kwargs
     >>> for key, value in loaded_model.get_params().items():
     ...     print(f"{key}: {value}")
+    fit_intercept: True
     inverse_link_function: <function <lambda> at ...>
     observation_model: PoissonObservations()
     regularizer: UnRegularized()

--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -592,8 +592,8 @@ class Ridge(Regularizer):
             The Ridge penalization value.
         """
 
-        def l2_penalty(coeff: jnp.ndarray, leaf_strength: jnp.ndarray):
-            return 0.5 * jnp.sum(leaf_strength * jnp.square(coeff))
+        def l2_penalty(coef: jnp.ndarray, leaf_strength: jnp.ndarray):
+            return 0.5 * jnp.sum(leaf_strength * jnp.square(coef))
 
         return tree_utils.pytree_map_and_reduce(
             l2_penalty,
@@ -637,8 +637,8 @@ class Lasso(Regularizer):
             The Lasso penalization value.
         """
 
-        def l1_penalty(coeff: jnp.ndarray, leaf_strength: jnp.ndarray):
-            return jnp.sum(leaf_strength * jnp.abs(coeff))
+        def l1_penalty(coef: jnp.ndarray, leaf_strength: jnp.ndarray):
+            return jnp.sum(leaf_strength * jnp.abs(coef))
 
         return tree_utils.pytree_map_and_reduce(
             l1_penalty,
@@ -713,10 +713,10 @@ class ElasticNet(Regularizer):
             The Elastic Net penalization value.
         """
 
-        def net_penalty(coeff, leaf_strength):
+        def net_penalty(coef, leaf_strength):
             s, r = leaf_strength
-            quad = 0.5 * (1.0 - r) * jnp.square(coeff)
-            l1 = r * jnp.abs(coeff)
+            quad = 0.5 * (1.0 - r) * jnp.square(coef)
+            l1 = r * jnp.abs(coef)
             return jnp.sum(s * (quad + l1))
 
         return tree_utils.pytree_map_and_reduce(

--- a/src/nemos/tree_utils.py
+++ b/src/nemos/tree_utils.py
@@ -259,7 +259,7 @@ def tree_broadcast_prefix(prefix: Any, full: Any) -> Any:
     Examples
     --------
     >>> from nemos.tree_utils import tree_broadcast_prefix
-    >>> tree_broadcast_prefix({"a": 1, "b": 0}, {"a": {"x": None, "y": None}, "b": None})
+    >>> tree_broadcast_prefix({"a": 1, "b": 0}, {"a": {"x": True, "y": True}, "b": True})
     {'a': {'x': 1, 'y': 1}, 'b': 0}
     """
     treedef = jax.tree_util.tree_structure(prefix)

--- a/src/nemos/tree_utils.py
+++ b/src/nemos/tree_utils.py
@@ -233,6 +233,47 @@ def tree_take(data, i, axis=1, is_leaf=None):
     )
 
 
+def tree_broadcast_prefix(prefix: Any, full: Any) -> Any:
+    """Expand a prefix-spelled pytree to one entry per leaf of ``full``.
+
+    A prefix tree names a whole subtree with a single value, the way ``jax.vmap``
+    accepts ``in_axes=GLMParams(1, 0)`` for parameters whose ``coef`` is itself a
+    pytree. That spelling is only usable where JAX does the broadcasting; operations
+    that pair the tree leaf-by-leaf (``equinox.partition`` against a per-leaf filter
+    spec, for instance) need it expanded first, otherwise they fail on the structure
+    mismatch.
+
+    Parameters
+    ----------
+    prefix :
+        Pytree whose leaves each stand for a subtree of ``full``.
+    full :
+        Pytree giving the structure to expand to. Must extend ``prefix``.
+
+    Returns
+    -------
+    :
+        A pytree with the structure of ``full``, where every leaf carries the value
+        of the ``prefix`` leaf that covers it.
+
+    Examples
+    --------
+    >>> from nemos.tree_utils import tree_broadcast_prefix
+    >>> tree_broadcast_prefix({"a": 1, "b": 0}, {"a": {"x": None, "y": None}, "b": None})
+    {'a': {'x': 1, 'y': 1}, 'b': 0}
+    """
+    treedef = jax.tree_util.tree_structure(prefix)
+    return jax.tree_util.tree_unflatten(
+        treedef,
+        [
+            jax.tree_util.tree_map(lambda _: value, subtree)
+            for value, subtree in zip(
+                jax.tree_util.tree_leaves(prefix), treedef.flatten_up_to(full)
+            )
+        ],
+    )
+
+
 # The following functions are adapted from jaxopt.tree_utils
 
 tree_add = partial(jax.tree_util.tree_map, operator.add)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ from nemos.hmm.params import HMMParams
 from nemos.hmm.utils import initialize_session_starts
 from nemos.hmm.validation import HMMValidator, from_hmm_params, to_hmm_params
 from nemos.params import ModelParams
+from nemos.regularizer import UnRegularized
+from nemos.solvers import get_solver
 from nemos.tree_utils import tree_full_like
 
 _totals = defaultdict(float)
@@ -100,6 +102,39 @@ def all_subclasses(cls):
         seen.add(sub)
         stack.extend(sub.__subclasses__())
     return seen
+
+
+@pytest.fixture
+def setup_solver():
+    """Factory instantiating a nemos solver directly from an objective.
+
+    Returns a callable ``setup(objective, init_params, ...)`` that builds a solver
+    through the nemos solver registry (``get_solver``), bypassing model plumbing.
+    Useful for exercising a raw objective (e.g. a partition-wrapped ``_compute_loss``)
+    with the maintained solver stack. ``solver.run(init_params, *args)`` returns the
+    usual ``(params, state, aux)`` tuple.
+    """
+
+    def _setup(
+        objective,
+        init_params,
+        tol=1e-12,
+        solver_name="LBFGS",
+        regularizer_strength=0.0,
+        regularizer=None,
+        has_aux=False,
+    ):
+        solver_class = get_solver(solver_name).implementation
+        return solver_class(
+            objective,
+            init_params=init_params,
+            regularizer=UnRegularized() if regularizer is None else regularizer,
+            regularizer_strength=regularizer_strength,
+            has_aux=has_aux,
+            tol=tol,
+        )
+
+    return _setup
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,8 +189,8 @@ def _make_optimizer_run_patch(monkeypatch, model_cls):
     real_init = model_cls._initialize_optimizer_and_state
     noop = _NOOP_OPTIMIZER_RUN.get(model_cls, _DEFAULT_NOOP_OPTIMIZER_RUN)
 
-    def _patched(self, init_params, data, y):
-        result = real_init(self, init_params, data, y)
+    def _patched(self, init_params, data, y, *args, **kwargs):
+        result = real_init(self, init_params, data, y, *args, **kwargs)
         self._optimizer_run = noop
         return result
 
@@ -240,8 +240,8 @@ def _make_optimizer_update_patch(monkeypatch, model_cls):
     real_init = model_cls._initialize_optimizer_and_state
     noop = _NOOP_OPTIMIZER_UPDATE.get(model_cls, _DEFAULT_NOOP_OPTIMIZER_UPDATE)
 
-    def _patched(self, init_params, data, y):
-        result = real_init(self, init_params, data, y)
+    def _patched(self, init_params, data, y, *args, **kwargs):
+        result = real_init(self, init_params, data, y, *args, **kwargs)
         self._optimizer_update = noop
         return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,9 +239,7 @@ ModelFixture = namedtuple(
 )
 
 
-def initialize_feature_mask_for_population_glm(
-    X, n_neurons: int, n_classes: int = 0, coef=None
-):
+def initialize_feature_mask_for_population_glm(X, n_neurons: int, coef=None):
     """
     Create a feature mask of ones for PopulationGLM testing.
 
@@ -256,24 +254,19 @@ def initialize_feature_mask_for_population_glm(
         Number of neurons (determines the second dimension of the mask).
         Ignored if coef is provided.
     coef :
-        Optional coefficient array/pytree. If provided, the mask shape will match
-        coef shape exactly (required for ClassifierPopulationGLM).
-    n_classes:
-        Number of classes (determines the second dimension of the mask).
+        Optional coefficient array/pytree. If provided, the mask leaves are shaped like
+        the features-by-neurons block of the coefficients.
 
     Returns
     -------
     :
-        A feature mask with all ones, shaped like the coefficients it masks. If coef is
-        provided, returns ones_like(coef). Otherwise each leaf of X contributes a mask of
-        shape (n_features_in_leaf, n_neurons, *extra_shape).
+        A feature mask with all ones, of shape (n_features_in_leaf, n_neurons) leaf by
+        leaf. Classifier coefficients carry a trailing class axis, which the mask does
+        not distinguish and therefore drops.
     """
-    extra_shape = (n_classes,) if n_classes else ()
     if coef is not None:
-        return jax.tree_util.tree_map(lambda c: jnp.ones(c.shape), coef)
-    return jax.tree_util.tree_map(
-        lambda x: jnp.ones((x.shape[1], n_neurons, *extra_shape)), X
-    )
+        return jax.tree_util.tree_map(lambda c: jnp.ones(c.shape[:2]), coef)
+    return jax.tree_util.tree_map(lambda x: jnp.ones((x.shape[1], n_neurons)), X)
 
 
 DEFAULT_KWARGS = {

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -63,6 +63,7 @@ DEFAULT_OBS_SHAPE = {
 
 HARD_CODED_GET_PARAMS_KEYS = {
     "GLM": {
+        "fit_intercept",
         "inverse_link_function",
         "observation_model",
         "regularizer",
@@ -71,6 +72,7 @@ HARD_CODED_GET_PARAMS_KEYS = {
         "solver_name",
     },
     "ClassifierGLM": {
+        "fit_intercept",
         "inverse_link_function",
         "n_classes",
         "regularizer",
@@ -79,6 +81,7 @@ HARD_CODED_GET_PARAMS_KEYS = {
         "solver_name",
     },
     "ClassifierPopulationGLM": {
+        "fit_intercept",
         "inverse_link_function",
         "n_classes",
         "regularizer",
@@ -87,6 +90,7 @@ HARD_CODED_GET_PARAMS_KEYS = {
         "solver_name",
     },
     "PopulationGLM": {
+        "fit_intercept",
         "inverse_link_function",
         "observation_model",
         "regularizer",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -3353,9 +3353,11 @@ def _set_masked_state(model, is_cls, as_pytree):
     ],
 )
 @pytest.mark.parametrize("n_samples", [20])
+@pytest.mark.parametrize("fit_intercept", [True, False])
 @pytest.mark.requires_x64
 def test_estimate_dof_resid_feature_mask(
     n_samples,
+    fit_intercept,
     reg,
     dof_per_neuron,
     scales_with_classes,
@@ -3366,19 +3368,22 @@ def test_estimate_dof_resid_feature_mask(
     """A masked-out feature is not charged against a neuron's residual DOF.
 
     Each neuron sees its own design, so the result is one DOF per neuron. The Lasso
-    branch reads the non-zero coefficients and is therefore mask-independent.
+    branch reads the non-zero coefficients and is therefore mask-independent. The mask
+    and the frozen intercept are independent subtractions: freezing the intercept shifts
+    every neuron's DOF by the same amount, whatever the mask lets through.
     """
     _, _, model, _, _ = request.getfixturevalue(
         model_instantiation + ("_pytree" if as_pytree else "")
     )
-    model.set_params(regularizer=reg)
+    model.set_params(regularizer=reg, fit_intercept=fit_intercept)
 
     is_cls = "classifier" in model_instantiation
     X = _set_masked_state(model, is_cls, as_pytree)
 
     n_m1_classes = getattr(model, "n_classes", 2) - 1
     dof = dof_per_neuron * n_m1_classes if scales_with_classes else dof_per_neuron
-    expected = n_samples - dof - n_m1_classes
+    intercept_dof = n_m1_classes if fit_intercept else 0
+    expected = n_samples - dof - intercept_dof
 
     num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
     np.testing.assert_allclose(num, expected)
@@ -3392,14 +3397,16 @@ def test_estimate_dof_resid_feature_mask(
         (nmo.regularizer.Ridge(), _DOF_MASK_COUNT),
     ],
 )
+@pytest.mark.parametrize("fit_intercept", [True, False])
 @pytest.mark.requires_x64
 def test_dof_resid_after_fit_feature_mask(
-    reg, dof_per_neuron, request, patch_optimizer_run
+    reg, dof_per_neuron, fit_intercept, request, patch_optimizer_run
 ):
     """fit stores the per-neuron DOF of the masked model.
 
     The solver is a no-op returning ``init_params``, so the fitted coefficients are the
-    injected ones and the DOF is fully determined.
+    injected ones and the DOF is fully determined. With ``fit_intercept=False`` the
+    intercept is frozen out of the partition and costs no DOF.
     """
     _, _, model, _, _ = request.getfixturevalue(
         "population_poissonGLM_model_instantiation"
@@ -3407,6 +3414,7 @@ def test_dof_resid_after_fit_feature_mask(
     patch_optimizer_run(nmo.glm.PopulationGLM)
     model.set_params(
         regularizer=reg,
+        fit_intercept=fit_intercept,
         regularizer_strength=(
             None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.0
         ),
@@ -3418,8 +3426,19 @@ def test_dof_resid_after_fit_feature_mask(
     model.coef_, model.intercept_ = None, None
     y = np.ones((X.shape[0], _DOF_N_NEURONS))
 
-    model.fit(X, y, init_params=init_params)
-    np.testing.assert_allclose(model.dof_resid_, X.shape[0] - dof_per_neuron - 1)
+    # the injected init_params carry an intercept, which a frozen intercept discards
+    warns_ignored_intercept = (
+        does_not_raise()
+        if fit_intercept
+        else pytest.warns(UserWarning, match="the provided intercept is ignored")
+    )
+    with warns_ignored_intercept:
+        model.fit(X, y, init_params=init_params)
+
+    intercept_dof = 1 if fit_intercept else 0
+    np.testing.assert_allclose(
+        model.dof_resid_, X.shape[0] - dof_per_neuron - intercept_dof
+    )
 
 
 @pytest.mark.parametrize("glm_type", ["", "population_"])

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2410,7 +2410,7 @@ class TestGLMObservationModel:
         )
         self._fit_and_compare_to_sklearn(model, sklearn_model, X, y, atol=1e-6)
 
-    @pytest.mark.parametrize("solver_name", ["LBFGS"])
+    @pytest.mark.parametrize("solver_name", ["LBFGS", "Newton"])
     @pytest.mark.solver_related
     @pytest.mark.requires_x64
     @pytest.mark.filterwarnings("ignore:Setting penalty=None will ignore:UserWarning")
@@ -2440,7 +2440,7 @@ class TestGLMObservationModel:
         )
         assert jnp.all(model.intercept_ == 0.0)
 
-    @pytest.mark.parametrize("solver_name", ["GradientDescent", "LBFGS"])
+    @pytest.mark.parametrize("solver_name", ["GradientDescent", "LBFGS", "Newton"])
     @pytest.mark.solver_related
     @pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
     def test_fit_intercept_false_leaves_intercept_zero(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2,6 +2,7 @@ import inspect
 from contextlib import nullcontext as does_not_raise
 from copy import deepcopy
 from typing import Callable
+from unittest.mock import MagicMock
 
 import equinox as eqx
 import jax
@@ -1680,6 +1681,57 @@ class TestNormalizeUserParams:
         bad_params = (true_params.coef,) * n_elements
         with pytest.raises(ValueError, match="length two"):
             model._normalize_user_params(bad_params, X, y)
+
+
+@pytest.mark.parametrize(
+    "glm_class",
+    [
+        nmo.glm.GLM,
+        nmo.glm.PopulationGLM,
+        nmo.glm.ClassifierGLM,
+        nmo.glm.ClassifierPopulationGLM,
+    ],
+)
+class TestFitInterceptProperty:
+    """Tests for the ``GLM.fit_intercept`` property: getter, bool coercion, the
+    active-parameter partition it drives, and the solver-invalidation-on-flip
+    contract."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [(True, True), (False, False), (1, True), (0, False), ("x", True), ("", False)],
+    )
+    def test_value_is_coerced_to_bool(self, glm_class, value, expected):
+        model = glm_class()
+        model.fit_intercept = value
+        assert model.fit_intercept is expected
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_active_params_track_fit_intercept(self, glm_class, value):
+        """coef is always active; the intercept is active iff ``fit_intercept``."""
+        model = glm_class()
+        model.fit_intercept = value
+        assert model._active_params.coef == True  # noqa: E712
+        assert model._active_params.intercept == value
+
+    def test_invalidates_solver_only_on_flip(self, glm_class, monkeypatch):
+        """``_invalidate_solver`` runs only when the flag actually changes value,
+        not when it is re-assigned the same value."""
+        model = glm_class()  # constructed with the default fit_intercept=True
+        spy = MagicMock(wraps=model._invalidate_solver)
+        monkeypatch.setattr(model, "_invalidate_solver", spy)
+
+        model.fit_intercept = True  # no change
+        spy.assert_not_called()
+
+        model.fit_intercept = False  # flip
+        assert spy.call_count == 1
+
+        model.fit_intercept = False  # no change
+        assert spy.call_count == 1
+
+        model.fit_intercept = True  # flip back
+        assert spy.call_count == 2
 
 
 @pytest.mark.parametrize("glm_type", ["", "population_"])

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1631,6 +1631,57 @@ _PYTREE_X_FACTORIES = [
 ]
 
 
+class TestNormalizeUserParams:
+    """Unit tests for ``GLM._normalize_user_params`` (the ``fit_intercept=False`` seam)."""
+
+    @pytest.mark.filterwarnings("error::UserWarning")
+    def test_fit_intercept_true_is_passthrough(self, poissonGLM_model_instantiation):
+        """With ``fit_intercept=True`` the user params are returned unchanged."""
+        X, y, model, true_params, _ = poissonGLM_model_instantiation
+        model.fit_intercept = True
+        init_params = (true_params.coef, true_params.intercept)
+        assert model._normalize_user_params(init_params, X, y) is init_params
+
+    @pytest.mark.filterwarnings("error::UserWarning")
+    @pytest.mark.parametrize(
+        "supply_intercept, expectation",
+        [
+            (False, does_not_raise()),
+            (True, pytest.warns(UserWarning, match="fit_intercept=False")),
+        ],
+    )
+    def test_fit_intercept_false_fills_intercept_with_zeros(
+        self, poissonGLM_model_instantiation, supply_intercept, expectation
+    ):
+        """With ``fit_intercept=False`` the intercept is filled with zeros and the
+        coefficients are left untouched. Omitting the intercept (``None``) is accepted
+        quietly; supplying one raises a ``UserWarning`` and the value is ignored."""
+        X, y, model, true_params, _ = poissonGLM_model_instantiation
+        model.fit_intercept = False
+        intercept = true_params.intercept + 5.0 if supply_intercept else None
+
+        with expectation:
+            coef, out_intercept = model._normalize_user_params(
+                (true_params.coef, intercept), X, y
+            )
+
+        np.testing.assert_array_equal(coef, true_params.coef)
+        np.testing.assert_array_equal(
+            out_intercept, jnp.zeros_like(true_params.intercept)
+        )
+
+    @pytest.mark.parametrize("n_elements", [1, 3])
+    def test_malformed_structure_raises(
+        self, poissonGLM_model_instantiation, n_elements
+    ):
+        """A user-params tuple whose length is not two is rejected."""
+        X, y, model, true_params, _ = poissonGLM_model_instantiation
+        model.fit_intercept = False
+        bad_params = (true_params.coef,) * n_elements
+        with pytest.raises(ValueError, match="length two"):
+            model._normalize_user_params(bad_params, X, y)
+
+
 @pytest.mark.parametrize("glm_type", ["", "population_"])
 @pytest.mark.parametrize(
     "model_instantiation",
@@ -3097,14 +3148,18 @@ def _set_sparse_state(model, glm_type, model_instantiation):
     ],
 )
 @pytest.mark.parametrize("n_samples", [1, 20])
+@pytest.mark.parametrize("fit_intercept", [True, False])
 @pytest.mark.requires_x64
-def test_estimate_dof_resid(n_samples, reg, request, glm_type, model_instantiation):
+def test_estimate_dof_resid(
+    n_samples, fit_intercept, reg, request, glm_type, model_instantiation
+):
     """_estimate_resid_degrees_of_freedom returns the correct residual DOF.
 
-    Uses a fixed sparse coef_ so no solver run is needed.
+    Uses a fixed sparse coef_ so no solver run is needed. A frozen intercept
+    (``fit_intercept=False``) consumes no degrees of freedom.
     """
     _, _, model, _, _ = request.getfixturevalue(glm_type + model_instantiation)
-    model.set_params(regularizer=reg)
+    model.set_params(regularizer=reg, fit_intercept=fit_intercept)
 
     X, n_nonzero = _set_sparse_state(model, glm_type, model_instantiation)
 
@@ -3119,7 +3174,9 @@ def test_estimate_dof_resid(n_samples, reg, request, glm_type, model_instantiati
         rank = int(jnp.linalg.matrix_rank(X))
         dof = rank * n_m1_classes if is_cls else rank
 
-    expected = n_samples - dof - n_m1_classes
+    # the intercept consumes n_m1_classes dof when estimated, none when frozen
+    intercept_dof = n_m1_classes if fit_intercept else 0
+    expected = n_samples - dof - intercept_dof
     num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
     assert np.allclose(num, expected)
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1734,6 +1734,48 @@ class TestFitInterceptProperty:
         assert spy.call_count == 2
 
 
+class TestPartitionActive:
+    """Tests for ``BaseRegressor._partition_active`` as driven by the GLM."""
+
+    @pytest.fixture
+    def params(self):
+        return nmo.glm.params.GLMParams(
+            coef=jnp.array([1.0, 2.0, 3.0]), intercept=jnp.array([5.0])
+        )
+
+    def test_all_active_when_fit_intercept_true(self, params):
+        """fit_intercept=True keeps every leaf active; the frozen tree is all-None."""
+        model = nmo.glm.GLM()
+        model.fit_intercept = True
+        active, frozen = model._partition_active(params)
+        np.testing.assert_array_equal(active.coef, params.coef)
+        np.testing.assert_array_equal(active.intercept, params.intercept)
+        assert frozen.coef is None
+        assert frozen.intercept is None
+
+    def test_intercept_frozen_when_fit_intercept_false(self, params):
+        """fit_intercept=False moves the intercept into the frozen tree and leaves
+        the coefficients active."""
+        model = nmo.glm.GLM()
+        model.fit_intercept = False
+        active, frozen = model._partition_active(params)
+        np.testing.assert_array_equal(active.coef, params.coef)
+        assert active.intercept is None
+        assert frozen.coef is None
+        np.testing.assert_array_equal(frozen.intercept, params.intercept)
+
+    def test_none_active_params_returns_full_and_empty(self, params):
+        """When ``_active_params`` is None (the base default, e.g. a model that never
+        sets it) the params are returned unchanged and the frozen tree is all-None."""
+        model = nmo.glm.GLM()
+        model._active_params = None
+        active, frozen = model._partition_active(params)
+        assert active is params
+        assert jax.tree_util.tree_leaves(frozen) == []
+        assert frozen.coef is None
+        assert frozen.intercept is None
+
+
 @pytest.mark.parametrize("glm_type", ["", "population_"])
 @pytest.mark.parametrize(
     "model_instantiation",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2682,89 +2682,56 @@ class TestPopulationGLM:
             model.feature_mask = mask
 
     @pytest.fixture
-    def feature_mask_compatibility_fit_expectation(self, model_instantiation):
+    def feature_mask_compatibility_fit_expectation(self):
         """
-        Fixture to return the expected exceptions for test_feature_mask_compatibility_fit
-        based on the model type (classifier vs non-classifier).
+        Fixture to return the expected exceptions for test_feature_mask_compatibility_fit.
 
-        For classifier models, the feature_mask shape is (n_features, n_neurons, n_classes)
-        which means all the test masks (which lack the n_classes dimension) will fail
-        shape validation.
+        Every model expects a feature_mask of shape (n_features, n_neurons): a classifier
+        masks a feature for a neuron across all of its classes, so a mask carrying the
+        trailing class axis of the coefficients is rejected like any other wrong shape.
         """
-        is_classifier = "classifier" in model_instantiation
-
         type_error_match = "feature_mask and X must have the same structure"
         # every model now reports a leaf-by-leaf shape mismatch the same way
         shape_mismatch_match = (
             "The ``feature_mask`` must match the shape of the ``coef``, leaf by leaf"
         )
 
-        if is_classifier:
-            # Classifier models expect feature_mask shape (n_features, n_neurons, n_classes)
-            # Masks without n_classes dimension fail shape validation
-            return {
-                "correct_shape_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_classifier_np": does_not_raise(),
-                "wrong_n_features_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_neurons_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_classifier_pytree": does_not_raise(),
-                "wrong_n_neurons_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "missing_key_pytree": pytest.raises(TypeError, match=type_error_match),
-                "missing_key_wrong_shape_pytree": pytest.raises(
-                    TypeError, match=type_error_match
-                ),
-            }
-        else:
-            # Non-classifier models expect feature_mask shape (n_features, n_neurons)
-            return {
-                "correct_shape_np": does_not_raise(),
-                "correct_shape_classifier_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_features_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_neurons_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_pytree": does_not_raise(),
-                "correct_shape_classifier_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_neurons_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "missing_key_pytree": pytest.raises(TypeError, match=type_error_match),
-                "missing_key_wrong_shape_pytree": pytest.raises(
-                    TypeError, match=type_error_match
-                ),
-            }
+        return {
+            "correct_shape_np": does_not_raise(),
+            "extra_class_axis_np": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "wrong_n_features_np": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "wrong_n_neurons_np": pytest.raises(ValueError, match=shape_mismatch_match),
+            "correct_shape_pytree": does_not_raise(),
+            "extra_class_axis_pytree": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "wrong_n_neurons_pytree": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "missing_key_pytree": pytest.raises(TypeError, match=type_error_match),
+            "missing_key_wrong_shape_pytree": pytest.raises(
+                TypeError, match=type_error_match
+            ),
+        }
 
     # Parametrization for test_feature_mask_compatibility_fit masks
     feature_mask_compatibility_fit_masks = (
         "mask, mask_key_np, mask_key_pytree",
         [
-            # Non-classifier correct shape: (n_features, n_neurons) = (5, 3)
+            # Correct shape: (n_features, n_neurons) = (5, 3)
             (
                 np.array([0, 1, 1] * 5).reshape(5, 3),
                 "correct_shape_np",
                 "missing_key_pytree",  # pytree expects dict, not array
             ),
-            # Classifier correct shape: (n_features, n_neurons, n_classes) = (5, 3, 3)
+            # One class axis too many: (n_features, n_neurons, n_classes) = (5, 3, 3)
             (
                 np.ones((5, 3, 3), dtype=int),
-                "correct_shape_classifier_np",
+                "extra_class_axis_np",
                 "missing_key_pytree",  # pytree expects dict, not array
             ),
             (
@@ -2777,7 +2744,7 @@ class TestPopulationGLM:
                 "wrong_n_neurons_np",
                 "missing_key_pytree",
             ),
-            # Non-classifier pytree correct shape: {'input_1': (3, 3), 'input_2': (2, 3)}
+            # Pytree correct shape: {'input_1': (3, 3), 'input_2': (2, 3)}
             (
                 {
                     "input_1": np.array([[0, 1, 0]] * 3),
@@ -2786,14 +2753,14 @@ class TestPopulationGLM:
                 "missing_key_pytree",  # np expects array, not dict
                 "correct_shape_pytree",
             ),
-            # Classifier pytree correct shape: {'input_1': (3, 3, 3), 'input_2': (2, 3, 3)}
+            # Pytree with one class axis too many: {'input_1': (3, 3, 3), 'input_2': (2, 3, 3)}
             (
                 {
                     "input_1": np.ones((3, 3, 3), dtype=int),
                     "input_2": np.ones((2, 3, 3), dtype=int),
                 },
                 "missing_key_pytree",  # np expects array, not dict
-                "correct_shape_classifier_pytree",
+                "extra_class_axis_pytree",
             ),
             # one neuron too many in every leaf
             (
@@ -3030,6 +2997,136 @@ def test_estimate_dof_resid(n_samples, reg, request, glm_type, model_instantiati
     expected = n_samples - dof - n_m1_classes
     num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
     assert np.allclose(num, expected)
+
+
+# A design whose last column duplicates the previous one: a neuron keeping both spends
+# two coefficients on one dimension, which is what separates the Ridge count from the
+# UnRegularized rank.
+_DOF_MASK_DESIGN = (
+    jnp.eye(_DOF_N_FEATURES).at[:, -1].set(jnp.eye(_DOF_N_FEATURES)[:, -2])
+)
+# neuron 0 keeps every feature, neuron 1 the first three, neuron 2 the collinear pair
+_DOF_MASK = jnp.array([[1, 1, 0], [1, 1, 0], [1, 1, 0], [1, 0, 1], [1, 0, 1]])
+_DOF_MASK_COUNT = jnp.array([5, 3, 2])  # features the mask lets through, per neuron
+_DOF_MASK_RANK = jnp.array([4, 3, 1])  # rank of each neuron's own design
+_DOF_MASK_NONZERO = jnp.array([3, 1, 1])  # non-zero coefficients set below, per neuron
+
+
+def _set_masked_state(model, is_cls, as_pytree):
+    """Assign a coef_/intercept_ and feature_mask, and return the matching design.
+
+    The non-zero coefficients sit at features the mask lets through, as a fitted model's
+    would; for the classifier they all sit in the first class, so the per-neuron counts
+    match the non-classifier case.
+    """
+    nf, nn = _DOF_N_FEATURES, _DOF_N_NEURONS
+    if is_cls:
+        coef = jnp.zeros((nf, nn, _DOF_N_CLASSES))
+        coef = coef.at[:3, 0, 0].set(1.0).at[:1, 1, 0].set(1.0).at[3:4, 2, 0].set(1.0)
+        intercept = jnp.zeros((nn, _DOF_N_CLASSES))
+    else:
+        coef = jnp.zeros((nf, nn))
+        coef = coef.at[:3, 0].set(1.0).at[:1, 1].set(1.0).at[3:4, 2].set(1.0)
+        intercept = jnp.zeros((nn,))
+
+    X, mask = _DOF_MASK_DESIGN, _DOF_MASK
+    if as_pytree:
+        # leaves are traversed in sorted-key order, matching the column order of X
+        X = {"input_1": X[:, :3], "input_2": X[:, 3:]}
+        mask = {"input_1": mask[:3], "input_2": mask[3:]}
+        coef = {"input_1": coef[:3], "input_2": coef[3:]}
+
+    # the mask goes in first: its setter refuses a model that already holds parameters
+    model.feature_mask = mask
+    model.coef_ = coef
+    model.intercept_ = intercept
+    return X
+
+
+@pytest.mark.parametrize(
+    "model_instantiation",
+    [
+        "population_poissonGLM_model_instantiation",
+        "population_classifierGLM_model_instantiation",
+    ],
+)
+@pytest.mark.parametrize("as_pytree", [False, True])
+@pytest.mark.parametrize(
+    "reg, dof_per_neuron, scales_with_classes",
+    [
+        (nmo.regularizer.UnRegularized(), _DOF_MASK_RANK, True),
+        (nmo.regularizer.Lasso(), _DOF_MASK_NONZERO, False),
+        (nmo.regularizer.Ridge(), _DOF_MASK_COUNT, True),
+    ],
+)
+@pytest.mark.parametrize("n_samples", [20])
+@pytest.mark.requires_x64
+def test_estimate_dof_resid_feature_mask(
+    n_samples,
+    reg,
+    dof_per_neuron,
+    scales_with_classes,
+    as_pytree,
+    request,
+    model_instantiation,
+):
+    """A masked-out feature is not charged against a neuron's residual DOF.
+
+    Each neuron sees its own design, so the result is one DOF per neuron. The Lasso
+    branch reads the non-zero coefficients and is therefore mask-independent.
+    """
+    _, _, model, _, _ = request.getfixturevalue(
+        model_instantiation + ("_pytree" if as_pytree else "")
+    )
+    model.set_params(regularizer=reg)
+
+    is_cls = "classifier" in model_instantiation
+    X = _set_masked_state(model, is_cls, as_pytree)
+
+    n_m1_classes = getattr(model, "n_classes", 2) - 1
+    dof = dof_per_neuron * n_m1_classes if scales_with_classes else dof_per_neuron
+    expected = n_samples - dof - n_m1_classes
+
+    num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
+    np.testing.assert_allclose(num, expected)
+
+
+@pytest.mark.parametrize(
+    "reg, dof_per_neuron",
+    [
+        (nmo.regularizer.UnRegularized(), _DOF_MASK_RANK),
+        (nmo.regularizer.Lasso(), _DOF_MASK_NONZERO),
+        (nmo.regularizer.Ridge(), _DOF_MASK_COUNT),
+    ],
+)
+@pytest.mark.requires_x64
+def test_dof_resid_after_fit_feature_mask(
+    reg, dof_per_neuron, request, patch_optimizer_run
+):
+    """fit stores the per-neuron DOF of the masked model.
+
+    The solver is a no-op returning ``init_params``, so the fitted coefficients are the
+    injected ones and the DOF is fully determined.
+    """
+    _, _, model, _, _ = request.getfixturevalue(
+        "population_poissonGLM_model_instantiation"
+    )
+    patch_optimizer_run(nmo.glm.PopulationGLM)
+    model.set_params(
+        regularizer=reg,
+        regularizer_strength=(
+            None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.0
+        ),
+    )
+
+    X = _set_masked_state(model, False, as_pytree=False)
+    # hand the sparse state to fit as the starting point, leaving the model unfitted
+    init_params = (model.coef_, model.intercept_)
+    model.coef_, model.intercept_ = None, None
+    y = np.ones((X.shape[0], _DOF_N_NEURONS))
+
+    model.fit(X, y, init_params=init_params)
+    np.testing.assert_allclose(model.dof_resid_, X.shape[0] - dof_per_neuron - 1)
 
 
 @pytest.mark.parametrize("glm_type", ["", "population_"])
@@ -4008,7 +4105,7 @@ class TestClassifierGLM:
         )
         model.inverse_link_function = inv_link
         if is_population_glm_type(glm_type):
-            model.feature_mask = jnp.ones((X.shape[1], y.shape[1], model.n_classes))
+            model.feature_mask = jnp.ones((X.shape[1], y.shape[1]))
             model.scale_ = jnp.ones((y.shape[1]))
             shape_log_proba = (X.shape[0], y.shape[1], model.n_classes)
         else:

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1776,6 +1776,46 @@ class TestPartitionActive:
         assert frozen.intercept is None
 
 
+@pytest.mark.parametrize(
+    "model_fixture",
+    ["poissonGLM_model_instantiation", "population_poissonGLM_model_instantiation"],
+)
+class TestFitInterceptIterative:
+    """``initialize_optimizer_and_state`` + ``update`` with a frozen intercept."""
+
+    @pytest.mark.parametrize("n_updates", [1, 5])
+    def test_update_keeps_intercept_zero(self, model_fixture, request, n_updates):
+        """With ``fit_intercept=False`` the intercept stays exactly zero across one
+        or more update steps, while the coefficients are updated."""
+        X, y, model, true_params, _ = request.getfixturevalue(model_fixture)
+        model.fit_intercept = False
+        coef0, _ = model.initialize_params(X, y)
+        # omit the frozen intercept on setup (the sanctioned input); no warning
+        state = model.initialize_optimizer_and_state((coef0, None), X, y)
+
+        params = (coef0, None)
+        for _ in range(n_updates):
+            params, state = model.update(params, state, X, y)
+
+        np.testing.assert_array_equal(
+            model.intercept_, jnp.zeros_like(true_params.intercept)
+        )
+        assert not np.allclose(model.coef_, coef0)
+
+    def test_flip_after_initialize_then_update_raises(self, model_fixture, request):
+        """Flipping ``fit_intercept`` after initializing the optimizer invalidates the
+        solver, so a subsequent update raises instead of using the stale solver."""
+        X, y, model, true_params, _ = request.getfixturevalue(model_fixture)
+        model.fit_intercept = False
+        coef0, _ = model.initialize_params(X, y)
+        state = model.initialize_optimizer_and_state((coef0, None), X, y)
+
+        model.fit_intercept = True  # flip -> invalidates the solver
+
+        with pytest.raises(RuntimeError, match="invalid state"):
+            model.update((coef0, None), state, X, y)
+
+
 @pytest.mark.parametrize("glm_type", ["", "population_"])
 @pytest.mark.parametrize(
     "model_instantiation",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1723,20 +1723,23 @@ class TestGLMObservationModel:
             raise ValueError("Unknown model instantiation")
         return ll
 
-    @pytest.fixture
-    def sklearn_model(self, model_instantiation):
-        """
-        Fixture for test_glm_fit_matches_sklearn
+    @staticmethod
+    def _make_sklearn_model(model_instantiation, fit_intercept):
+        """Build the matching unregularized sklearn estimator.
+
+        ``fit_intercept`` toggles whether sklearn estimates the bias, mirroring
+        nemos ``GLM(fit_intercept=...)``. Returns ``None`` when no sklearn
+        counterpart exists (negative-binomial).
         """
         if "poisson" in model_instantiation:
-            return PoissonRegressor(fit_intercept=True, tol=10**-12, alpha=0.0)
+            return PoissonRegressor(fit_intercept=fit_intercept, tol=10**-12, alpha=0.0)
 
         elif "gamma" in model_instantiation:
-            return GammaRegressor(fit_intercept=True, tol=10**-12, alpha=0.0)
+            return GammaRegressor(fit_intercept=fit_intercept, tol=10**-12, alpha=0.0)
 
         elif "bernoulli" in model_instantiation:
             return LogisticRegression(
-                fit_intercept=True,
+                fit_intercept=fit_intercept,
                 tol=10**-12,
                 C=np.inf,
             )
@@ -1745,13 +1748,13 @@ class TestGLMObservationModel:
             return None
 
         elif "gaussian" in model_instantiation:
-            return LinearRegression(fit_intercept=True)
+            return LinearRegression(fit_intercept=fit_intercept)
 
         elif "classifier" in model_instantiation:
             # In sklearn 1.5+, multinomial is the default with lbfgs solver
             # Use C=1.0 (Ridge with strength=1.0) for identifiable parameters
             return LogisticRegression(
-                fit_intercept=True,
+                fit_intercept=fit_intercept,
                 tol=10**-12,
                 C=1.0,
                 solver="lbfgs",
@@ -1760,6 +1763,20 @@ class TestGLMObservationModel:
 
         else:
             raise ValueError("Unknown model instantiation")
+
+    @pytest.fixture
+    def sklearn_model(self, model_instantiation):
+        """
+        Fixture for test_glm_fit_matches_sklearn
+        """
+        return self._make_sklearn_model(model_instantiation, fit_intercept=True)
+
+    @pytest.fixture
+    def sklearn_model_no_intercept(self, model_instantiation):
+        """
+        Fixture for test_fit_intercept_false_matches_sklearn
+        """
+        return self._make_sklearn_model(model_instantiation, fit_intercept=False)
 
     @pytest.fixture
     def obs_has_defaults(self, model_instantiation):
@@ -1838,6 +1855,7 @@ class TestGLMObservationModel:
             f"{second_line}"
             f"    inverse_link_function={inverse_link_function},\n"
             "    regularizer=UnRegularized(),\n"
+            "    fit_intercept=True,\n"
             f"    solver_name='{solver_name}'\n"
             ")"
         )
@@ -2086,6 +2104,12 @@ class TestGLMObservationModel:
             intercept = sklearn_model.intercept_
         else:
             coef, intercept = sklearn_model.coef_, sklearn_model.intercept_
+
+        if isinstance(
+            nemos_model.observation_model, nmo.observation_models.BernoulliObservations
+        ):
+            # Logistic regression of sklearn always returns a 2d array
+            coef = np.squeeze(coef)
         return coef, intercept
 
     @staticmethod
@@ -2093,28 +2117,49 @@ class TestGLMObservationModel:
         sklearn_coef, sklearn_intercept, nemos_coef, nemos_intercept, atol=1e-6
     ):
         """Assert that sklearn and nemos parameters match within tolerance."""
-        match_weights = jnp.allclose(sklearn_coef, nemos_coef, atol=atol, rtol=0.0)
-        match_intercepts = jnp.allclose(
+        np.testing.assert_allclose(sklearn_coef, nemos_coef, atol=atol, rtol=0.0)
+        np.testing.assert_allclose(
             sklearn_intercept, nemos_intercept, atol=atol, rtol=0.0
         )
-        if not (match_weights and match_intercepts):
-            raise ValueError("GLM.fit estimate does not match sklearn!")
 
-    @pytest.mark.parametrize("solver_name", ["LBFGS"])
-    @pytest.mark.solver_related
-    @pytest.mark.requires_x64
-    @pytest.mark.filterwarnings("ignore:Setting penalty=None will ignore:UserWarning")
-    def test_glm_fit_matches_sklearn(
-        self, solver_name, request, glm_type, model_instantiation, sklearn_model
+    def _fit_and_compare_to_sklearn(self, model, sklearn_model, X, y, atol=1e-6):
+        """Fit ``model`` and ``sklearn_model`` on the same data and assert their
+        coefficients and intercepts match within ``atol``.
+
+        Population models are compared neuron-by-neuron, since sklearn fits each
+        output independently. When the nemos model has ``fit_intercept=False`` the
+        sklearn counterpart is built with ``fit_intercept=False`` too, so both
+        intercepts are zero and the comparison still holds.
+        """
+        model.fit(X, y)
+        if is_population_model(model):
+            for n in range(y.shape[1]):
+                sklearn_model.fit(X, y[:, n])
+                sk_coef, sk_intercept = self._format_sklearn_params(
+                    sklearn_model, model
+                )
+                self._assert_params_match(
+                    sk_coef, sk_intercept, model.coef_[:, n], model.intercept_[n], atol
+                )
+        else:
+            sklearn_model.fit(X, y)
+            sk_coef, sk_intercept = self._format_sklearn_params(sklearn_model, model)
+            self._assert_params_match(
+                sk_coef, sk_intercept, model.coef_, model.intercept_, atol
+            )
+
+    @staticmethod
+    def _build_matched_model(
+        model_obs, model_instantiation, X, solver_name, fit_intercept=True
     ):
-        """Test that nemos GLM produces the same estimates as sklearn."""
-        if sklearn_model is None:
-            pytest.skip(f"sklearn model is not available for {model_instantiation}")
+        """Reconstruct a nemos model configured to match its sklearn counterpart.
 
-        X, y, model_obs, true_params, firing_rate = request.getfixturevalue(
-            glm_type + model_instantiation
-        )
-
+        Uses the ``_get_param_names`` filter so the same call works for GLM,
+        PopulationGLM and their classifier variants (which take ``n_classes``
+        rather than ``observation_model``). Classifier models get the Ridge
+        strength that matches sklearn's ``C=1.0``; other models are unregularized.
+        ``fit_intercept`` is forwarded to toggle intercept estimation.
+        """
         n_samples = (
             X.shape[0] if not isinstance(X, dict) else list(X.values())[0].shape[0]
         )
@@ -2134,6 +2179,7 @@ class TestGLMObservationModel:
             regularizer=regularizer,
             regularizer_strength=regularizer_strength,
             observation_model=model_obs.observation_model,
+            fit_intercept=fit_intercept,
             solver_name=solver_name,
             solver_kwargs={"tol": 10**-12},
         )
@@ -2147,34 +2193,80 @@ class TestGLMObservationModel:
         if "gamma" in model_instantiation:
             model.inverse_link_function = jnp.exp
 
+        return model
+
+    @pytest.mark.parametrize("solver_name", ["BFGS"])
+    @pytest.mark.solver_related
+    @pytest.mark.requires_x64
+    @pytest.mark.filterwarnings("ignore:Setting penalty=None will ignore:UserWarning")
+    def test_glm_fit_matches_sklearn(
+        self, solver_name, request, glm_type, model_instantiation, sklearn_model
+    ):
+        """Test that nemos GLM produces the same estimates as sklearn."""
+        if sklearn_model is None:
+            pytest.skip(f"sklearn model is not available for {model_instantiation}")
+
+        X, y, model_obs, true_params, firing_rate = request.getfixturevalue(
+            glm_type + model_instantiation
+        )
+
+        model = self._build_matched_model(
+            model_obs, model_instantiation, X, solver_name
+        )
+        self._fit_and_compare_to_sklearn(model, sklearn_model, X, y, atol=1e-6)
+
+    @pytest.mark.parametrize("solver_name", ["LBFGS"])
+    @pytest.mark.solver_related
+    @pytest.mark.requires_x64
+    @pytest.mark.filterwarnings("ignore:Setting penalty=None will ignore:UserWarning")
+    def test_fit_intercept_false_matches_sklearn(
+        self,
+        solver_name,
+        request,
+        glm_type,
+        model_instantiation,
+        sklearn_model_no_intercept,
+    ):
+        """With ``fit_intercept=False`` the estimated coefficients match an
+        sklearn fit that also drops the intercept, and the frozen nemos intercept
+        stays exactly zero."""
+        if sklearn_model_no_intercept is None:
+            pytest.skip(f"sklearn model is not available for {model_instantiation}")
+
+        X, y, model_obs, true_params, firing_rate = request.getfixturevalue(
+            glm_type + model_instantiation
+        )
+
+        model = self._build_matched_model(
+            model_obs, model_instantiation, X, solver_name, fit_intercept=False
+        )
+        self._fit_and_compare_to_sklearn(
+            model, sklearn_model_no_intercept, X, y, atol=1e-6
+        )
+        assert jnp.all(model.intercept_ == 0.0)
+
+    @pytest.mark.parametrize("solver_name", ["GradientDescent", "LBFGS"])
+    @pytest.mark.solver_related
+    @pytest.mark.filterwarnings("ignore:The fit did not converge:RuntimeWarning")
+    def test_fit_intercept_false_leaves_intercept_zero(
+        self, solver_name, request, glm_type, model_instantiation
+    ):
+        """Fitting with ``fit_intercept=False`` holds the intercept exactly at
+        zero while the coefficients are still estimated (finite and moved off the
+        zero-valued leaves)."""
+        X, y, model_obs, true_params, firing_rate = request.getfixturevalue(
+            glm_type + model_instantiation
+        )
+
+        model = self._build_matched_model(
+            model_obs, model_instantiation, X, solver_name, fit_intercept=False
+        )
         model.fit(X, y)
 
-        is_population = is_population_model(model)
-
-        if is_population:
-            # Population GLM: fit each neuron separately in sklearn and compare
-            for n in range(y.shape[1]):
-                sklearn_model.fit(X, y[:, n])
-                sk_coef, sk_intercept = self._format_sklearn_params(
-                    sklearn_model, model
-                )
-                self._assert_params_match(
-                    sk_coef,
-                    sk_intercept,
-                    model.coef_[:, n],
-                    model.intercept_[n],
-                    atol=1e-6,
-                )
-        else:
-            sklearn_model.fit(X, y)
-            sk_coef, sk_intercept = self._format_sklearn_params(sklearn_model, model)
-            self._assert_params_match(
-                sk_coef,
-                sk_intercept,
-                model.coef_,
-                model.intercept_,
-                atol=1e-6,
-            )
+        coef_leaves = jax.tree_util.tree_leaves(model.coef_)
+        assert jnp.all(model.intercept_ == 0.0)
+        assert all(jnp.all(jnp.isfinite(leaf)) for leaf in coef_leaves)
+        assert any(jnp.any(leaf != 0.0) for leaf in coef_leaves)
 
     @staticmethod
     def _get_expected_par_shape(X, y, model):

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1707,12 +1707,22 @@ class TestFitInterceptProperty:
         assert model.fit_intercept is expected
 
     @pytest.mark.parametrize("value", [True, False])
-    def test_active_params_track_fit_intercept(self, glm_class, value):
+    def test_partition_tracks_fit_intercept(self, glm_class, value):
         """coef is always active; the intercept is active iff ``fit_intercept``."""
         model = glm_class()
         model.fit_intercept = value
-        assert model._active_params.coef == True  # noqa: E712
-        assert model._active_params.intercept == value
+        params = nmo.glm.params.GLMParams(
+            coef=jnp.array([1.0, 2.0, 3.0]), intercept=jnp.array([5.0])
+        )
+        active, frozen = model._partition_active(params)
+        np.testing.assert_array_equal(active.coef, params.coef)
+        assert frozen.coef is None
+        if value:
+            np.testing.assert_array_equal(active.intercept, params.intercept)
+            assert frozen.intercept is None
+        else:
+            assert active.intercept is None
+            np.testing.assert_array_equal(frozen.intercept, params.intercept)
 
     def test_invalidates_solver_only_on_flip(self, glm_class, monkeypatch):
         """``_invalidate_solver`` runs only when the flag actually changes value,
@@ -1764,13 +1774,13 @@ class TestPartitionActive:
         assert frozen.coef is None
         np.testing.assert_array_equal(frozen.intercept, params.intercept)
 
-    def test_none_active_params_returns_full_and_empty(self, params):
-        """When ``_active_params`` is None (the base default, e.g. a model that never
-        sets it) the params are returned unchanged and the frozen tree is all-None."""
+    def test_default_settings_return_full_and_empty(self, params):
+        """With the defaults (``_fix_params=None``, ``fit_intercept=True``, neither
+        ever assigned) every value stays active and the frozen tree is all-None."""
         model = nmo.glm.GLM()
-        model._active_params = None
         active, frozen = model._partition_active(params)
-        assert active is params
+        np.testing.assert_array_equal(active.coef, params.coef)
+        np.testing.assert_array_equal(active.intercept, params.intercept)
         assert jax.tree_util.tree_leaves(frozen) == []
         assert frozen.coef is None
         assert frozen.intercept is None

--- a/tests/test_glm_hmm_class.py
+++ b/tests/test_glm_hmm_class.py
@@ -1,5 +1,6 @@
 """Tests for GLMHMM.fit and related fit-path validation."""
 
+import inspect
 import math
 import warnings
 from contextlib import nullcontext as does_not_raise
@@ -244,6 +245,41 @@ def glm_hmm_data():
         init_params=(coef, intercept, scale, init_prob, trans_prob),
         n_states=s,
     )
+
+
+class TestFitInterceptDeferred:
+    """Parameter freezing (``fit_intercept``) is not extended to GLM-HMM; the base
+    signature change (``frozen_params``) must stay compatible and inert."""
+
+    def test_fit_intercept_not_exposed(self, glm_hmm_data):
+        """GLM-HMM does not expose ``fit_intercept`` (freezing is deferred)."""
+        model = GLMHMM(n_states=glm_hmm_data["n_states"], observation_model="Bernoulli")
+        assert "fit_intercept" not in model.get_params()
+        assert not hasattr(model, "fit_intercept")
+
+    def test_initialize_optimizer_accepts_frozen_params(self):
+        """``_initialize_optimizer_and_state`` accepts ``frozen_params`` for signature
+        compatibility with the base entry points."""
+        sig = inspect.signature(GLMHMM._initialize_optimizer_and_state)
+        assert "frozen_params" in sig.parameters
+
+    def test_frozen_params_is_ignored(self, glm_hmm_data):
+        """Passing a non-None ``frozen_params`` yields the same optimizer state as
+        passing None: the GLM-HMM ignores it."""
+        model = GLMHMM(n_states=glm_hmm_data["n_states"], observation_model="Bernoulli")
+        X, y = glm_hmm_data["X"], glm_hmm_data["y"]
+        casted = model._validator.validate_and_cast_params(glm_hmm_data["init_params"])
+
+        state_none = model._initialize_optimizer_and_state(
+            casted, X, y, frozen_params=None
+        )
+        state_frozen = model._initialize_optimizer_and_state(
+            casted, X, y, frozen_params="ignored-sentinel"
+        )
+
+        assert isinstance(state_none, EMState) and isinstance(state_frozen, EMState)
+        assert state_none.iterations == state_frozen.iterations == 0
+        assert bool(state_none.converged) is bool(state_frozen.converged) is False
 
 
 def _spy_instantiate_solver(monkeypatch):

--- a/tests/test_glm_initialization.py
+++ b/tests/test_glm_initialization.py
@@ -1,11 +1,18 @@
 import warnings
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from nemos.glm.initialize_parameters import initialize_intercept_matching_mean_rate
+import nemos as nmo
+from nemos.glm.initialize_parameters import (
+    initialize_constant_coef_matching_mean_rate,
+    initialize_intercept_matching_mean_rate,
+)
+from nemos.glm.params import GLMParams
+from nemos.inverse_link_function_utils import exp as nmo_exp
 
 
 @pytest.mark.parametrize(
@@ -101,3 +108,236 @@ def test_initialization_error_logistic_all_one_output():
         initialize_intercept_matching_mean_rate(
             inverse_link_function=jax.lax.logistic, y=output_y
         )
+
+
+# ---------------------------------------------------------------------------
+# initialize_constant_coef_matching_mean_rate
+# ---------------------------------------------------------------------------
+
+
+def _row_sum(X):
+    """Row-sum of the design over features across all leaves, matching the impl."""
+    return sum(jnp.nansum(leaf, axis=1) for leaf in jax.tree_util.tree_leaves(X))
+
+
+def _freeze_intercept_partition(params):
+    """Split params into (trainable=coef, frozen=intercept).
+
+    Local stand-in for the model-side freezing mechanism (not yet plugged into
+    the model): the solver optimizes ``diff`` (intercept is ``None``), and the
+    frozen intercept is recombined afterwards.
+    """
+    filter_spec = jax.tree_util.tree_map(lambda _: True, params)
+    filter_spec = eqx.tree_at(lambda p: p.intercept, filter_spec, replace=False)
+    return eqx.partition(params, filter_spec)
+
+
+def _make_design(kind, n=4000, p=3, seed=0):
+    """Corner-case design matrices, all shape (n, p)."""
+    rng = np.random.RandomState(seed)
+    if kind == "positive":
+        X = np.abs(rng.randn(n, p))
+    elif kind == "centered":
+        # each column sums to ~0 over samples -> row-sums have ~zero mean
+        X = np.abs(rng.randn(n, p))
+        X = X - X.mean(axis=0, keepdims=True)
+    elif kind == "outliers":
+        X = 0.01 * rng.randn(n, p)
+        X[:: n // 20] += 50.0  # a few large-magnitude rows
+    elif kind == "with_nans":
+        X = np.abs(rng.randn(n, p))
+        X[::50, 0] = np.nan
+    elif kind == "all_zero":
+        X = np.zeros((n, p))
+    else:  # pragma: no cover
+        raise ValueError(kind)
+    return jnp.asarray(X)
+
+
+@pytest.fixture
+def design(request):
+    """A corner-case design matrix (n, p), selected by indirect parametrization."""
+    return _make_design(request.param)
+
+
+def _make_y(n=4000, n_neurons=None, seed=1):
+    rng = np.random.RandomState(seed)
+    if n_neurons is None:
+        return jnp.asarray(rng.poisson(0.1, size=n).astype(float))
+    rates = np.linspace(0.05, 0.5, n_neurons)
+    return jnp.asarray(rng.poisson(rates, size=(n, n_neurons)).astype(float))
+
+
+@pytest.mark.parametrize(
+    "design", ["positive", "centered", "outliers", "with_nans"], indirect=True
+)
+@pytest.mark.parametrize("as_dict", [False, True])
+@pytest.mark.parametrize("n_neurons", [None, 2])
+def test_constant_coef_satisfies_normal_equation(design, as_dict, n_neurons):
+    """The constant is the least-squares minimizer, i.e. it satisfies the
+    (eps-regularized) normal equation ``c (Σs² + eps) = η* (Σs + eps)``."""
+    X = design
+    p = X.shape[1]
+    y = _make_y(n_neurons=n_neurons)
+    if as_dict:
+        X = {"a": X[:, :1], "b": X[:, 1:]}
+        empty_coef = {
+            "a": jnp.empty((1,) if n_neurons is None else (1, n_neurons)),
+            "b": jnp.empty((2,) if n_neurons is None else (2, n_neurons)),
+        }
+    else:
+        empty_coef = jnp.empty((p,) if n_neurons is None else (p, n_neurons))
+
+    coef = initialize_constant_coef_matching_mean_rate(nmo_exp, X, y, empty_coef)
+
+    # structure and shapes preserved
+    assert jax.tree_util.tree_structure(coef) == jax.tree_util.tree_structure(empty_coef)
+    for c, e in zip(jax.tree_util.tree_leaves(coef), jax.tree_util.tree_leaves(empty_coef)):
+        assert c.shape == e.shape
+        assert jnp.all(jnp.isfinite(c))
+
+    # every leaf is a single constant per output
+    const_leaves = [jnp.reshape(c, (-1,) if n_neurons is None else (-1, n_neurons))
+                    for c in jax.tree_util.tree_leaves(coef)]
+    const = const_leaves[0][0]  # shape () or (n_neurons,)
+    for c in jax.tree_util.tree_leaves(coef):
+        assert jnp.allclose(c, jnp.broadcast_to(const, c.shape), rtol=1e-5)
+
+    # normal-equation identity, verified independently of the closed-form impl
+    eta = initialize_intercept_matching_mean_rate(nmo_exp, y)  # (n_out,)
+    s = _row_sum(X)
+    eps = jnp.finfo(s.dtype).eps
+    lhs = jnp.atleast_1d(const) * (jnp.sum(s**2) + eps)
+    rhs = eta * (jnp.sum(s) + eps)
+    assert jnp.allclose(lhs, rhs, rtol=1e-4, atol=1e-6)
+
+
+@pytest.mark.parametrize("design", ["all_zero"], indirect=True)
+def test_constant_coef_all_zero_design_equals_target(design):
+    """With an all-zero design no constant can inject an offset; the eps
+    stabilization returns c = η* and stays finite (no NaN)."""
+    y = _make_y()
+    coef = initialize_constant_coef_matching_mean_rate(nmo_exp, design, y, jnp.empty((3,)))
+    eta = initialize_intercept_matching_mean_rate(nmo_exp, y)
+    assert jnp.all(jnp.isfinite(coef))
+    assert jnp.allclose(coef, eta)
+
+
+@pytest.mark.parametrize("design", ["centered"], indirect=True)
+def test_constant_coef_centered_columns_degrades_to_zero(design):
+    """On a zero-mean design the projection scale ~0, so the constant ~0 and the
+    heuristic degrades gracefully (finite) rather than blowing up."""
+    y = _make_y()
+    coef = initialize_constant_coef_matching_mean_rate(nmo_exp, design, y, jnp.empty((3,)))
+    assert jnp.all(jnp.isfinite(coef))
+    assert jnp.all(jnp.abs(coef) < 1e-2)
+
+
+@pytest.mark.requires_x64
+@pytest.mark.parametrize("design", ["positive"], indirect=True)
+def test_constant_coef_float_dtype_matches_empty_coef(design):
+    """coef inherits the dtype of empty_coef (via ones_like)."""
+    y = _make_y()
+    empty_coef = jnp.empty((3,), dtype=jnp.float32)
+    coef = initialize_constant_coef_matching_mean_rate(nmo_exp, design, y, empty_coef)
+    assert coef.dtype == empty_coef.dtype
+
+
+# ---------------------------------------------------------------------------
+# no-intercept fit via partition around _compute_loss (mechanism precursor)
+# ---------------------------------------------------------------------------
+
+
+# obs model -> (single-neuron true coef, population true coef). Magnitudes are
+# modest so exp(X @ coef) stays bounded on the centered design; Gamma's coef is
+# positive so the default 1/x link gives a positive mean on the positive design.
+_FIT_CASES = {
+    "Poisson": ([-1.0, -0.8, -1.2], [[-1.0, -0.6], [-0.8, -0.4], [-1.2, -0.9]]),
+    "Gaussian": ([0.5, -0.3, 0.2], [[0.5, 0.3], [-0.3, -0.1], [0.2, 0.4]]),
+    "Gamma": ([0.5, 0.3, 0.8], [[0.5, 0.4], [0.3, 0.2], [0.8, 0.6]]),
+}
+
+
+@pytest.fixture
+def fit_models(request, design):
+    """Return ``(ground_truth, empty, X, n_neurons)`` for a fit case.
+
+    ``ground_truth`` carries the true (intercept-free) params so ``simulate`` can
+    generate ``y``; ``empty`` is an unfit model of the same config, used to fit.
+    Parametrized indirectly by ``(obs_model, "single"|"population")``. Gamma's 1/x
+    link needs a positive mean, which the centered design violates, so on that
+    design Gamma uses an ``exp`` link instead.
+    """
+    obs, kind = request.param
+    design_kind = request.node.callspec.params["design"]
+    n_neurons = None if kind == "single" else 2
+    model_cls = nmo.glm.GLM if n_neurons is None else nmo.glm.PopulationGLM
+    true_coef = jnp.asarray(_FIT_CASES[obs][0 if n_neurons is None else 1])
+
+    kwargs = dict(observation_model=obs)
+    if obs == "Gamma" and design_kind == "centered":
+        # default link is 1/x which doesn't enforce positivity
+        # and fails with centered X.
+        kwargs["inverse_link_function"] = nmo_exp
+
+    ground_truth = model_cls(**kwargs)
+    ground_truth.coef_ = true_coef
+    ground_truth.intercept_ = jnp.zeros(1 if n_neurons is None else n_neurons)
+    ground_truth.scale_ = jnp.ones_like(ground_truth.intercept_)
+
+    empty = model_cls(**kwargs)
+    return ground_truth, empty, design, n_neurons
+
+
+@pytest.mark.requires_x64
+@pytest.mark.parametrize("design", ["positive", "centered"], indirect=True)
+@pytest.mark.parametrize(
+    "fit_models",
+    [
+        (obs, kind)
+        for obs in ("Poisson", "Gaussian", "Gamma")
+        for kind in ("single", "population")
+    ],
+    indirect=True,
+)
+def test_fit_with_frozen_intercept(setup_solver, fit_models):
+    """Freezing the intercept via eqx.partition around ``_compute_loss`` and
+    fitting with the nemos solver leaves the intercept at 0, converges, and
+    lowers the (unregularized) loss. ``y`` is generated via ``simulate`` from an
+    intercept-free ground-truth model."""
+    ground_truth, model, X, n_neurons = fit_models
+    p = X.shape[1]
+
+    y, _ = ground_truth.simulate(jax.random.key(0), X)
+
+    intercept0 = jnp.zeros(1 if n_neurons is None else n_neurons)
+    empty_coef = jnp.empty((p,) if n_neurons is None else (p, n_neurons))
+    init_coef = initialize_constant_coef_matching_mean_rate(
+        model._inverse_link_function, X, y, empty_coef
+    )
+    params0 = GLMParams(coef=init_coef, intercept=intercept0)
+    diff0, frozen = _freeze_intercept_partition(params0)
+
+    # partition correctness: intercept removed from the trainable subtree
+    assert diff0.intercept is None
+    assert jnp.all(frozen.intercept == 0.0)
+
+    def loss_on_diff(diff, X, y):
+        return model._compute_loss(eqx.combine(diff, frozen), X, y)
+
+    loss_init = loss_on_diff(diff0, X, y)
+    solver = setup_solver(loss_on_diff, init_params=diff0, tol=1e-10)
+    diff_fit, state, _ = solver.run(diff0, X, y)
+    fitted = eqx.combine(diff_fit, frozen)
+
+    # intercept never moved
+    assert jnp.all(fitted.intercept == 0.0)
+
+    # solver reports convergence (mirrors the detection in GLM.fit)
+    converged = getattr(
+        getattr(state, "stats", None), "converged", getattr(state, "converged", None)
+    )
+    assert bool(converged)
+
+    # loss decreased
+    assert loss_on_diff(diff_fit, X, y) <= loss_init

--- a/tests/test_glm_initialization.py
+++ b/tests/test_glm_initialization.py
@@ -191,14 +191,20 @@ def test_constant_coef_satisfies_normal_equation(design, as_dict, n_neurons):
     coef = initialize_constant_coef_matching_mean_rate(nmo_exp, X, y, empty_coef)
 
     # structure and shapes preserved
-    assert jax.tree_util.tree_structure(coef) == jax.tree_util.tree_structure(empty_coef)
-    for c, e in zip(jax.tree_util.tree_leaves(coef), jax.tree_util.tree_leaves(empty_coef)):
+    assert jax.tree_util.tree_structure(coef) == jax.tree_util.tree_structure(
+        empty_coef
+    )
+    for c, e in zip(
+        jax.tree_util.tree_leaves(coef), jax.tree_util.tree_leaves(empty_coef)
+    ):
         assert c.shape == e.shape
         assert jnp.all(jnp.isfinite(c))
 
     # every leaf is a single constant per output
-    const_leaves = [jnp.reshape(c, (-1,) if n_neurons is None else (-1, n_neurons))
-                    for c in jax.tree_util.tree_leaves(coef)]
+    const_leaves = [
+        jnp.reshape(c, (-1,) if n_neurons is None else (-1, n_neurons))
+        for c in jax.tree_util.tree_leaves(coef)
+    ]
     const = const_leaves[0][0]  # shape () or (n_neurons,)
     for c in jax.tree_util.tree_leaves(coef):
         assert jnp.allclose(c, jnp.broadcast_to(const, c.shape), rtol=1e-5)
@@ -217,7 +223,9 @@ def test_constant_coef_all_zero_design_equals_target(design):
     """With an all-zero design no constant can inject an offset; the eps
     stabilization returns c = η* and stays finite (no NaN)."""
     y = _make_y()
-    coef = initialize_constant_coef_matching_mean_rate(nmo_exp, design, y, jnp.empty((3,)))
+    coef = initialize_constant_coef_matching_mean_rate(
+        nmo_exp, design, y, jnp.empty((3,))
+    )
     eta = initialize_intercept_matching_mean_rate(nmo_exp, y)
     assert jnp.all(jnp.isfinite(coef))
     assert jnp.allclose(coef, eta)
@@ -228,7 +236,9 @@ def test_constant_coef_centered_columns_degrades_to_zero(design):
     """On a zero-mean design the projection scale ~0, so the constant ~0 and the
     heuristic degrades gracefully (finite) rather than blowing up."""
     y = _make_y()
-    coef = initialize_constant_coef_matching_mean_rate(nmo_exp, design, y, jnp.empty((3,)))
+    coef = initialize_constant_coef_matching_mean_rate(
+        nmo_exp, design, y, jnp.empty((3,))
+    )
     assert jnp.all(jnp.isfinite(coef))
     assert jnp.all(jnp.abs(coef) < 1e-2)
 

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -221,8 +221,10 @@ def _freeze_first_coef_leaf(model, params):
     leaves the interesting block untouched.
     """
     leaves, treedef = jax.tree_util.tree_flatten(params.coef)
+    # cast the pinned leaf: ``fit`` casts its inputs, so an un-cast spec would be
+    # compared against a fitted leaf of a different dtype
     spec = jax.tree_util.tree_unflatten(
-        treedef, [leaves[0]] + [None] * (len(leaves) - 1)
+        treedef, [jnp.asarray(leaves[0])] + [None] * (len(leaves) - 1)
     )
     model._fix_params = GLMParams(spec, None)
     return spec
@@ -293,7 +295,16 @@ def test_newton_leaves_frozen_params_untouched(
         )
     else:
         pinned = _freeze_first_coef_leaf(frozen_model, true_params)
-        frozen_model.fit(X, y)
+        # the spec decides which leaves the solver skips, not what they are worth: a
+        # frozen leaf is held at whatever the initialization put there. The intercept
+        # is filled from the spec at init time, a coef leaf is not, so the pinned value
+        # is handed in through ``init_params`` for the fitted leaf to be comparable.
+        zeros = jax.tree_util.tree_map(jnp.zeros_like, true_params.coef)
+        init_params = (
+            eqx.combine(pinned, zeros),
+            jnp.zeros_like(true_params.intercept),
+        )
+        frozen_model.fit(X, y, init_params=init_params)
         fitted = jax.tree_util.tree_leaves(frozen_model.coef_)[0]
         np.testing.assert_array_equal(fitted, jax.tree_util.tree_leaves(pinned)[0])
 

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -4,6 +4,7 @@ import importlib
 import pkgutil
 from copy import deepcopy
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
@@ -212,36 +213,199 @@ def test_newton_glm_instantiate_solver(regularizer_name, glm_class):
     assert isinstance(solver, Newton)
 
 
+def _freeze_first_coef_leaf(model, params):
+    """Build a ``fix_params`` spec pinning the first ``coef`` leaf to its true value.
+
+    Freezing a coefficient leaf rather than the intercept is what exercises the
+    ``coef`` block of the Hessian: the intercept is a single row, so dropping it
+    leaves the interesting block untouched.
+    """
+    leaves, treedef = jax.tree_util.tree_flatten(params.coef)
+    spec = jax.tree_util.tree_unflatten(
+        treedef, [leaves[0]] + [None] * (len(leaves) - 1)
+    )
+    model.fix_params = (spec, None)
+    # read the spec back: the setter validates and casts it, so this is the value
+    # the frozen leaf is actually pinned to
+    return model.fix_params[0]
+
+
+@pytest.mark.requires_x64
 @pytest.mark.parametrize("regularizer_name", ["Ridge", "UnRegularized"])
 @pytest.mark.parametrize(
     "model_fixture",
     ["poissonGLM_model_instantiation", "population_poissonGLM_model_instantiation"],
 )
-def test_newton_rejects_frozen_intercept(regularizer_name, model_fixture, request):
-    """Newton's Hessian is built over the full parameter set and is not
-    partition-aware, so requesting it with a frozen intercept
-    (``fit_intercept=False``) raises rather than silently ignoring the freeze."""
-    X, y, model, *_ = request.getfixturevalue(model_fixture)
+@pytest.mark.parametrize("freeze", ["intercept", "coef_leaf"])
+def test_newton_matches_first_order_solver_with_frozen_params(
+    regularizer_name, model_fixture, freeze, request
+):
+    """Newton differentiates the combined loss with respect to the active subtree,
+    so it must land on the same optimum as a partition-agnostic first-order solver.
+
+    Both freezing modes are covered: a frozen intercept drops a Hessian row, while a
+    frozen ``coef`` leaf carves a block out of the ``coef`` block itself.
+    """
+    X, y, model, true_params, _ = request.getfixturevalue(model_fixture)
+
+    def build(solver_name):
+        m = type(model)(
+            regularizer=regularizer_name,
+            regularizer_strength=1.0 if regularizer_name == "Ridge" else None,
+            solver_name=solver_name,
+            solver_kwargs={"tol": 10**-12},
+        )
+        if freeze == "intercept":
+            m.fit_intercept = False
+        else:
+            _freeze_first_coef_leaf(m, true_params)
+        return m
+
+    newton = build("Newton").fit(X, y)
+    reference = build("LBFGS").fit(X, y)
+
+    assert newton.solver_name == "Newton"
+    np.testing.assert_allclose(newton.coef_, reference.coef_, atol=1e-5)
+    np.testing.assert_allclose(newton.intercept_, reference.intercept_, atol=1e-5)
+
+
+@pytest.mark.parametrize("regularizer_name", ["Ridge", "UnRegularized"])
+@pytest.mark.parametrize(
+    "model_fixture",
+    ["poissonGLM_model_instantiation", "population_poissonGLM_model_instantiation"],
+)
+@pytest.mark.parametrize("freeze", ["intercept", "coef_leaf"])
+def test_newton_leaves_frozen_params_untouched(
+    regularizer_name, model_fixture, freeze, request
+):
+    """The frozen leaves come back bit-identical, not merely close: a Hessian that
+    silently included them would move them by a small but nonzero amount."""
+    X, y, model, true_params, _ = request.getfixturevalue(model_fixture)
 
     frozen_model = type(model)(
-        regularizer=regularizer_name, fit_intercept=False, solver_name="Newton"
+        regularizer=regularizer_name,
+        regularizer_strength=1.0 if regularizer_name == "Ridge" else None,
+        solver_name="Newton",
     )
-    with pytest.raises(
-        ValueError, match="Newton solver does not support frozen parameters"
-    ):
+    if freeze == "intercept":
+        frozen_model.fit_intercept = False
         frozen_model.fit(X, y)
+        np.testing.assert_array_equal(
+            frozen_model.intercept_, np.zeros_like(true_params.intercept)
+        )
+    else:
+        pinned = _freeze_first_coef_leaf(frozen_model, true_params)
+        frozen_model.fit(X, y)
+        fitted = jax.tree_util.tree_leaves(frozen_model.coef_)[0]
+        np.testing.assert_array_equal(fitted, jax.tree_util.tree_leaves(pinned)[0])
 
 
 @pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
-def test_ridge_default_solver_skips_newton_when_intercept_frozen(glm_class):
-    """Ridge defaults to Newton because its penalized Hessian is positive definite,
-    but only when the intercept is estimated; freezing the intercept defers to the
-    regularizer's own default solver, since Newton is not partition-aware."""
-    assert glm_class(regularizer="Ridge", fit_intercept=True).solver_name == "Newton"
+@pytest.mark.parametrize("fit_intercept", [True, False])
+def test_ridge_defaults_to_newton_regardless_of_freezing(glm_class, fit_intercept):
+    """Ridge defaults to Newton because its penalized Hessian is positive definite.
+    Newton is partition-aware, so freezing the intercept no longer forces a fallback
+    to the regularizer's first-order default."""
+    model = glm_class(regularizer="Ridge", fit_intercept=fit_intercept)
+    assert model.solver_name == "Newton"
+    assert Ridge().default_solver != "Newton"  # the fallback would have been visible
 
-    frozen = glm_class(regularizer="Ridge", fit_intercept=False)
-    assert frozen.solver_name != "Newton"
-    assert frozen.solver_name == Ridge().default_solver
+
+@pytest.mark.requires_x64
+@pytest.mark.parametrize("regularizer_name", ["Ridge"])
+@pytest.mark.parametrize("freeze", ["intercept", "coef_leaf"])
+def test_newton_population_glm_feature_mask_with_frozen_params(
+    regularizer_name, freeze, request
+):
+    """The mask, the active axes and the frozen axes all index the neuron axis of the
+    block Hessian. A wrong ``in_axes`` survives the unmasked tests, so pair the mask
+    with a freeze and check Newton still lands where a first-order solver does.
+
+    Ridge only: a masked-out coefficient has zero gradient *and* zero curvature, so an
+    unpenalized masked Hessian is singular and the Newton step is NaN. That is unrelated
+    to parameter freezing (it reproduces with nothing frozen) and is tracked in #580.
+    """
+    X, y, model, true_params, _ = request.getfixturevalue(
+        "population_poissonGLM_model_instantiation_pytree"
+    )
+    mask = initialize_feature_mask_for_population_glm(X, y.shape[1])
+    # zero a block so the mask is not the identity: a masked-out coefficient must not
+    # pick up curvature from the neuron it is masked away from
+    first = sorted(mask)[0]
+    mask[first] = mask[first].at[:, 0].set(0.0)
+
+    def build(solver_name):
+        m = nmo.glm.PopulationGLM(
+            regularizer=regularizer_name,
+            regularizer_strength=1.0 if regularizer_name == "Ridge" else None,
+            solver_name=solver_name,
+            solver_kwargs={"tol": 10**-12},
+            feature_mask=mask,
+        )
+        if freeze == "intercept":
+            m.fit_intercept = False
+        else:
+            _freeze_first_coef_leaf(m, true_params)
+        return m
+
+    newton = build("Newton").fit(X, y)
+    reference = build("LBFGS").fit(X, y)
+
+    for key in mask:
+        np.testing.assert_allclose(newton.coef_[key], reference.coef_[key], atol=1e-5)
+    np.testing.assert_allclose(newton.intercept_, reference.intercept_, atol=1e-5)
+
+
+@pytest.mark.parametrize("freeze", ["intercept", "coef_leaf"])
+def test_population_glm_hess_fn_drops_frozen_leaves(freeze, request):
+    """``_get_hess_fn`` returns the active block only: every frozen leaf position is
+    ``None`` in the returned pytree, and the surviving blocks carry the neuron axis."""
+    X, y, model, true_params, _ = request.getfixturevalue(
+        "population_poissonGLM_model_instantiation_pytree"
+    )
+    model = nmo.glm.PopulationGLM(regularizer="Ridge", regularizer_strength=1.0)
+    if freeze == "intercept":
+        model.fit_intercept = False
+    else:
+        _freeze_first_coef_leaf(model, true_params)
+
+    params = model._model_specific_initialization(X, y)
+    active, frozen = model._partition_active(params)
+    hess = model._get_hess_fn(frozen=frozen)(active, X, y)
+
+    n_neurons = y.shape[1]
+    if freeze == "intercept":
+        assert hess.intercept is None
+        assert all(row.intercept is None for row in hess.coef.values())
+    else:
+        pinned = sorted(model.fix_params[0])[0]
+        assert active.coef[pinned] is None
+        assert hess.coef[pinned] is None
+        # the frozen leaf is dropped as a column too, not just as a row
+        assert all(
+            row.coef[pinned] is None for row in hess.coef.values() if row is not None
+        )
+
+    # every surviving block is stacked on the neuron axis
+    for block in jax.tree_util.tree_leaves(hess):
+        assert block.shape[0] == n_neurons
+
+
+def test_feature_mask_reassignment_invalidates_solver(request):
+    """The loss and the Hessian both read ``_feature_mask`` at call time, so a solver
+    built against the previous mask is stale and must be torn down."""
+    X, y, model, *_ = request.getfixturevalue(
+        "population_poissonGLM_model_instantiation"
+    )
+    model = nmo.glm.PopulationGLM(regularizer="Ridge", regularizer_strength=1.0)
+    params = model._model_specific_initialization(X, y)
+    active, frozen = model._partition_active(params)
+    model._initialize_optimizer_and_state(active, X, y, frozen_params=frozen)
+    assert model.solver is not None
+
+    model.feature_mask = initialize_feature_mask_for_population_glm(X, y.shape[1])
+    assert model.solver is None
+    assert model.optimizer_run is None
 
 
 @pytest.mark.parametrize("regularizer_name", ["Ridge", "UnRegularized"])
@@ -361,7 +525,7 @@ def test_newton_population_glm_matches_full_autodiff(request, feature_mask):
         )
 
     full_model = deepcopy(model)
-    full_model._get_hess_fn = lambda: None
+    full_model._get_hess_fn = lambda frozen=None: None
     full_model._hess_tag = HessianTag(structure=Full, property=PositiveSemiDefinite)
 
     full_model.fit(X, y)
@@ -409,7 +573,7 @@ def test_newton_block_diagonal_matches_full_autodiff_update(
         )
 
     full_model = deepcopy(model)
-    full_model._get_hess_fn = lambda: None
+    full_model._get_hess_fn = lambda frozen=None: None
     full_model._hess_tag = HessianTag(structure=Full, property=PositiveSemiDefinite)
 
     p0 = model.initialize_params(X, y)
@@ -460,7 +624,7 @@ def test_newton_population_glm_block_hessian_matches_full(
         )
 
     full_model = deepcopy(model)
-    full_model._get_hess_fn = lambda: None
+    full_model._get_hess_fn = lambda frozen=None: None
     full_model._hess_tag = HessianTag(structure=Full, property=PositiveSemiDefinite)
 
     p0 = model.initialize_params(X, y)
@@ -578,7 +742,7 @@ def test_newton_population_classifier_glm_matches_full_autodiff(request, feature
         )
 
     full_model = deepcopy(model)
-    full_model._get_hess_fn = lambda: None
+    full_model._get_hess_fn = lambda frozen=None: None
     full_model._hess_tag = HessianTag(structure=Full, property=PositiveSemiDefinite)
 
     full_model.fit(X, y)
@@ -621,7 +785,7 @@ def test_newton_population_classifier_glm_block_hessian_matches_full(
         )
 
     full_model = deepcopy(model)
-    full_model._get_hess_fn = lambda: None
+    full_model._get_hess_fn = lambda frozen=None: None
     full_model._hess_tag = HessianTag(structure=Full, property=PositiveSemiDefinite)
 
     p0 = model.initialize_params(X, y)
@@ -697,9 +861,11 @@ class _FullHessianGLM(GLM):
     early return it triggers in ``Regularizer._get_hess_fn``.
     """
 
-    def _get_hess_fn(self):
+    def _get_hess_fn(self, frozen=None):
         def loss(params, X, y):
-            rate = self._predict(params, X)
+            # mirrors the in-tree implementations: differentiate the combined loss
+            # with respect to the active subtree alone
+            rate = self._predict(eqx.combine(params, frozen), X)
             return self._observation_model._negative_log_likelihood(y, rate)
 
         return jax.hessian(loss)
@@ -872,8 +1038,12 @@ def test_population_glm_hess_tag_structure():
 
 
 def test_population_glm_hess_tag_property():
-    """PopulationGLM Hessian should be PositiveDefinite at the class level."""
-    assert PopulationGLM._hess_tag.property is PositiveDefinite
+    """PopulationGLM certifies only PositiveSemiDefinite at the class level, like GLM
+    and ClassifierPopulationGLM: the unpenalized block is singular whenever a
+    coefficient carries no curvature (a masked-out feature). Ridge promotes it to
+    PositiveDefinite via ``_hess_property_override``, checked just below."""
+    assert PopulationGLM._hess_tag.property is PositiveSemiDefinite
+    assert PopulationGLM._hess_tag.property is GLM._hess_tag.property
 
 
 def test_population_glm_hess_tag_batch_axes():

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -214,6 +214,38 @@ def test_newton_glm_instantiate_solver(regularizer_name, glm_class):
 
 @pytest.mark.parametrize("regularizer_name", ["Ridge", "UnRegularized"])
 @pytest.mark.parametrize(
+    "model_fixture",
+    ["poissonGLM_model_instantiation", "population_poissonGLM_model_instantiation"],
+)
+def test_newton_rejects_frozen_intercept(regularizer_name, model_fixture, request):
+    """Newton's Hessian is built over the full parameter set and is not
+    partition-aware, so requesting it with a frozen intercept
+    (``fit_intercept=False``) raises rather than silently ignoring the freeze."""
+    X, y, model, *_ = request.getfixturevalue(model_fixture)
+
+    frozen_model = type(model)(
+        regularizer=regularizer_name, fit_intercept=False, solver_name="Newton"
+    )
+    with pytest.raises(
+        ValueError, match="Newton solver does not support frozen parameters"
+    ):
+        frozen_model.fit(X, y)
+
+
+@pytest.mark.parametrize("glm_class", [nmo.glm.GLM, nmo.glm.PopulationGLM])
+def test_ridge_default_solver_skips_newton_when_intercept_frozen(glm_class):
+    """Ridge defaults to Newton because its penalized Hessian is positive definite,
+    but only when the intercept is estimated; freezing the intercept defers to the
+    regularizer's own default solver, since Newton is not partition-aware."""
+    assert glm_class(regularizer="Ridge", fit_intercept=True).solver_name == "Newton"
+
+    frozen = glm_class(regularizer="Ridge", fit_intercept=False)
+    assert frozen.solver_name != "Newton"
+    assert frozen.solver_name == Ridge().default_solver
+
+
+@pytest.mark.parametrize("regularizer_name", ["Ridge", "UnRegularized"])
+@pytest.mark.parametrize(
     "glm_class",
     [
         nmo.glm.GLM,

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -214,7 +214,7 @@ def test_newton_glm_instantiate_solver(regularizer_name, glm_class):
 
 
 def _freeze_first_coef_leaf(model, params):
-    """Build a ``fix_params`` spec pinning the first ``coef`` leaf to its true value.
+    """Build a ``_fix_params`` spec pinning the first ``coef`` leaf to its true value.
 
     Freezing a coefficient leaf rather than the intercept is what exercises the
     ``coef`` block of the Hessian: the intercept is a single row, so dropping it
@@ -224,10 +224,8 @@ def _freeze_first_coef_leaf(model, params):
     spec = jax.tree_util.tree_unflatten(
         treedef, [leaves[0]] + [None] * (len(leaves) - 1)
     )
-    model.fix_params = (spec, None)
-    # read the spec back: the setter validates and casts it, so this is the value
-    # the frozen leaf is actually pinned to
-    return model.fix_params[0]
+    model._fix_params = GLMParams(spec, None)
+    return spec
 
 
 @pytest.mark.requires_x64
@@ -378,7 +376,7 @@ def test_population_glm_hess_fn_drops_frozen_leaves(freeze, request):
         assert hess.intercept is None
         assert all(row.intercept is None for row in hess.coef.values())
     else:
-        pinned = sorted(model.fix_params[0])[0]
+        pinned = sorted(model._fix_params.coef)[0]
         assert active.coef[pinned] is None
         assert hess.coef[pinned] is None
         # the frozen leaf is dropped as a column too, not just as a row

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -321,6 +321,24 @@ class TestGLMStochasticFit:
         assert model.coef_.shape == (5,)
 
     @pytest.mark.parametrize("solver", _stochastic_solver_names)
+    def test_stochastic_fit_frozen_intercept(self, simple_data, solver):
+        """With ``fit_intercept=False`` stochastic_fit holds the intercept at zero
+        while still estimating the coefficients."""
+        X, y = simple_data
+        loader = ArrayDataLoader(X, y, batch_size=32, shuffle="full")
+
+        model = nmo.glm.GLM(
+            fit_intercept=False,
+            solver_name=solver,
+            solver_kwargs=self._default_solver_kwargs(solver),
+        )
+        model.stochastic_fit(loader, num_epochs=5)
+
+        np.testing.assert_array_equal(model.intercept_, jnp.zeros(1))
+        assert model.coef_.shape == (5,)
+        assert np.all(np.isfinite(model.coef_))
+
+    @pytest.mark.parametrize("solver", _stochastic_solver_names)
     def test_stochastic_fit_with_init_params(self, simple_data, solver):
         """Test stochastic_fit with provided initial parameters."""
         X, y = simple_data
@@ -873,6 +891,27 @@ class TestPopulationGLMStochasticFit:
         assert model.intercept_ is not None
         assert model.coef_.shape == (5, 3)
         assert model.intercept_.shape == (3,)
+
+    @pytest.mark.parametrize("solver", _stochastic_solver_names)
+    def test_population_stochastic_fit_frozen_intercept(self, population_data, solver):
+        """With ``fit_intercept=False`` the per-neuron intercept stays at zero while
+        the coefficients are estimated for every neuron."""
+        X, y = population_data
+        loader = ArrayDataLoader(X, y, batch_size=32, shuffle="full")
+
+        solver_kwargs = {"stepsize": 0.001, "maxiter": 100}
+        solver_class = solvers.get_solver(solver).implementation
+        if "acceleration" in solver_class.get_accepted_arguments():
+            solver_kwargs["acceleration"] = False
+
+        model = nmo.glm.PopulationGLM(
+            fit_intercept=False, solver_name=solver, solver_kwargs=solver_kwargs
+        )
+        model.stochastic_fit(loader, num_epochs=5)
+
+        np.testing.assert_array_equal(model.intercept_, jnp.zeros(3))
+        assert model.coef_.shape == (5, 3)
+        assert np.all(np.isfinite(model.coef_))
 
 
 class TestSolverStochasticRun:

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -159,6 +159,31 @@ class TestCallbackSystem:
         assert ctx.should_stop
         assert ctx.stop_reason == "test reason"
 
+    def test_training_context_params_passthrough_when_no_frozen(self):
+        """With ``frozen=None`` the params getter returns exactly what was set."""
+        params = SimpleNamespace(coef="COEF", intercept="INT")
+        ctx = TrainingContext(params=params)
+        assert ctx.params is params
+
+    def test_training_context_params_recombines_frozen(self):
+        """With a frozen subtree set, reading ``params`` recombines it with the
+        active subtree, while the setter stores only the active subtree (so
+        callbacks always see the complete parameters)."""
+        frozen = (None, jnp.array([7.0]))
+        ctx = TrainingContext(params=(jnp.array([0.0, 0.0]), None), frozen=frozen)
+
+        # the constructor-provided active subtree recombines with frozen on read
+        np.testing.assert_array_equal(ctx.params[0], jnp.array([0.0, 0.0]))
+        np.testing.assert_array_equal(ctx.params[1], jnp.array([7.0]))
+
+        # the training loop assigns a new active subtree ...
+        ctx.params = (jnp.array([3.0, 4.0]), None)
+        # ... stored active-only (the frozen slot stays empty) ...
+        assert ctx._params[1] is None
+        # ... and recombined with frozen on the next read
+        np.testing.assert_array_equal(ctx.params[0], jnp.array([3.0, 4.0]))
+        np.testing.assert_array_equal(ctx.params[1], jnp.array([7.0]))
+
     def test_callback_hooks_are_noop(self):
         """Base Callback hooks don't raise."""
         cb = Callback()

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -186,21 +186,21 @@ class TestCallbackSystem:
 
     def test_repr_single_line(self):
         """A short context renders on one line; None fields are omitted."""
-        ctx = TrainingContext(epoch_idx=1, batch_idx=3, num_epochs=5)
-        assert repr(ctx) == "TrainingContext(epoch_idx=1, batch_idx=3, num_epochs=5)"
+        ctx = TrainingContext(pass_idx=1, batch_idx=3, n_passes=5)
+        assert repr(ctx) == "TrainingContext(pass_idx=1, batch_idx=3, n_passes=5)"
 
     def test_repr_empty(self):
-        """Only ``num_epochs`` (default 0, not None) shows for a bare context."""
-        assert repr(TrainingContext()) == "TrainingContext(num_epochs=0)"
+        """Only ``n_passes`` (default 0, not None) shows for a bare context."""
+        assert repr(TrainingContext()) == "TrainingContext(n_passes=0)"
 
     def test_repr_multiline_over_threshold(self):
         """Past ``N_CHAR_MAX`` the repr breaks to one field per line."""
-        ctx = TrainingContext(epoch_idx=1, batch_idx=3, num_epochs=5)
+        ctx = TrainingContext(pass_idx=1, batch_idx=3, n_passes=5)
         assert ctx.__repr__(N_CHAR_MAX=10) == (
             "TrainingContext(\n"
-            "    epoch_idx=1,\n"
+            "    pass_idx=1,\n"
             "    batch_idx=3,\n"
-            "    num_epochs=5,\n"
+            "    n_passes=5,\n"
             ")"
         )
 
@@ -362,7 +362,7 @@ class TestGLMStochasticFit:
             solver_name=solver,
             solver_kwargs=self._default_solver_kwargs(solver),
         )
-        model.stochastic_fit(loader, num_epochs=5)
+        model.stochastic_fit(loader, n_passes=5)
 
         np.testing.assert_array_equal(model.intercept_, jnp.zeros(1))
         assert model.coef_.shape == (5,)
@@ -937,7 +937,7 @@ class TestPopulationGLMStochasticFit:
         model = nmo.glm.PopulationGLM(
             fit_intercept=False, solver_name=solver, solver_kwargs=solver_kwargs
         )
-        model.stochastic_fit(loader, num_epochs=5)
+        model.stochastic_fit(loader, n_passes=5)
 
         np.testing.assert_array_equal(model.intercept_, jnp.zeros(3))
         assert model.coef_.shape == (5, 3)

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -184,6 +184,36 @@ class TestCallbackSystem:
         np.testing.assert_array_equal(ctx.params[0], jnp.array([3.0, 4.0]))
         np.testing.assert_array_equal(ctx.params[1], jnp.array([7.0]))
 
+    def test_repr_single_line(self):
+        """A short context renders on one line; None fields are omitted."""
+        ctx = TrainingContext(epoch_idx=1, batch_idx=3, num_epochs=5)
+        assert repr(ctx) == "TrainingContext(epoch_idx=1, batch_idx=3, num_epochs=5)"
+
+    def test_repr_empty(self):
+        """Only ``num_epochs`` (default 0, not None) shows for a bare context."""
+        assert repr(TrainingContext()) == "TrainingContext(num_epochs=0)"
+
+    def test_repr_multiline_over_threshold(self):
+        """Past ``N_CHAR_MAX`` the repr breaks to one field per line."""
+        ctx = TrainingContext(epoch_idx=1, batch_idx=3, num_epochs=5)
+        assert ctx.__repr__(N_CHAR_MAX=10) == (
+            "TrainingContext(\n"
+            "    epoch_idx=1,\n"
+            "    batch_idx=3,\n"
+            "    num_epochs=5,\n"
+            ")"
+        )
+
+    def test_repr_shows_recombined_params(self):
+        """``params`` renders through the property: the complete (recombined)
+        parameters, not the partial active-only subtree."""
+        ctx = TrainingContext(
+            params=(jnp.array([1.0]), None), frozen=(None, jnp.array([7.0]))
+        )
+        text = repr(ctx)
+        assert f"params={ctx.params}" in text
+        assert f"params={ctx._params}" not in text
+
     def test_callback_hooks_are_noop(self):
         """Base Callback hooks don't raise."""
         cb = Callback()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -581,7 +581,7 @@ class ComplexParam(Base):
             nmo.glm.GLM(inverse_link_function=deepcopy(jax.numpy.exp)),
             None,
             [],
-            "GLM(observation_model=PoissonObservations(), inverse_link_function=<PjitFunction>, regularizer=UnRegularized(), solver_name='LBFGS')",
+            "GLM(observation_model=PoissonObservations(), inverse_link_function=<PjitFunction>, regularizer=UnRegularized(), fit_intercept=True, solver_name='LBFGS')",
         ),
     ],
 )
@@ -668,6 +668,7 @@ def test_inspect_npz(tmp_path, model_class, monkeypatch, capsys):
         lines.append("feature_mask           : None")
 
     lines += [
+        "fit_intercept          : True",
         "inverse_link_function  : jax.numpy.exp",
         "observation_model      : {'class': 'nemos.observation_models.PoissonObservations'}",
         "regularizer            : {'class': 'nemos.regularizer.Ridge'}",


### PR DESCRIPTION
## Summary

Some models, including the Fourier approximate GP regression we plan to implement, are more easily implemented if the intercept term is included as part of the design matrix and regularized appropriately. To allow this behavior, we introduced a new parameter for the GLM: a boolean flag `fit_intercept` that by default is True (usual behavior) and when False it pins the intercept to zero. 

The implementation is done by marking which parameter sub-tree must be kept frozen + an initialization that enforces the intercept to be frozen and pinned to zero. 

The frozen parameter machinery is implemented at the level of the `BaseRegressor` and will be hopefully re-usable to allow partial parameter specifications in the future. 

A new weights initialization procedure is introduced for the `fit_intercept=False` case. Specifically, since the intercept is pinned to 0, the coefficients must be set to somewhat match the mean firing rate of the neuron(s). This limits the risk of nans, or infs in the log-likelihood which may occur when the predicted rate is very far off the observed one.  

The initialization chosen is to set the weights to a constant $c$ minimizing,

$$
c^* = \text{argmin}_{c \in \mathbb{R}} \sum_t (s_t \cdot c - f^{-1}(\bar{y}))^2 ,
$$

where $s_t = \sum_i X_{ti}$, the sum over rows of the design matrix $X$, $\bar{y} = \frac{1}{T} \sum_t y_t$ is the mean firing rate per bin and $f$ is the non-linearity. This guarantees that the predicted rate at the initial parameters $f(X_t \cdot w_0) = f(s_t \cdot c^*)$ approximates the mean rate of the neuron(s).

## Motivation

Not including the intercept term enables regularizing over all the GLM parameters (the intercept is unregularized currently). This feature is new and enables some interesting model specifications. For example, one can perform approximate GP regression with NeMoS with an appropriately defined design matrix, but this model instance requires that all parameters are ridge regularized. 

The more limited implementation would have been to pin the intercept to zero at the GLM level. However we opted for a solution that is more aligned with the package future plans: we introduced additional `BaseRegressor` machinery that marks frozen and active parameters. The frozen parameters are pinned, the active will be learned. This machinery works for the simple case of pinning the intercept to zero, which is all we need here, but should be reusable more generally. 

Ideally, in the future, it will enable to partition a parameter tree into an active and a frozen sub-tree, and learn just what one needs. #485 is an example of a use case, freezing the intercept to a specific value and learning the coefficients.

## Implementation Details

### `BaseRegressor`

**Class attributes**

- `_active_params`: a tree of booleans with the same structure of the model params  or `None`.  This marks which parameters should be learned, and it is used to split the parameter tree via [`equinox.partition`](https://docs.kidger.site/equinox/api/manipulation/#equinox.partition).
- `_frozen_params`: a tree of arrays or `None` matching the model parameter structure. This includes the parameter that are pinned to a specific value. It is required for iterative fitting loops using `update`; at each iteration we need a reference to the pinned parameter value.

**Methods**

- **New** `_partition_active` method that uses `_active_params` to split the parameter tree in frozen and active.
- **New** `_run_optimizer` method (used by`fit` and `stochastic_fit`). This is a thin wrapper of the solver run method which partitions, initializes, run the solver and recombines the parameters in a single call.
- **New** `_normalize_user_params` method. A hook necessary to fill in the zero intercept as a frozen parameter. By default it does nothing.
- **Updated** `_instantiate_solver`. This method receives an optional `frozen_params` parameter. When this is provided, the loss function is wrapped with a tree recombination step which forms the full parameter tree from the initial active and the frozen parameters.
- **Updated** `initialize_optimizer_and_state`. This public method is invoked before an update loop to initialize the solver and the state. The method was updated to partition the initial parameters, and cache the frozen parameter for the update loop.

### `glm` Module 

- **New** `initialize_constant_coef_matching_mean_rate`. This performs the initialization described in the summary. The formula for the optimal c is analytical and fast to compute. Additionally, a machine precision correction is added to take care of the case of zeros design matrix, preventing `c=inf` or `c=nan`
- **Updated** `_resolve_default_solver` which for now, sets `"LBFGS"` for ridge regression and no intercept. This is only temporary because currently the Hessian is not via autodiff. @wulfdewolf is working on a full autodiff path in another branch. After that is done we can drop this extra bit of machinery.
- **Updated** `_model_specific_initialization`. This method now calls different initialization paths depending on `fit_intercept`. 
- **New** `_normalize_user_params` overrides. This method takes care of setting the frozen parameters for the intercept to a zeros. If the user provided initial parameters that include the intercept and the model is set to `fit_intercept=False`, the method warns the user that the intercept is not being fit and will be pinned to zero.
- **Updated** `fit` method. It now relies on `_run_optimizer` to take care of the partial parameter specification machinery at the base regressor level.
- **Updated** `stochastic_fit`: wrap the training context (used by callbacks monitoring the fit convergence etc) in a function that stores the frozen parameters a context attribute, then runs the stochastic optimization. This wrapping is needed because the frozen parameter are populated as part the `_run_optimizer` call, and are not available at context creation. 
- **Updated** `_estimate_resid_degrees_of_freedom` count the dof based on the active parameters only.
- **Updated** `_initialize_optimizer_and_state`. This method now routes down the frozen parameter to `_instantiate_solver`. 
- **Updated** `update`. The method now get the set of active parameter and uses the cached frozen parameters for computing optimization updates.

### TrainingContext

This context now needs to store the frozen parameters. The user is not exposed to frozen and active params in training,  the parameters are recombined as a property. In order to define the property, I dropped the `dataclass` and used a standard `__init__` method. Additionally, I added a simple repr that mimicked that of a `dataclass`.

 

