### PR TITLE
Fft convolve

### DIFF
--- a/src/nemos/convolve.py
+++ b/src/nemos/convolve.py
@@ -39,8 +39,8 @@ _CORR_VEC_FFT = jax.vmap(partial(fftconvolve, mode="valid"), (1, None), 1)
 _CORR_VEC_FFT = jax.vmap(_CORR_VEC_FFT, (None, 1), 2)
 
 # FFT-based convolution is asymptotically cheaper once the kernel length grows large
-# relative to log2(num_samples). This factor sets that crossover for the CPU heuristic;
-# it is deliberately conservative and tunable.
+# relative to log2 of the convolution block size. This factor sets that crossover for the
+# CPU heuristic; it is deliberately conservative and tunable.
 _FFT_WINDOW_LOG_FACTOR = 3.0
 
 
@@ -59,20 +59,29 @@ def _array_on_cpu(array: Any) -> bool:
         return False
 
 
-def _resolve_use_fft(use_fft: Optional[bool], array: Any, eval_basis: NDArray) -> bool:
+def _resolve_use_fft(
+    use_fft: Optional[bool],
+    array: Any,
+    eval_basis: NDArray,
+    batch_size_samples: int,
+) -> bool:
     """Decide whether to run FFT-based convolution for a single input array.
 
     ``use_fft=True``/``False`` forces the choice. When ``None``, the heuristic engages
-    only on CPU (comparing kernel length against ``log2(num_samples)``); on other
+    only on CPU (comparing kernel length against ``log2`` of the block size); on other
     backends it returns ``False``, deferring device convolution to XLA.
+
+    The comparison uses ``batch_size_samples`` -- the length each FFT actually operates
+    on -- rather than the full sample-axis length, since with sample batching the FFT is
+    applied per block. The two coincide only when there is no sample batching.
     """
     if use_fft is not None:
         return use_fft
     if not _array_on_cpu(array):
         return False
-    n_samples = array.shape[0]
+    block_size = min(batch_size_samples, array.shape[0])
     window_size = eval_basis.shape[0]
-    return window_size > _FFT_WINDOW_LOG_FACTOR * max(1.0, log2(max(n_samples, 2)))
+    return window_size > _FFT_WINDOW_LOG_FACTOR * max(1.0, log2(max(block_size, 2)))
 
 
 def _reorganize_scan_out(out, axis):
