### PR TITLE
Dtype convert bug

### DIFF
--- a/src/nemos/glm/initialize_parameters.py
+++ b/src/nemos/glm/initialize_parameters.py
@@ -140,6 +140,7 @@ def initialize_intercept_matching_mean_rate(
         The initial intercept term, shape (n_neurons,).
 
     """
+    y = jnp.asarray(y, float)
     # return inverse if analytical solution is available
     analytical_inv = get_inverse_function(inverse_link_function)
 

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -28,6 +28,7 @@ from .initialize_parameters import (
     DEFAULT_INIT_FUNCTIONS,
     HMM_INITIALIZATION_FN_DICT,
     KMeansInitializer,
+    _resolution_was_noop,
     _resolve_dirichlet_priors,
     _validate_init_funcs_keys,
     generate_hmm_initial_params,
@@ -378,6 +379,10 @@ class BaseHMM(
             value, DEFAULT_INIT_FUNCTIONS
         )
         self._hmm_setup()
+        if value is not None and _resolution_was_noop(
+            value, self._hmm_initialization_funcs
+        ):
+            self._hmm_initialization_funcs = value
 
     @property
     def model_initialization_funcs(self) -> MODEL_INITIALIZATION_FN_DICT_T | None:
@@ -398,6 +403,10 @@ class BaseHMM(
             value, self._model_default_init_dict
         )
         self._model_setup()
+        if value is not None and _resolution_was_noop(
+            value, self._model_initialization_funcs
+        ):
+            self._model_initialization_funcs = value
 
     def _hmm_params_initialization(
         self,

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -32,6 +32,8 @@ from .initialize_parameters import (
     _resolve_dirichlet_priors,
     _validate_init_funcs_keys,
     generate_hmm_initial_params,
+    kmeans_initial_proba_init,
+    kmeans_transition_proba_init,
     setup_hmm_initialization,
 )
 from .params import HMMModelParamsT, HMMUserParams, HMMUserProvidedParamsT
@@ -192,11 +194,6 @@ class BaseHMM(
         transition_proba_init_kwargs :
             A dictionary of keyword arguments to pass to the transition probability initialization function.
         """
-        # flag for initializing kmeans model at parameter initialization
-        self._hmm_use_kmeans = {
-            "initial_proba_init": initial_proba_init == "kmeans",
-            "transition_proba_init": transition_proba_init == "kmeans",
-        }
         self._hmm_initialization_funcs = setup_hmm_initialization(
             initial_proba_init=initial_proba_init,
             initial_proba_init_kwargs=initial_proba_init_kwargs,
@@ -204,6 +201,20 @@ class BaseHMM(
             transition_proba_init_kwargs=transition_proba_init_kwargs,
             init_funcs=self._hmm_initialization_funcs,
         )
+        # flag for initializing kmeans model at parameter initialization; derived
+        # from the identity of the stored callables so the flag stays accurate when
+        # the dict is set via the hmm_initialization_funcs property (e.g. sklearn
+        # clone) and not only when the string "kmeans" is passed to setup
+        self._hmm_use_kmeans = {
+            "initial_proba_init": (
+                self._hmm_initialization_funcs["initial_proba_init"]
+                is kmeans_initial_proba_init
+            ),
+            "transition_proba_init": (
+                self._hmm_initialization_funcs["transition_proba_init"]
+                is kmeans_transition_proba_init
+            ),
+        }
 
     @abc.abstractmethod
     def _model_setup(self, **kwargs):

--- a/src/nemos/hmm/initialize_parameters.py
+++ b/src/nemos/hmm/initialize_parameters.py
@@ -769,6 +769,18 @@ def _validate_init_funcs_keys(
     return init_funcs
 
 
+def _resolution_was_noop(value: dict, resolved: dict) -> bool:
+    """Check that resolving ``value`` left keys and value identities unchanged.
+
+    Used by the ``*_initialization_funcs`` setters to keep the caller's dict when
+    resolution changed nothing, so sklearn clone's identity round-trip
+    (``get_params -> __init__ -> get_params``) holds.
+    """
+    return value.keys() == resolved.keys() and all(
+        value[k] is resolved[k] for k in value
+    )
+
+
 def _resolve_existing_slots(
     init_funcs: dict,
     slot_keys: Tuple[str, ...],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2008,11 +2008,14 @@ def instantiate_base_regressor_subclass(request):
     obs_model: str | nmo.observation_models.Observations = request.param["obs_model"]
     simulate: bool = request.param["simulate"]
 
-    # Create cache key (class-scoped)
+    # Create cache key (class-scoped). Include the x64 flag: data simulated under
+    # one precision must not be served to tests running under the other (the
+    # requires_x64 marker partitions the configs per test, not the cache).
     cache_key = (
         model_name,
         str(obs_model),
         simulate,
+        jax.config.jax_enable_x64,
         id(request.cls) if request.cls else id(request.module),
     )
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -156,8 +156,8 @@ def compare_basis(b1, b2):
         freqs1 = b1.__dict__.get("_freq_combinations", -1)
         freqs2 = b2.__dict__.get("_freq_combinations", -1)
         assert np.all(freqs1 == freqs2)
-        f1, f2 = b1.__dict__.pop("_funcs", [True]), b2.__dict__.pop("_funcs", [True])
-        assert all(fi == fj for fi, fj in zip(f1, f2))
+        f1, f2 = b1.__dict__.get("_funcs", [True]), b2.__dict__.get("_funcs", [True])
+        assert all(fi == fj for fi, fj in zip(f1, f2, strict=True))
         d1 = filter_attributes(
             b1,
             exclude_keys=[
@@ -165,6 +165,7 @@ def compare_basis(b1, b2):
                 "_parent",
                 "_frequencies",
                 "_freq_combinations",
+                "_funcs",
             ],
         )
         d2 = filter_attributes(
@@ -174,6 +175,7 @@ def compare_basis(b1, b2):
                 "_parent",
                 "_frequencies",
                 "_freq_combinations",
+                "_funcs",
             ],
         )
         assert d1 == d2

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -149,13 +149,13 @@ def compare_basis(b1, b2):
     else:
         decay_rates_b1 = b1.__dict__.get("_decay_rates", -1)
         decay_rates_b2 = b2.__dict__.get("_decay_rates", -1)
-        assert np.array_equal(decay_rates_b1, decay_rates_b2)
+        np.testing.assert_array_equal(decay_rates_b1, decay_rates_b2)
         freqs1 = b1.__dict__.get("_frequencies", [-1])
         freqs2 = b2.__dict__.get("_frequencies", [-1])
         assert all(np.all(fi == fj) for fi, fj in zip(freqs1, freqs2))
         freqs1 = b1.__dict__.get("_freq_combinations", -1)
         freqs2 = b2.__dict__.get("_freq_combinations", -1)
-        assert np.all(freqs1 == freqs2)
+        np.testing.assert_array_equal(freqs1 == freqs2)
         f1, f2 = b1.__dict__.get("_funcs", [True]), b2.__dict__.get("_funcs", [True])
         assert all(fi == fj for fi, fj in zip(f1, f2, strict=True))
         d1 = filter_attributes(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -155,7 +155,7 @@ def compare_basis(b1, b2):
         assert all(np.all(fi == fj) for fi, fj in zip(freqs1, freqs2))
         freqs1 = b1.__dict__.get("_freq_combinations", -1)
         freqs2 = b2.__dict__.get("_freq_combinations", -1)
-        np.testing.assert_array_equal(freqs1 == freqs2)
+        np.testing.assert_array_equal(freqs1, freqs2)
         f1, f2 = b1.__dict__.get("_funcs", [True]), b2.__dict__.get("_funcs", [True])
         assert all(fi == fj for fi, fj in zip(f1, f2, strict=True))
         d1 = filter_attributes(

--- a/tests/test_glm_hmm_class.py
+++ b/tests/test_glm_hmm_class.py
@@ -111,6 +111,27 @@ def test_get_fit_attrs(instantiate_base_regressor_subclass, mock_glm_hmm_optimiz
 class TestGLMHMM:
     """Unit tests for GLMHMM.fit that are observation-model-agnostic."""
 
+    @pytest.mark.requires_x64
+    def test_fit_accepts_bool_y(self, instantiate_base_regressor_subclass):
+        """Test that bool array are valid inputs.
+
+        Notes
+        -----
+        The test requires x64 to generate a corner case. The initialization function
+        for the intercept calls a``jnp.nanmean``, which for bool arrays returns x32
+        regardless of the jax configuration.
+        If we do not cast y to float (inheriting the dtype from the configurations)
+        the dtype change will raise at compilation time. This bug emerges only if the
+        jax configuration is enabling x64, otherwise everything would remain x32 and
+        the compilation would not raise.
+        """
+        fixture = instantiate_base_regressor_subclass
+        n = 10
+        X = fixture.X[:n]
+        y = fixture.y[:n]
+        y = y.astype(bool)
+        fixture.model.fit(X, y)
+
     def test_fit_pynapple_tsd(self, instantiate_base_regressor_subclass):
         """Pynapple TSD/TsdFrame accepted; session boundaries affect the fit."""
         fixture = instantiate_base_regressor_subclass

--- a/tests/test_glm_hmm_class_init.py
+++ b/tests/test_glm_hmm_class_init.py
@@ -424,9 +424,7 @@ def _init_funcs_attr(func_name):
 
 
 def _use_kmeans_attr(func_name):
-    return (
-        "_model_use_kmeans" if func_name in _GLM_FUNC_NAMES else "_hmm_use_kmeans"
-    )
+    return "_model_use_kmeans" if func_name in _GLM_FUNC_NAMES else "_hmm_use_kmeans"
 
 
 def _filter_attributes(obj, exclude_keys):

--- a/tests/test_glm_hmm_class_init.py
+++ b/tests/test_glm_hmm_class_init.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock, create_autospec, patch
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
+from sklearn.base import clone
 
 from nemos._inspect_utils import extract_literal_options
 from nemos.glm_hmm.glm_hmm import GLMHMM
@@ -400,3 +402,123 @@ class TestGLMHMMCheckModelIsFit:
         model = GLMHMM(n_states=2)
         with pytest.raises(ValueError):
             model._check_model_is_fit()
+
+
+# =============================================================================
+# TestGLMHMMSklearnClone — identity round-trip of the init-func dicts
+# =============================================================================
+
+
+def _get_custom_func(func_name):
+    # plain functions, not autospec mocks: sklearn clone deepcopies params, and
+    # deepcopy preserves identity for functions but returns a new object for mocks
+    return _glm_mock_template if func_name in _GLM_FUNC_NAMES else _hmm_mock_template
+
+
+def _init_funcs_attr(func_name):
+    return (
+        "model_initialization_funcs"
+        if func_name in _GLM_FUNC_NAMES
+        else "hmm_initialization_funcs"
+    )
+
+
+def _use_kmeans_attr(func_name):
+    return (
+        "_model_use_kmeans" if func_name in _GLM_FUNC_NAMES else "_hmm_use_kmeans"
+    )
+
+
+def _filter_attributes(obj, exclude_keys):
+    return {k: v for k, v in obj.__dict__.items() if k not in exclude_keys}
+
+
+# Attributes needing bespoke comparison in compare_hmm_models; everything else
+# in __dict__ must compare equal under plain == (catch-all below).
+_ARRAY_STATE_ATTRS = (
+    "_seed",
+    "_dirichlet_initial_proba",
+    "_dirichlet_transition_proba",
+)
+_INSTANCE_STATE_ATTRS = ("_regularizer", "_observation_model")
+_LAZY_STATE_ATTRS = ("_solver_spec",)
+
+
+def compare_hmm_models(m1, m2):
+    """Stringent whole-state comparison between two distinct HMM-based models.
+
+    Default-deny: any ``__dict__`` attribute not explicitly handled below must
+    compare equal under plain ``==`` (callables compare by identity), so newly
+    added state is covered automatically and fails loudly if it needs bespoke
+    handling.
+    """
+    assert m1 is not m2
+    assert type(m1) is type(m2)
+    # arrays (or None): == inside the catch-all dict comparison would raise
+    for attr in _ARRAY_STATE_ATTRS:
+        np.testing.assert_array_equal(m1.__dict__[attr], m2.__dict__[attr])
+    # instances without __eq__: compare class and full state
+    for attr in _INSTANCE_STATE_ATTRS:
+        v1, v2 = m1.__dict__[attr], m2.__dict__[attr]
+        assert type(v1) is type(v2)
+        assert v1.__dict__ == v2.__dict__
+    # _solver_spec is resolved lazily by the solver_name property, so one side
+    # may hold None and the other a resolved SolverSpec; compare the resolved
+    # name instead of the stored value
+    assert m1.solver_name == m2.solver_name
+    exclude = _ARRAY_STATE_ATTRS + _INSTANCE_STATE_ATTRS + _LAZY_STATE_ATTRS
+    assert _filter_attributes(m1, exclude) == _filter_attributes(m2, exclude)
+
+
+class TestGLMHMMSklearnClone:
+    """``sklearn.base.clone`` rebuilds the model from ``get_params`` and requires
+    each param of the rebuilt model to be the same object it passed to ``__init__``;
+    the ``*_initialization_funcs`` setters must therefore round-trip an already
+    resolved dict container by identity."""
+
+    def test_clone_default(self):
+        model = GLMHMM(n_states=2)
+        compare_hmm_models(model, clone(model))
+
+    @pytest.mark.parametrize("func_name", FUNC_NAMES)
+    @pytest.mark.parametrize(
+        "value_kind, kwargs",
+        [
+            ("string", None),
+            ("string", {}),
+            ("kmeans", None),
+            ("custom", None),
+            ("custom", {}),
+            ("custom", MOCK_VALID_KWARGS),
+        ],
+    )
+    def test_clone_single_func(self, func_name, value_kind, kwargs):
+        if value_kind == "kmeans":
+            value = "kmeans"
+        elif value_kind == "string":
+            value = VALID_STRINGS[func_name]
+        else:
+            value = _get_custom_func(func_name)
+        config = {func_name: value}
+        if kwargs is not None:
+            config[f"{func_name}_kwargs"] = kwargs
+        model = GLMHMM(n_states=2, **{_init_funcs_attr(func_name): config})
+        cloned = clone(model)
+        compare_hmm_models(model, cloned)
+        if value_kind == "kmeans":
+            # the use-kmeans flag must survive the get_params -> __init__ round
+            # trip, not just the callable itself
+            assert getattr(cloned, _use_kmeans_attr(func_name))[func_name]
+
+    def test_clone_all_funcs_custom(self):
+        hmm_config, model_config = {}, {}
+        for func_name in FUNC_NAMES:
+            config = model_config if func_name in _GLM_FUNC_NAMES else hmm_config
+            config[func_name] = _get_custom_func(func_name)
+            config[f"{func_name}_kwargs"] = dict(MOCK_VALID_KWARGS)
+        model = GLMHMM(
+            n_states=2,
+            hmm_initialization_funcs=hmm_config,
+            model_initialization_funcs=model_config,
+        )
+        compare_hmm_models(model, clone(model))


### PR DESCRIPTION
Tiny bugfixes in GLMHMM:

- `jax.nanmean` dtype default to x32 if input is of bool type disregarding configs. This created a bug in GLMHMM EM since the intercept was initialized as x32, but converted to x64 at runtime when y was passed as a boolean array, creating a compilation error.
- HMM k-means detection was based on string identity, however, kmeans can be specified by passing functions instead. Function identity after setup is used to identify the kmeans setting.
- GLMHMM was not compatible with sklearn clone. This is beacuse the identity of the initialization function dictionary changed at each instantiation even if the content (values of the dict) were not deepcopied. Changed to a true no-op attribute setting.
- Float 32 vs 64 config was affecting the model fixture. Added config to fixture cache key, so that each config has its own fixture. This is not an issue for the CI, where x32 and x64 tests are run separately but may have created issues when running tests locally ignoring the mark.

Tests covering all those cases where added.