@@ -453,7 +462,7 @@ def _shift_time_axis_and_convolve(
     array = jnp.swapaxes(array, 0, axis)
 
     # convolve
-    if _resolve_use_fft(use_fft, array, eval_basis):
+    if _resolve_use_fft(use_fft, array, eval_basis, batch_size_samples):
         if batch_size_samples < array.shape[0]:
             # sample axis is batched: overlap-save FFT over blocks of batch_size_samples
             conv = _fft_overlap_save_convolve(

--- a/src/nemos/convolve.py
+++ b/src/nemos/convolve.py
@@ -47,14 +47,11 @@ _FFT_WINDOW_LOG_FACTOR = 3.0
 def _array_on_cpu(array: Any) -> bool:
     """Return whether ``array`` lives on a CPU device.
 
-    Host/NumPy arrays count as CPU. Abstract values (e.g. tracers under ``jit``) have
-    no concrete device, so we return ``False`` to keep them on the direct path.
+    Under ``jit`` the array is a tracer with no concrete device and ``.devices()`` raises;
+    in that case we return ``False`` so the caller falls back to the direct path.
     """
-    devices = getattr(array, "devices", None)
-    if devices is None:
-        return True
     try:
-        return all(d.platform == "cpu" for d in devices())
+        return all(d.platform == "cpu" for d in array.devices())
     except Exception:
         return False
 
@@ -69,11 +66,15 @@ def _resolve_use_fft(
 
     ``use_fft=True``/``False`` forces the choice. When ``None``, the heuristic engages
     only on CPU (comparing kernel length against ``log2`` of the block size); on other
-    backends it returns ``False``, deferring device convolution to XLA.
+    devices it returns ``False``, deferring the algorithm choice to XLA.
 
     The comparison uses ``batch_size_samples`` -- the length each FFT actually operates
     on -- rather than the full sample-axis length, since with sample batching the FFT is
     applied per block. The two coincide only when there is no sample batching.
+
+    Note: under ``jit`` the array is a tracer with no concrete device, so it is treated as
+    non-CPU and the direct path is used. To use FFT while tracing, pass an explicit
+    ``use_fft=True``.
     """
     if use_fft is not None:
         return use_fft
@@ -658,13 +659,12 @@ def create_convolutional_predictor(
         of kernels. Default vectorizes over all basis kernels.
     use_fft :
         Whether to compute the convolution in the frequency domain via
-        :func:`jax.scipy.signal.fftconvolve`. If ``True``/``False`` the choice is forced;
-        if ``None`` (default) it is resolved per input array by a heuristic that selects
-        FFT for long kernels on CPU and otherwise defers to the direct convolution. The
-        FFT result matches the direct one up to floating-point round-off. ``batch_size_samples``
-        still applies under FFT: if set below the sample-axis length, the convolution is
-        batched over samples via overlap-save; otherwise the full sample axis is
-        transformed at once.
+        :func:`jax.scipy.signal.fftconvolve`. ``True`` or ``False`` forces the choice,
+        while ``None`` (the default) resolves it per input array with a heuristic that
+        selects FFT for long kernels on CPU and otherwise falls back to the direct
+        convolution. At jit-compilation time the device is unavailable, so the default
+        direct (``jnp.convolve``) path is dispatched; set ``use_fft=True`` to force the
+        FFT convolution under jit.
 
     Returns
     -------
@@ -690,6 +690,13 @@ def create_convolutional_predictor(
         Raised if any explicitly provided batch sizes—``batch_size_samples``,
         ``batch_size_channels``, or ``batch_size_basis``—are not positive integers.
         A value of ``None`` is allowed and treated as unspecified.
+
+    Notes
+    -----
+    Under ``jax.jit`` the inputs are tracers with no concrete device, so the automatic
+    backend selection (``use_fft=None``) cannot inspect device placement and falls back
+    to the direct convolution. If you need the FFT path while tracing, do not rely on the
+    auto-detection: pass ``use_fft=True`` explicitly.
 
     """
     # apply checks

--- a/src/nemos/convolve.py
+++ b/src/nemos/convolve.py
@@ -318,12 +318,13 @@ def _fft_convolve(
     batch_size_channels: int,
     batch_size_basis: int,
 ):
-    """FFT-based counterpart of :func:`_tensor_convolve`.
+    """FFT-based counterpart of :func:`_tensor_convolve`, without sample batching.
 
     Produces the same ``"valid"`` convolution and output shape as ``_tensor_convolve``,
     but replaces the direct correlation primitive with an FFT one. The full sample axis
-    is transformed at once, so ``batch_size_samples`` does not apply here; memory is
-    still batched over channels and basis filters.
+    is transformed at once (a single FFT), so this variant does not batch over samples;
+    memory is still batched over channels and basis filters. Use
+    :func:`_fft_overlap_save_convolve` when the sample axis must be batched.
     """
     n_samples, *feat_shape = array.shape
 
@@ -333,6 +334,69 @@ def _fft_convolve(
     conv_output = _batch_convolve_over_channels(
         array, eval_basis, batch_size_channels, batch_size_basis, corr_vec=_CORR_VEC_FFT
     )
+    return conv_output.reshape(n_samples - window_size + 1, *feat_shape, n_basis)
+
+
+def _fft_overlap_save_convolve(
+    array: NDArray,
+    eval_basis: NDArray,
+    batch_size_samples: int,
+    batch_size_channels: int,
+    batch_size_basis: int,
+):
+    """Overlap-save FFT convolution over a batched sample axis.
+
+    Long inputs are convolved in blocks of ``batch_size_samples`` rather than with a
+    single full-length FFT. Consecutive blocks overlap by ``window_size - 1`` samples,
+    and each block's ``"valid"`` FFT convolution contributes
+    ``batch_size_samples - window_size + 1`` outputs that tile the result contiguously
+    (the overlap-save method). The blocking (pad/step/scan) mirrors
+    :func:`_tensor_convolve` exactly, so the output is identical to the direct path up to
+    floating-point round-off; only the per-block primitive differs (FFT vs. direct).
+
+    This function is used only when the sample axis is actually batched
+    (``batch_size_samples < n_samples``); the non-batched case goes through
+    :func:`_fft_convolve` (a single FFT).
+    """
+    n_samples, *feat_shape = array.shape
+
+    array = array.reshape(n_samples, -1)
+    window_size, n_basis = eval_basis.shape
+    n_features = array.shape[1]
+
+    step = batch_size_samples - window_size + 1
+    n_samples_padded = (
+        ((n_samples - window_size + 1 + step - 1) // step) * step + window_size - 1
+    )
+    n_batches = (n_samples_padded - window_size + 1) // step
+
+    pad_len = n_samples_padded - n_samples
+    array = jnp.pad(array, ((0, pad_len), (0, 0)), constant_values=0.0)
+
+    def conv_batch(concat_conv, batch_idx):
+        start_chunk = batch_idx * step
+        chunk = jax.lax.dynamic_slice(
+            array, (start_chunk, 0), (batch_size_samples, n_features)
+        )
+        concat_conv = jax.lax.dynamic_update_slice(
+            concat_conv,
+            _batch_convolve_over_channels(
+                chunk,
+                eval_basis,
+                batch_size_channels,
+                batch_size_basis,
+                corr_vec=_CORR_VEC_FFT,
+            ),
+            (start_chunk, 0, 0),
+        )
+        return concat_conv, None
+
+    # initialize output of valid convolution
+    conv_output = jnp.full(
+        (n_samples_padded - window_size + 1, n_features, n_basis), jnp.nan
+    )
+    conv_output, _ = jax.lax.scan(conv_batch, conv_output, jnp.arange(n_batches))
+    conv_output = conv_output[: n_samples - window_size + 1]
     return conv_output.reshape(n_samples - window_size + 1, *feat_shape, n_basis)
 
 
@@ -369,7 +433,9 @@ def _shift_time_axis_and_convolve(
         Size of the batches in number of basis filters.
     use_fft :
         Whether to convolve via FFT. If ``None``, the choice is resolved per array by
-        :func:`_resolve_use_fft`. When FFT is used, ``batch_size_samples`` is ignored.
+        :func:`_resolve_use_fft`. When FFT is used and ``batch_size_samples`` is smaller
+        than the sample-axis length, the convolution is batched over samples via
+        overlap-save (:func:`_fft_overlap_save_convolve`); otherwise a single FFT is used.
 
     Returns
     -------
@@ -388,7 +454,20 @@ def _shift_time_axis_and_convolve(
 
     # convolve
     if _resolve_use_fft(use_fft, array, eval_basis):
-        conv = _fft_convolve(array, eval_basis, batch_size_channels, batch_size_basis)
+        if batch_size_samples < array.shape[0]:
+            # sample axis is batched: overlap-save FFT over blocks of batch_size_samples
+            conv = _fft_overlap_save_convolve(
+                array,
+                eval_basis,
+                batch_size_samples,
+                batch_size_channels,
+                batch_size_basis,
+            )
+        else:
+            # whole sample axis at once: a single FFT
+            conv = _fft_convolve(
+                array, eval_basis, batch_size_channels, batch_size_basis
+            )
     else:
         conv = _tensor_convolve(
             array, eval_basis, batch_size_samples, batch_size_channels, batch_size_basis
@@ -573,9 +652,10 @@ def create_convolutional_predictor(
         :func:`jax.scipy.signal.fftconvolve`. If ``True``/``False`` the choice is forced;
         if ``None`` (default) it is resolved per input array by a heuristic that selects
         FFT for long kernels on CPU and otherwise defers to the direct convolution. The
-        FFT result matches the direct one up to floating-point round-off. When FFT is
-        used, ``batch_size_samples`` does not apply (the full sample axis is transformed
-        at once).
+        FFT result matches the direct one up to floating-point round-off. ``batch_size_samples``
+        still applies under FFT: if set below the sample-axis length, the convolution is
+        batched over samples via overlap-save; otherwise the full sample axis is
+        transformed at once.
 
     Returns
     -------

--- a/src/nemos/convolve.py
+++ b/src/nemos/convolve.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import re
 import warnings
 from functools import partial
-from math import prod
+from math import log2, prod
 from typing import Any, Callable, List, Literal, Optional
 
 import jax
 import jax.numpy as jnp
+from jax.scipy.signal import fftconvolve
 from numpy.typing import ArrayLike, NDArray
 
 from . import type_casting, utils, validation
@@ -26,6 +27,52 @@ _CORR_VEC_BASIS = jax.vmap(partial(jnp.convolve, mode="valid"), (None, 1), 1)
 
 _CORR_VEC = jax.vmap(partial(jnp.convolve, mode="valid"), (1, None), 1)
 _CORR_VEC = jax.vmap(_CORR_VEC, (None, 1), 2)
+
+
+# FFT counterpart of `_CORR_VEC`, using `jax.scipy.signal.fftconvolve` as the primitive.
+# The vmap reduces each call to 1D operands (a single basis column and a single input
+# channel), so `fftconvolve` performs a strictly 1D convolution over the sample axis --
+# matching `jnp.convolve(basis_col, signal, mode="valid")` -- rather than convolving over
+# all axes as it would on n-d inputs. The input/output axis layout mirrors `_CORR_VEC`
+# exactly, so the batching helpers route to either primitive transparently.
+_CORR_VEC_FFT = jax.vmap(partial(fftconvolve, mode="valid"), (1, None), 1)
+_CORR_VEC_FFT = jax.vmap(_CORR_VEC_FFT, (None, 1), 2)
+
+# FFT-based convolution is asymptotically cheaper once the kernel length grows large
+# relative to log2(num_samples). This factor sets that crossover for the CPU heuristic;
+# it is deliberately conservative and tunable.
+_FFT_WINDOW_LOG_FACTOR = 3.0
+
+
+def _array_on_cpu(array: Any) -> bool:
+    """Return whether ``array`` lives on a CPU device.
+
+    Host/NumPy arrays count as CPU. Abstract values (e.g. tracers under ``jit``) have
+    no concrete device, so we return ``False`` to keep them on the direct path.
+    """
+    devices = getattr(array, "devices", None)
+    if devices is None:
+        return True
+    try:
+        return all(d.platform == "cpu" for d in devices())
+    except Exception:
+        return False
+
+
+def _resolve_use_fft(use_fft: Optional[bool], array: Any, eval_basis: NDArray) -> bool:
+    """Decide whether to run FFT-based convolution for a single input array.
+
+    ``use_fft=True``/``False`` forces the choice. When ``None``, the heuristic engages
+    only on CPU (comparing kernel length against ``log2(num_samples)``); on other
+    backends it returns ``False``, deferring device convolution to XLA.
+    """
+    if use_fft is not None:
+        return use_fft
+    if not _array_on_cpu(array):
+        return False
+    n_samples = array.shape[0]
+    window_size = eval_basis.shape[0]
+    return window_size > _FFT_WINDOW_LOG_FACTOR * max(1.0, log2(max(n_samples, 2)))
 
 
 def _reorganize_scan_out(out, axis):
@@ -231,10 +278,16 @@ def _tensor_convolve(
 
 
 def _batch_convolve_over_channels(
-    array: NDArray, eval_basis: NDArray, batch_size_channels: int, batch_size_basis: int
+    array: NDArray,
+    eval_basis: NDArray,
+    batch_size_channels: int,
+    batch_size_basis: int,
+    corr_vec: Callable = _CORR_VEC,
 ):
     def conv_over_basis(array_chunk, basis_matrix):
-        return _batch_over_basis_convolve(array_chunk, basis_matrix, batch_size_basis)
+        return _batch_over_basis_convolve(
+            array_chunk, basis_matrix, batch_size_basis, corr_vec
+        )
 
     return _batch_binary_func(
         array, eval_basis, conv_over_basis, batch_size_channels, axis=1
@@ -242,18 +295,45 @@ def _batch_convolve_over_channels(
 
 
 def _batch_over_basis_convolve(
-    array: NDArray, eval_basis: NDArray, batch_size_basis: int
+    array: NDArray,
+    eval_basis: NDArray,
+    batch_size_basis: int,
+    corr_vec: Callable = _CORR_VEC,
 ):
     out = _batch_binary_func(
         eval_basis,
         array,
-        _CORR_VEC,
+        corr_vec,
         batch_size_basis,
         axis=1,
         out_axis=1,
     )
     # move basis axis.
     return out.transpose(0, 2, 1)
+
+
+def _fft_convolve(
+    array: NDArray,
+    eval_basis: NDArray,
+    batch_size_channels: int,
+    batch_size_basis: int,
+):
+    """FFT-based counterpart of :func:`_tensor_convolve`.
+
+    Produces the same ``"valid"`` convolution and output shape as ``_tensor_convolve``,
+    but replaces the direct correlation primitive with an FFT one. The full sample axis
+    is transformed at once, so ``batch_size_samples`` does not apply here; memory is
+    still batched over channels and basis filters.
+    """
+    n_samples, *feat_shape = array.shape
+
+    array = array.reshape(n_samples, -1)
+    window_size, n_basis = eval_basis.shape
+
+    conv_output = _batch_convolve_over_channels(
+        array, eval_basis, batch_size_channels, batch_size_basis, corr_vec=_CORR_VEC_FFT
+    )
+    return conv_output.reshape(n_samples - window_size + 1, *feat_shape, n_basis)
 
 
 def _shift_time_axis_and_convolve(
@@ -263,6 +343,7 @@ def _shift_time_axis_and_convolve(
     batch_size_samples: int,
     batch_size_channels: int,
     batch_size_basis: int,
+    use_fft: Optional[bool] = None,
 ) -> jnp.ndarray:
     """
     Shifts the specified axis to the first position, applies convolution, and then reverses the shift.
@@ -286,6 +367,9 @@ def _shift_time_axis_and_convolve(
         Size of the batches in number of input channels.
     batch_size_basis :
         Size of the batches in number of basis filters.
+    use_fft :
+        Whether to convolve via FFT. If ``None``, the choice is resolved per array by
+        :func:`_resolve_use_fft`. When FFT is used, ``batch_size_samples`` is ignored.
 
     Returns
     -------
@@ -303,9 +387,12 @@ def _shift_time_axis_and_convolve(
     array = jnp.swapaxes(array, 0, axis)
 
     # convolve
-    conv = _tensor_convolve(
-        array, eval_basis, batch_size_samples, batch_size_channels, batch_size_basis
-    )
+    if _resolve_use_fft(use_fft, array, eval_basis):
+        conv = _fft_convolve(array, eval_basis, batch_size_channels, batch_size_basis)
+    else:
+        conv = _tensor_convolve(
+            array, eval_basis, batch_size_samples, batch_size_channels, batch_size_basis
+        )
 
     # reverse transposition
     conv = jnp.swapaxes(conv, axis, 0)
@@ -344,6 +431,7 @@ def _convolve_pad_and_shift(
     predictor_causality: Literal["causal", "acausal", "anti-causal"] = "causal",
     axis: int = 0,
     shift: Optional[bool] = None,
+    use_fft: Optional[bool] = None,
 ) -> jnp.ndarray:
     """
     Create predictor by convolving basis_matrix with time_series.
@@ -381,6 +469,9 @@ def _convolve_pad_and_shift(
         Whether to shift predictor based on causality (only valid if
         `predictor_causality != 'acausal'`). Default is True for `causal` and
         `anti-causal`, False for `acausal`.
+    use_fft :
+        Whether to convolve via FFT. If ``None``, the choice is resolved per array
+        by :func:`_resolve_use_fft`.
 
     Returns
     -------
@@ -395,6 +486,7 @@ def _convolve_pad_and_shift(
         batch_size_samples=batch_size_samples,
         batch_size_channels=batch_size_channels,
         batch_size_basis=batch_size_basis,
+        use_fft=use_fft,
     )
 
     with warnings.catch_warnings(record=True) as warns:
@@ -428,6 +520,7 @@ def create_convolutional_predictor(
     batch_size_samples: Optional[int] = None,
     batch_size_channels: Optional[int] = None,
     batch_size_basis: Optional[int] = None,
+    use_fft: Optional[bool] = None,
 ):
     """
     Create a convolutional predictor by convolving a basis matrix with a time series.
@@ -475,6 +568,14 @@ def create_convolutional_predictor(
         Batch size for the convolution in terms of number of basis kernels.
         If this parameter is set, the convolution will be vectorized over batches
         of kernels. Default vectorizes over all basis kernels.
+    use_fft :
+        Whether to compute the convolution in the frequency domain via
+        :func:`jax.scipy.signal.fftconvolve`. If ``True``/``False`` the choice is forced;
+        if ``None`` (default) it is resolved per input array by a heuristic that selects
+        FFT for long kernels on CPU and otherwise defers to the direct convolution. The
+        FFT result matches the direct one up to floating-point round-off. When FFT is
+        used, ``batch_size_samples`` does not apply (the full sample axis is transformed
+        at once).
 
     Returns
     -------
@@ -570,6 +671,7 @@ def create_convolutional_predictor(
                 predictor_causality=predictor_causality,
                 axis=axis,
                 shift=shift,
+                use_fft=use_fft,
             )
 
         flat_stack = jax.tree_util.tree_map(
@@ -586,6 +688,7 @@ def create_convolutional_predictor(
             batch_size_channels,
             batch_size_samples,
             batch_size_basis,
+            use_fft=use_fft,
         )
     return jax.tree_util.tree_unflatten(struct, flat_stack)
 
@@ -600,6 +703,7 @@ def _convolve_pynapple(
     batch_size_channels: List[int],
     batch_size_samples: List[int],
     batch_size_basis: int,
+    use_fft: Optional[bool] = None,
 ):
     """
     Convolve a PyTree containing pynapple time series.
@@ -685,6 +789,7 @@ def _convolve_pynapple(
                 predictor_causality=predictor_causality,
                 axis=axis,
                 shift=shift,
+                use_fft=use_fft,
             )
 
     conv = jax.tree_util.tree_map(

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -1,6 +1,8 @@
 from contextlib import nullcontext as does_not_raise
+from unittest.mock import Mock
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 import pynapple as nap
 import pytest
@@ -12,6 +14,7 @@ def _get_sample_axis_len(time_series, axis=0):
     return jax.tree_util.tree_leaves(time_series)[0].shape[axis]
 
 
+@pytest.mark.parametrize("use_fft", [False, True])
 class TestShiftTimeAxisAndConvolve:
 
     @pytest.mark.parametrize(
@@ -25,7 +28,7 @@ class TestShiftTimeAxisAndConvolve:
             (np.zeros((1, 20, 1)), lambda x: x.ndim == 4, -3),
         ],
     )
-    def test_output_ndim(self, time_series, check_func, axis):
+    def test_output_ndim(self, time_series, check_func, axis, use_fft):
         """Check that the output dimensionality matches expectation."""
         res = convolve._shift_time_axis_and_convolve(
             time_series,
@@ -34,6 +37,7 @@ class TestShiftTimeAxisAndConvolve:
             batch_size_channels=1,
             batch_size_basis=1,
             batch_size_samples=_get_sample_axis_len(time_series, axis=axis),
+            use_fft=use_fft,
         )
         if not utils.pytree_map_and_reduce(check_func, all, res):
             raise ValueError("Output doesn't match expected structure")
@@ -45,7 +49,7 @@ class TestShiftTimeAxisAndConvolve:
             (np.zeros((1, 20, 1)), 1, (1, 20, 1, 1)),
         ],
     )
-    def test_output_shape(self, time_series, axis, output_shape):
+    def test_output_shape(self, time_series, axis, output_shape, use_fft):
         """Check that the output shape matches expectation."""
 
         def check_func(x):
@@ -58,6 +62,7 @@ class TestShiftTimeAxisAndConvolve:
             batch_size_channels=1,
             batch_size_basis=1,
             batch_size_samples=_get_sample_axis_len(time_series, axis=axis),
+            use_fft=use_fft,
         )
         if not utils.pytree_map_and_reduce(check_func, all, res):
             raise ValueError("Output  number of neuron doesn't match input.")
@@ -71,7 +76,7 @@ class TestShiftTimeAxisAndConvolve:
         ],
     )
     @pytest.mark.parametrize("basis_matrix", [np.zeros((1, 1)), np.zeros((1, 2))])
-    def test_output_num_basis(self, time_series, basis_matrix, axis):
+    def test_output_num_basis(self, time_series, basis_matrix, axis, use_fft):
         """Check that the number of features in input and output matches."""
 
         def check_func(conv):
@@ -84,6 +89,7 @@ class TestShiftTimeAxisAndConvolve:
             batch_size_channels=1,
             batch_size_basis=1,
             batch_size_samples=_get_sample_axis_len(time_series, axis=axis),
+            use_fft=use_fft,
         )
         if not utils.pytree_map_and_reduce(check_func, all, res):
             raise ValueError("Output  number of neuron doesn't match input.")
@@ -94,8 +100,8 @@ class TestShiftTimeAxisAndConvolve:
     @pytest.mark.parametrize(
         "trial_counts", [np.random.normal(size=(2, 10, 3)) for _ in range(2)]
     )
-    def test_valid_convolution_output(self, basis_matrix, trial_counts):
-        """Check output matches numpy convolve."""
+    def test_valid_convolution_output(self, basis_matrix, trial_counts, use_fft):
+        """Check output matches numpy convolve for both the direct and FFT paths."""
         numpy_out = np.zeros(
             (
                 trial_counts.shape[0],
@@ -119,6 +125,7 @@ class TestShiftTimeAxisAndConvolve:
                 batch_size_channels=1,
                 batch_size_basis=basis_matrix.shape[1],
                 batch_size_samples=_get_sample_axis_len(trial_counts, axis=1),
+                use_fft=use_fft,
             )
         )
         assert np.allclose(utils_out, numpy_out, rtol=10**-5, atol=10**-5), (
@@ -340,8 +347,15 @@ class TestCreateConvolutionalPredictor:
     @pytest.mark.parametrize("batch_samples", [None, 5])
     @pytest.mark.parametrize("batch_channels", [None, 1, 2])
     @pytest.mark.parametrize("batch_basis", [None, 1, 2])
+    @pytest.mark.parametrize("use_fft", [False, True])
     def test_valid_convolution_output_tree(
-        self, basis_matrix, trial_counts, batch_samples, batch_channels, batch_basis
+        self,
+        basis_matrix,
+        trial_counts,
+        batch_samples,
+        batch_channels,
+        batch_basis,
+        use_fft,
     ):
         numpy_out = np.zeros(
             (
@@ -366,6 +380,7 @@ class TestCreateConvolutionalPredictor:
             batch_size_samples=batch_samples,
             batch_size_basis=batch_basis,
             batch_size_channels=batch_channels,
+            use_fft=use_fft,
         )
         check = all(
             np.allclose(utils_out[k][ws - 1 :], numpy_out[k], rtol=10**-5, atol=10**-5)
@@ -417,6 +432,7 @@ class TestCreateConvolutionalPredictor:
     @pytest.mark.parametrize("batch_samples", [None, 5])
     @pytest.mark.parametrize("batch_channels", [None, 1, 2])
     @pytest.mark.parametrize("batch_basis", [None, 1, 2])
+    @pytest.mark.parametrize("use_fft", [False, True])
     def test_expected_nan(
         self,
         axis,
@@ -427,6 +443,7 @@ class TestCreateConvolutionalPredictor:
         batch_samples,
         batch_channels,
         batch_basis,
+        use_fft,
     ):
         shape = [1, 1, 1]
         shape[axis] = 30
@@ -441,6 +458,7 @@ class TestCreateConvolutionalPredictor:
             batch_size_samples=batch_samples,
             batch_size_basis=batch_basis,
             batch_size_channels=batch_channels,
+            use_fft=use_fft,
         )
         # get expected non-nan idxs
         other_idx = list(set(np.arange(res.shape[1])).difference(nan_idx))
@@ -480,6 +498,7 @@ class TestCreateConvolutionalPredictor:
     @pytest.mark.parametrize("batch_samples", [None, 5])
     @pytest.mark.parametrize("batch_channels", [None, 1, 2])
     @pytest.mark.parametrize("batch_basis", [None, 1, 2])
+    @pytest.mark.parametrize("use_fft", [False, True])
     def test_multi_epoch_pynapple(
         self,
         tsd,
@@ -490,6 +509,7 @@ class TestCreateConvolutionalPredictor:
         batch_samples,
         batch_channels,
         batch_basis,
+        use_fft,
     ):
         """Test nan location in multi-epoch pynapple tsd."""
         basis = np.zeros((window_size, 1))
@@ -501,6 +521,7 @@ class TestCreateConvolutionalPredictor:
             batch_size_samples=batch_samples,
             batch_size_basis=batch_basis,
             batch_size_channels=batch_channels,
+            use_fft=use_fft,
         )
 
         nan_index = np.sort(nan_index)
@@ -731,6 +752,160 @@ def test_tensor_convolve(input_shape, basis_shape, batch_sizes):
     expected = numpy_tensor_convolve(np.array(array), np.array(eval_basis))
 
     np.testing.assert_allclose(np.array(result), expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("input_shape", [(30, 4), (50, 6)])
+@pytest.mark.parametrize("basis_shape", [(5, 3), (7, 2)])
+@pytest.mark.parametrize("batch_channels", [1, 2])
+@pytest.mark.parametrize("batch_basis", [1, 2])
+def test_fft_convolve(input_shape, basis_shape, batch_channels, batch_basis):
+    """Test the FFT path against the naive implementation across channel/basis batch
+    combinations (``_fft_convolve`` has no sample batching, so ``batch_size_samples``
+    is not a parameter, and it takes resolved integer batch sizes, so ``None`` is not
+    a valid value here)."""
+    key = jax.random.PRNGKey(0)
+    array = jax.random.normal(key, shape=input_shape)
+    eval_basis = jax.random.normal(key, shape=basis_shape)
+
+    result = convolve._fft_convolve(array, eval_basis, batch_channels, batch_basis)
+    expected = numpy_tensor_convolve(np.array(array), np.array(eval_basis))
+
+    np.testing.assert_allclose(np.array(result), expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("input_shape", [(60, 4), (50, 6)])
+@pytest.mark.parametrize("basis_shape", [(5, 3), (7, 2)])
+# block sizes that both evenly and unevenly tile the sample axis
+@pytest.mark.parametrize("batch_samples", [10, 16, 23])
+@pytest.mark.parametrize("batch_channels", [1, 2])
+@pytest.mark.parametrize("batch_basis", [1, 2])
+def test_fft_overlap_save_convolve(
+    input_shape, basis_shape, batch_samples, batch_channels, batch_basis
+):
+    """Overlap-save FFT matches the naive implementation across block sizes and
+    channel/basis batch combinations."""
+    key = jax.random.PRNGKey(0)
+    array = jax.random.normal(key, shape=input_shape)
+    eval_basis = jax.random.normal(key, shape=basis_shape)
+
+    result = convolve._fft_overlap_save_convolve(
+        array, eval_basis, batch_samples, batch_channels, batch_basis
+    )
+    expected = numpy_tensor_convolve(np.array(array), np.array(eval_basis))
+
+    np.testing.assert_allclose(np.array(result), expected, rtol=1e-5, atol=1e-5)
+
+
+def _shaped_noop(array, eval_basis, *args, **kwargs):
+    """Zero-valued stand-in for a convolution, shaped like a ``"valid"`` result.
+
+    Mirrors how model-fit tests replace an expensive call with a noop: it lets the
+    surrounding pad/shift machinery run while skipping the actual convolution.
+    """
+    n_out = array.shape[0] - eval_basis.shape[0] + 1
+    return jnp.zeros((n_out, *array.shape[1:], eval_basis.shape[1]))
+
+
+@pytest.mark.parametrize(
+    "use_fft, window_size, n_samples, batch_samples, expected",
+    [
+        # forced direct, with or without sample batching
+        (False, 64, 128, None, "direct"),
+        (False, 64, 128, 100, "direct"),
+        # forced FFT: full FFT when unbatched / batch spans the axis, overlap-save when
+        # the block is smaller than the sample axis
+        (True, 4, 128, None, "full_fft"),
+        (True, 4, 128, 128, "full_fft"),
+        (True, 4, 128, 50, "overlap_save"),
+        # use_fft=None: CPU heuristic routes on window vs log2(n_samples), then the batch
+        # size selects full FFT vs overlap-save
+        (None, 4, 1024, None, "direct"),  # short kernel -> direct
+        (None, 64, 128, None, "full_fft"),  # long kernel, unbatched -> full FFT
+        (None, 64, 128, 100, "overlap_save"),  # long kernel, batched -> overlap-save
+    ],
+)
+def test_use_fft_routing(
+    monkeypatch, use_fft, window_size, n_samples, batch_samples, expected
+):
+    """``use_fft`` (incl. the ``None`` heuristic) and ``batch_size_samples`` together
+    dispatch to the right implementation: direct, single FFT, or overlap-save FFT.
+
+    All three backends are replaced with shaped noops so the test asserts only on which
+    one is invoked, not on numerical output.
+    """
+    mocks = {
+        "direct": Mock(side_effect=_shaped_noop),
+        "full_fft": Mock(side_effect=_shaped_noop),
+        "overlap_save": Mock(side_effect=_shaped_noop),
+    }
+    monkeypatch.setattr(convolve, "_tensor_convolve", mocks["direct"])
+    monkeypatch.setattr(convolve, "_fft_convolve", mocks["full_fft"])
+    monkeypatch.setattr(convolve, "_fft_overlap_save_convolve", mocks["overlap_save"])
+
+    time_series = np.zeros((n_samples, 2))
+    basis_matrix = np.zeros((window_size, 3))
+    convolve.create_convolutional_predictor(
+        basis_matrix, time_series, use_fft=use_fft, batch_size_samples=batch_samples
+    )
+
+    mocks.pop(expected).assert_called()
+    for name, mock in mocks.items():
+        mock.assert_not_called()
+
+
+@pytest.mark.parametrize("batch_channels", [None, 1, 2])
+@pytest.mark.parametrize("batch_basis", [None, 1, 2])
+def test_fft_path_uses_batching(monkeypatch, batch_channels, batch_basis):
+    """The FFT path routes through the batching machinery with the FFT primitive.
+
+    The FFT correlation op is swapped for a jittable noop, and ``_batch_binary_func`` is
+    spied on (delegating to the real implementation) to verify that the user-provided
+    channel/basis batch sizes are threaded through and that the FFT primitive is the
+    innermost callable, across every combination of the two batch sizes.
+    """
+
+    def fake_corr(eval_basis, array):
+        # match `_CORR_VEC` output layout: (n_out, n_basis, n_channels)
+        n_out = array.shape[0] - eval_basis.shape[0] + 1
+        return jnp.zeros((n_out, eval_basis.shape[1], array.shape[1]))
+
+    monkeypatch.setattr(convolve, "_CORR_VEC_FFT", fake_corr)
+
+    spy_binary = Mock(wraps=convolve._batch_binary_func)
+    spy_fft = Mock(wraps=convolve._fft_convolve)
+    spy_direct = Mock(wraps=convolve._tensor_convolve)
+    monkeypatch.setattr(convolve, "_batch_binary_func", spy_binary)
+    monkeypatch.setattr(convolve, "_fft_convolve", spy_fft)
+    monkeypatch.setattr(convolve, "_tensor_convolve", spy_direct)
+
+    n_channels, n_basis = 4, 3
+    time_series = np.random.randn(60, n_channels)
+    basis_matrix = np.random.randn(6, n_basis)
+    convolve.create_convolutional_predictor(
+        basis_matrix,
+        time_series,
+        use_fft=True,
+        batch_size_channels=batch_channels,
+        batch_size_basis=batch_basis,
+    )
+
+    # `None` means "one batch spanning the whole axis"; otherwise it is capped at the size.
+    expected_channels = n_channels if batch_channels is None else min(batch_channels, n_channels)
+    expected_basis = n_basis if batch_basis is None else min(batch_basis, n_basis)
+
+    # the FFT path is taken, the direct path is not
+    spy_fft.assert_called_once()
+    spy_direct.assert_not_called()
+
+    # batching machinery is exercised, and the resolved batch sizes are threaded through
+    # (`batch_size` is the 4th positional arg of `_batch_binary_func`)
+    batch_sizes = {call.args[3] for call in spy_binary.call_args_list}
+    assert {expected_channels, expected_basis}.issubset(batch_sizes)
+
+    # the FFT primitive is the innermost callable passed to the batched convolution
+    # (`binary_func` is the 3rd positional arg)
+    binary_funcs = [call.args[2] for call in spy_binary.call_args_list]
+    assert fake_corr in binary_funcs
 
 
 @pytest.mark.parametrize(

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -910,6 +910,43 @@ def test_fft_path_uses_batching(monkeypatch, batch_channels, batch_basis):
     assert fake_corr in binary_funcs
 
 
+def test_use_fft_none_is_jit_safe():
+    """``use_fft=None`` is safe to trace under ``jit``.
+
+    While tracing, the array is a tracer whose ``.devices()`` raises; ``_array_on_cpu``
+    catches it and returns ``False``, so the heuristic falls back to the direct path.
+    The end result is that ``create_convolutional_predictor`` compiles and its output
+    matches the eager direct convolution.
+    """
+    # the guard is exercised under a trace: the tracer's .devices() raises and is caught
+    on_cpu_under_jit = {}
+
+    @jax.jit
+    def probe(x):
+        on_cpu_under_jit["value"] = convolve._array_on_cpu(x)
+        return x
+
+    probe(jnp.zeros((5,)))
+    assert on_cpu_under_jit["value"] is False
+
+    # end-to-end: use_fft=None compiles and equals the direct path
+    rng = np.random.default_rng(0)
+    kernel = rng.standard_normal((6, 4))
+    time_series = rng.standard_normal((60, 3))
+    jitted = jax.jit(
+        lambda k, x: convolve.create_convolutional_predictor(k, x, use_fft=None)
+    )
+    np.testing.assert_allclose(
+        np.asarray(jitted(kernel, time_series)),
+        np.asarray(
+            convolve.create_convolutional_predictor(kernel, time_series, use_fft=False)
+        ),
+        rtol=1e-5,
+        atol=1e-5,
+        equal_nan=True,
+    )
+
+
 @pytest.mark.parametrize(
     "tsd, nan_placement",
     [

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -817,7 +817,7 @@ def _shaped_noop(array, eval_basis, *args, **kwargs):
         (True, 4, 128, None, "full_fft"),
         (True, 4, 128, 128, "full_fft"),
         (True, 4, 128, 50, "overlap_save"),
-        # use_fft=None: CPU heuristic routes on window vs log2(n_samples), then the batch
+        # use_fft=None: CPU heuristic routes on window vs log2(block size), then the batch
         # size selects full FFT vs overlap-save
         (None, 4, 1024, None, "direct"),  # short kernel -> direct
         (None, 64, 128, None, "full_fft"),  # long kernel, unbatched -> full FFT

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -890,7 +890,9 @@ def test_fft_path_uses_batching(monkeypatch, batch_channels, batch_basis):
     )
 
     # `None` means "one batch spanning the whole axis"; otherwise it is capped at the size.
-    expected_channels = n_channels if batch_channels is None else min(batch_channels, n_channels)
+    expected_channels = (
+        n_channels if batch_channels is None else min(batch_channels, n_channels)
+    )
     expected_basis = n_basis if batch_basis is None else min(batch_basis, n_basis)
 
     # the FFT path is taken, the direct path is not


### PR DESCRIPTION

This PR adds FFT convolution capability to the `convolve` module of nemos.

`convolve.create_convolutional_predictor` gains a new parameter `use_fft`, default `None`. `True`/`False` force the backend; `None` resolves it per input array with the following decision tree:

1. **Device is not CPU** (e.g. GPU/TPU) → use the direct convolution, letting XLA select and fuse device-optimized primitives. Our heuristic is a CPU cost model and the FFT-vs-direct crossover on an accelerator is hardware-dependent, so we do not override the compiler's own algorithm selection. (Under `jit`, an abstract value has no concrete device and takes this branch too, which keeps `use_fft=None` jit-safe.)
2. **Device is CPU** → compare the kernel length against the convolution *block size*: choose FFT when `window_size > FACTOR * log2(block_size)` (`FACTOR = 3.0`, conservative and tunable), otherwise direct. `block_size` is `batch_size_samples` — the length each FFT actually operates on — which equals the sample-axis length only when there is no sample batching.

When FFT is selected, the sample axis is convolved either as a single FFT (no batching) or, when `batch_size_samples < n_samples`, via overlap-save in blocks of `batch_size_samples`. Output matches the direct convolution up to floating-point round-off, and every convolutional basis inherits the option for free (it is a passthrough `conv_kwargs`).


### Backend

| Function | Role |
|---|---|
| `_CORR_VEC_FFT` | FFT primitive: `jax.scipy.signal.fftconvolve(mode="valid")` vmapped with the *same* axis layout as `_CORR_VEC`, so the batching helpers route to either transparently. The two-level vmap reduces each call to 1D operands, so `fftconvolve` does a strictly 1D convolution over the sample axis (it convolves over all axes on n-d input — the vmap is what keeps it 1D). |
| `_fft_convolve` | Single full-length FFT over the whole sample axis. Batches over channels/basis, not samples. |
| `_fft_overlap_save_convolve` | Overlap-save: blocks the sample axis into chunks of `batch_size_samples` overlapping by `window_size − 1`; each block's valid FFT convolution yields `batch_size_samples − window_size + 1` outputs that tile the result. Its pad/step/scan blocking mirrors `_tensor_convolve` exactly, so output is identical to the direct path up to round-off — only the per-block primitive differs. |

`jax.scipy.signal.fftconvolve` was chosen over a hand-rolled `rfft`/`irfft`: it supports `mode="valid"`, auto-swaps when the kernel is shorter than the signal, and is better tested.
