### PR TITLE
Refactor terminology: `epoch`->`passes` + improve dataloder note

### DIFF
--- a/docs/developers_notes/07-solvers.md
+++ b/docs/developers_notes/07-solvers.md
@@ -147,7 +147,7 @@ model = nmo.glm.GLM(
     solver_name="GradientDescent",
     solver_kwargs={"stepsize": 0.01, "acceleration": False},
 )
-model.stochastic_fit(loader, num_epochs=10)
+model.stochastic_fit(loader, n_passes=10)
 
 ```
 
@@ -178,7 +178,7 @@ NeMoS provides `ArrayDataLoader` for in-memory arrays. For out-of-core data, use
 At the solver level, stochastic optimization is provided through the `stochastic_run` method:
 
 ```python
-params, state, aux = solver.stochastic_run(init_params, data_loader, num_epochs=10)
+params, state, aux = solver.stochastic_run(init_params, data_loader, n_passes=10)
 ```
 
 Not all solvers support stochastic optimization. Only solvers with `_supports_stochastic = True` can be used. Currently supported solvers:
@@ -192,7 +192,7 @@ Solvers that do not support stochastic optimization (e.g., `BFGS`, `LBFGS`, `Non
 
 ### Implementation details
 
-Stochastic support is implemented through the `StochasticSolverMixin` class which provides a default implementation of `_stochastic_run_impl`. This mixin iterates over the data loader for the specified number of epochs, calling `update` on each batch.
+Stochastic support is implemented through the `StochasticSolverMixin` class which provides a default implementation of `_stochastic_run_impl`. This mixin iterates over the data loader for the specified number of passes, calling `update` on each batch.
 
 For SVRG-based solvers, `stochastic_run` in the wrappers dispatches to a `run_streaming` method that handles the more complex optimization loop that requires computing full gradients at reference points.
 

--- a/docs/how_to_guide/batching/custom_callbacks_and_termination.md
+++ b/docs/how_to_guide/batching/custom_callbacks_and_termination.md
@@ -129,7 +129,7 @@ class EarlyStoppingCallback(nmo.callbacks.Callback):
     y_test :
         Test target data.
     patience :
-        Number of training epochs (passes through the data) with no improvement before stopping.
+        Number of passes with no improvement before stopping.
     min_delta :
         Minimum decrease in loss to count as an improvement.
     """

--- a/docs/how_to_guide/batching/custom_callbacks_and_termination.md
+++ b/docs/how_to_guide/batching/custom_callbacks_and_termination.md
@@ -54,7 +54,7 @@ nap.nap_config.suppress_conversion_warnings = True
 np.random.seed(123)
 ```
 
-First, quickly set up and run a stochastic fit for 10 epochs:
+First, quickly set up and run a stochastic fit for 10 passes:
 
 ```{code-cell} ipython3
 _simulate_and_write_to_disk()
@@ -80,7 +80,7 @@ glm = nmo.glm.PopulationGLM(
     solver_kwargs={"stepsize": 0.05, "acceleration": False},
 )
 
-glm.stochastic_fit(loader, num_epochs=10, callbacks=batch_logger)
+glm.stochastic_fit(loader, n_passes=10, callbacks=batch_logger)
 
 plot_loss_history(batch_logger.loss_history)
 ```
@@ -89,13 +89,13 @@ plot_loss_history(batch_logger.loss_history)
 
 +++
 
-Instead of guessing how many epochs we need, undershooting and restarting, or overshooting and waiting too long, we can use callbacks to run optimization until convergence.
+Instead of guessing how many passes we need, undershooting and restarting, or overshooting and waiting too long, we can use callbacks to run optimization until convergence.
 
 +++
 
 As mentioned before, to monitor training progress and the optimization's state during the fitting run, NeMoS has a callback system, allowing to execute custom code on the following events:
 - beginning and end of training
-- before and after each epoch
+- before and after each pass
 - before and after each batch
 
 +++
@@ -104,11 +104,11 @@ As mentioned before, to monitor training progress and the optimization's state d
 
 +++
 
-We define a custom callback that requests a stop based on the loss evaluated on a test set if it hasn't improved much for a given number of epochs.
+We define a custom callback that requests a stop based on the loss evaluated on a test set if it hasn't improved much for a given number of passes through the data.
 
-Custom callbacks should inherit from [`Callback`](nemos.callbacks.Callback) and overwrite the required methods. In the current example we will implement `on_epoch_end` to evaluate the loss after every epoch.
+Custom callbacks should inherit from [`Callback`](nemos.callbacks.Callback) and overwrite the required methods. In the current example we will implement `on_pass_end` to evaluate the loss after every pass.
 
-Information is passed to callbacks through a [`TrainingContext`](nemos.callbacks.TrainingContext) object, which carries information about the state of the training such as the solver state, the current parameters, and the current epoch and batch indices.
+Information is passed to callbacks through a [`TrainingContext`](nemos.callbacks.TrainingContext) object, which carries information about the state of the training such as the solver state, the current parameters, and the current pass and batch indices.
 For convenience, the model being fit is also added to the context.
 
 Requesting a stop of the optimization can be done by calling `ctx.request_stop()`.
@@ -118,9 +118,9 @@ class EarlyStoppingCallback(nmo.callbacks.Callback):
     """
     Stop training when test loss stops improving.
 
-    Evaluates ``model.compute_loss(params, X_test, y_test)`` at the end of each epoch.
+    Evaluates ``model.compute_loss(params, X_test, y_test)`` at the end of each pass.
     If the loss does not improve by at least ``min_delta`` for
-    ``patience`` consecutive epochs, requests an early stop.
+    ``patience`` consecutive passes through the data, requests an early stop.
 
     Parameters
     ----------
@@ -129,7 +129,7 @@ class EarlyStoppingCallback(nmo.callbacks.Callback):
     y_test :
         Test target data.
     patience :
-        Number of epochs with no improvement before stopping.
+        Number of training epochs (passes through the data) with no improvement before stopping.
     min_delta :
         Minimum decrease in loss to count as an improvement.
     """
@@ -143,7 +143,7 @@ class EarlyStoppingCallback(nmo.callbacks.Callback):
         self._ref_loss = np.inf
         self._wait = 0
 
-    def on_epoch_end(self, ctx: nmo.callbacks.TrainingContext) -> None:
+    def on_pass_end(self, ctx: nmo.callbacks.TrainingContext) -> None:
         """Check whether test loss has improved and request stop if patience exceeded."""
         current_loss = ctx.model.compute_loss(
             (ctx.params.coef, ctx.params.intercept),
@@ -158,7 +158,7 @@ class EarlyStoppingCallback(nmo.callbacks.Callback):
             self._wait += 1
             if self._wait >= self.patience:
                 ctx.request_stop(
-                    f"Loss improved by less than {self.min_delta} for {self.patience} consecutive epochs.\n"
+                    f"Loss improved by less than {self.min_delta} for {self.patience} consecutive passes through the data (training epochs).\n"
                     f"last loss: {current_loss:.6f}\n"
                     f"reference loss: {self._ref_loss:.6f}\n"
                 )
@@ -170,7 +170,7 @@ Convergence can be defined in multiple ways, loss on a test set is just one of t
 NeMoS provides a [`SolverConvergenceCallback`](nemos.callbacks.SolverConvergenceCallback)
 which evaluates the solver's own convergence criterion defined as its
 `stochastic_convergence_criterion`. For built-in solvers this means
-examining the change in parameter values at the end of each epoch.
+examining the change in parameter values at the end of each pass.
 :::
 
 +++
@@ -209,8 +209,8 @@ Here, we continue logging the loss and add the early stopping callback:
 ```{code-cell} ipython3
 glm.stochastic_fit(
     loader,
-    # set num_epochs very high, so stopping has to be triggered by the callback
-    num_epochs=10_000,
+    # set n_passes very high, so stopping has to be triggered by the callback
+    n_passes=10_000,
     init_params=glm.get_model_params(),
     callbacks=[batch_logger, early_stopping],
 )

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -64,21 +64,145 @@ A [`DataLoader`](nemos.batching.DataLoader) is any object that streams `(X_batch
 - `n_samples`: the total number of samples in the dataset.
 - `sample_batch`: a cheap, deterministic batch used once to initialize the solver state.
 
-Anything that provides these three works. The rest of this page builds one for a specific problem: batching correctly a recording that is split into disjoint temporal intervals.
+Anything that provides these three works.
 
-## Custom `DataLoader` for discontinuous recordings
+## A Simple Example: `PynappleDataLoader`
 
-### Simulating the dataset
+As a minimal example, let's define a simple `DataLoader` that builds the design matrix for a fully coupled GLM directly from the spike times, using `pynapple` and a `NeMoS` basis to:
 
-We simulate one continuous recording, write it to disk as an NWB file, and load the spike times back with `pynapple`.
+1. sample a random 1 s interval and bin the spikes into counts;
+2. pass the counts through a convolutional basis to build the design matrix.
+
+Let's simulate the spike trains first.
 
 ```{code-cell} ipython3
 _simulate_and_write_to_disk()
 data = nap.load_file(DEFAULT_NWB_PATH)
 units = data["units"]  # contains spike times per unit
+units
 ```
 
-The simulation is a single uninterrupted stretch. To reproduce a realistic recording, we define three disjoint intervals -- standing in for the valid recording periods, or the experimental condition of interest -- and restrict the spike times to them. Restricting sets the `TsGroup`'s `time_support` to these intervals.
+Now we are ready to set up the data loader.
+
+```{code-cell} ipython3
+class PynappleDataLoader(nmo.batching.DataLoader):
+    def __init__(self, spike_times, basis, batch_size, bin_size):
+        self.spike_times = spike_times
+        self.basis = basis
+        self.batch_size = batch_size
+        self.bin_size = bin_size
+        self.n_batches_per_epoch = int(
+            spike_times.time_support.tot_length() // self.batch_size
+        )
+        self.rng = np.random.default_rng(seed=123)
+
+        self._sample_batch = None
+
+    def __iter__(self):
+        """
+        Yield one batch per step for a full epoch.
+
+        Defining this is what lets `stochastic_fit` loop over the loader
+        (`for X_batch, y_batch in loader`) one batch at a time.
+        It is called once at the start of every epoch, so it has to begin a
+        fresh pass over the data each time. Using `yield` here (which turns
+        the method into a generator) takes care of that automatically.
+        """
+        for i in range(self.n_batches_per_epoch):
+            yield self._random_batch()
+
+    @property
+    def n_samples(self):
+        """Number of samples in the full dataset"""
+        return int(np.round(self.spike_times.time_support.tot_length() / self.bin_size))
+
+    def sample_batch(self):
+        """Generate a sample batch at the start of the time support."""
+        if self._sample_batch is None:
+            self._sample_batch = self._batch_at_t(self.spike_times.time_support[0, 0])
+
+        return self._sample_batch
+
+    def _batch_at_t(self, t: float):
+        """Generate a batch starting at time t."""
+        ep = nap.IntervalSet(t, t + self.batch_size)
+        counts = self.spike_times.restrict(ep).count(self.bin_size)
+        X = self.basis.compute_features(counts)
+
+        return X, counts
+
+    def _random_batch(self):
+        """Generate a batch at a random time within the time support."""
+        t = self.rng.uniform(
+            self.spike_times.time_support[0, 0],
+            self.spike_times.time_support[0, 1] - self.batch_size,
+        )
+        return self._batch_at_t(t)
+```
+
+:::{note}
+For best performance (i.e. to avoid unnecessary function recompilations), generate batches that all have the same or at least a limited number of distinct sizes.
+:::
+
+Let's instantiate it and get a batch.
+
+```{code-cell} ipython3
+
+batch_size = 1  # seconds
+bin_size = 0.005  # seconds
+window_size = int(0.2 / bin_size) # bins
+
+# define a convolutional basis
+basis = nmo.basis.RaisedCosineLogConv(5, window_size=window_size)
+loader = PynappleDataLoader(units, basis, batch_size, bin_size)
+
+X_batch, y_batch = loader.sample_batch()
+print(X_batch)
+```
+
+:::{admonition} NaN padding
+:class: note
+
+The first `window_size` rows of the design matrix are NaNs. This is NeMoS default convolution behavior: the convolution is run in mode `"valid"` to avoid border artifact and then NaN padded to preserve the original time axis length. NeMoS `GLM.stochastic_fit` will filter out the NaNs, so the effective batch size will be `160 = 200 - window_size`.
+:::
+
+
+### Set up logging and run the optimization
+
+We again use the preprocessed full dataset as the test set, but in practice this would be a smaller held-out dataset.
+
+```{code-cell} ipython3
+batch_logger = nmo.callbacks.TestLossLogger(
+    data["X"],
+    data["spike_trains"],
+    events={"train_begin", "batch_end"},
+)
+```
+
+Fit for 30 passes:
+
+```{code-cell} ipython3
+glm = nmo.glm.PopulationGLM(
+    solver_name="GradientDescent",
+    regularizer="Ridge",
+    regularizer_strength=0.01,
+    solver_kwargs={"stepsize": 0.05, "acceleration": False},
+)
+```
+
+```{code-cell} ipython3
+glm.stochastic_fit(loader, n_passes=30, callbacks=batch_logger)
+```
+
+```{code-cell} ipython3
+plot_loss_history(batch_logger.loss_history)
+```
+
+## Handling Disjoint Recording Intervals
+
+Next we build a `DataLoader` for a common real-world case: sampling batches from a discontinuous recording. Often only parts of a recording are of interest -- valid trials, periods when the subject is engaged in the task, and so on.
+
+Let's simulate this scenario by chunking generated spike trains in three epochs. In `pynapple` terms, this is equivalent of restricting the time series to a multi-epoch `IntervalSet`.
 
 ```{code-cell} ipython3
 recording = nap.IntervalSet(start=[0.0, 25.0, 42.0], end=[20.0, 40.0, 50.0])
@@ -88,11 +212,11 @@ units.time_support
 
 ### Batching a fully coupled GLM
 
-The model we want to fit is a fully coupled GLM: each neuron's firing rate is predicted from the recent spike history of the entire population (the [head-direction tutorial](../../tutorials/plot_02_head_direction.md) works through such a model in full). Forming that predictor means convolving the spike counts with a basis to build the design matrix, and it is this convolution that makes batching a discontinuous recording non-trivial: a batch must not convolve across the gap between two intervals, and the batches should be uniform in size.
+The design matrix comes from convolving the spike counts with a basis, and it is this convolution that makes batching a discontinuous recording non-trivial: a batch must not convolve across the gap between two intervals, and the batches should have a small number of distinct sizes (each new size recompiles the update step).
 
 The simplest way to keep batches from crossing a gap is to build them as contiguous chunks. We split each recording interval into equal-duration chunks -- so a chunk never spans a gap -- and visit them in a random order on every pass over the dataset. Reshuffling the chunk order each pass decorrelates successive gradient steps and covers every chunk exactly once.
 
-Each feature is a convolution that looks back over the previous `window_size` bins, so the first `window_size` bins of a chunk have no history to convolve when the chunk is processed on its own. To give them that history, before convolving we extend the chunk backward by `window_size` bins -- a *context* window of `window_size * bin_size` seconds -- clipped at the recording interval start so it never reaches back across a gap. These context bins exist only to supply history to the chunk's first real bins; they are not training samples themselves. Only the true interval starts, where no earlier data exists, keep an unavoidable gap of `window_size` bins.
+As we have seen before, the first `window_size` of each batch is filled with NaNs that will be dropped at fit time. We will enforce an effective batch (batch size after dropping the NaNs) by extending the chunk of data of an extra *context* of `window_size` bin length. These context bins exist only to supply history to the chunk's first real bins; they are not training samples themselves.
 
 The construction is sketched below (bin counts are illustrative, not to scale):
 
@@ -102,14 +226,10 @@ The construction is sketched below (bin counts are illustrative, not to scale):
 plot_batching_schematic();
 ```
 
-:::{note}
-[`compute_features`](nemos.basis.RaisedCosineLogConv.compute_features) marks bins without a full history window as NaN: the prepended context bins, plus the first `window_size` bins of each recording interval. We leave those rows in each batch and let [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit) drop them internally.
-:::
-
 Putting the pieces together:
 
 ```{code-cell} ipython3
-class PynappleDataLoader(nmo.batching.DataLoader):
+class MultiEpochPynappleDataLoader(nmo.batching.DataLoader):
     def __init__(self, spike_times, basis, interval_size, bin_size, shuffle=True, seed=123):
         self.spike_times = spike_times
         self.basis = basis
@@ -153,24 +273,29 @@ class PynappleDataLoader(nmo.batching.DataLoader):
             yield self._batch(start, end, interval_start)
 ```
 
-## Create the loader
+### Defining the Loader & Running The Optimization
 
-Spikes are binned in 5 ms bins, and each neuron's firing rate is predicted from the recent spike history of the whole population, built with a NeMoS convolutional basis over a 200 ms window. We use 5 s chunks as batches.
+The loader can be defined as before.
 
 ```{code-cell} ipython3
-bin_size = 5 / 1000  # seconds
-interval_size = 5.0  # seconds
 
-basis = nmo.basis.RaisedCosineLogConv(5, window_size=int(0.2 / bin_size))
+batch_size = 5  # seconds
+window_size_sec = window_size * bin_size
 
-loader = PynappleDataLoader(units, basis, interval_size, bin_size)
+# interval_size = batch_size + window_size_sec
+interval_size = batch_size + window_size_sec  # seconds
+
+loader = MultiEpochPynappleDataLoader(units, basis, interval_size, bin_size)
+
+X_batch, y_batch = loader.sample_batch()
+
+# Check the effective batch size after dropping nans
+print(f"Effective batch size: {X_batch.dropna().shape[0] * bin_size} secs")
 ```
 
 :::{note}
 This loader re-bins and re-convolves the data on every pass. If the design matrix is larger than RAM but fits on disk, it is faster to compute it once and store it in a memory-mappable format that `pynapple` [loads lazily](https://pynapple.org/user_guide/02_input_output.html) -- Zarr, HDF5, NWB, or similar -- then stream it with [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader), as in the [basics section](./stochastic_fit.md).
 :::
-
-## Set up logging and run the optimization
 
 We again use the preprocessed full dataset as the test set, but in practice this would be a smaller held-out dataset.
 
@@ -182,7 +307,7 @@ batch_logger = nmo.callbacks.TestLossLogger(
 )
 ```
 
-Fit for 30 epochs:
+Fit for 30 passes:
 
 ```{code-cell} ipython3
 glm = nmo.glm.PopulationGLM(
@@ -194,7 +319,7 @@ glm = nmo.glm.PopulationGLM(
 ```
 
 ```{code-cell} ipython3
-glm.stochastic_fit(loader, num_epochs=30, callbacks=batch_logger)
+glm.stochastic_fit(loader, n_passes=30, callbacks=batch_logger)
 ```
 
 ```{code-cell} ipython3

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -299,7 +299,7 @@ class MultiEpochPynappleDataLoader(nmo.batching.DataLoader):
         return self._batch(*self._chunks[0])
 
     def __iter__(self):
-        """Yield one batch per chunk, reshuffling the chunk order each epoch."""
+        """Yield one batch per chunk, reshuffling the chunk order at each pass over the data."""
         chunks = self._chunks
         if self.shuffle:
             chunks = chunks[self.rng.permutation(len(chunks))]

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -27,10 +27,9 @@ warnings.filterwarnings(
 
 # Creating a custom `DataLoader`
 
-In the previous section we loaded the model's input and output data from disk. These were already preprocessed and stored as arrays with matching lengths (`X` and `spike_trains`), making them easy to plug into [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader).
+In the previous section we loaded preprocessed arrays (`X` and `spike_trains`) straight into a [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader). Here we start one step earlier, from raw spike times on disk, and build the counts and design matrix on the fly inside the loader.
 
-Now, for illustration purposes, let's imagine we only have the raw spike times saved on disk.
-Here, we show how to create a custom data loader that creates arrays the GLM can work with from these spike times on the fly.
+Two features of the data shape the loader. The recording is split into several disjoint intervals -- experiments rarely produce one uninterrupted stretch -- and the design matrix is built by convolution. A batch must therefore be a contiguous span of time that stays within a single recording interval: convolving across the gap between two intervals would mix spike history that is seconds or minutes apart.
 
 ```{code-cell} ipython3
 import jax
@@ -62,111 +61,88 @@ data = nap.load_file(DEFAULT_NWB_PATH)
 units = data["units"]  # contains spike times per unit
 ```
 
+The toy recording is one continuous stretch, so we carve it into three valid intervals with gaps between them to mimic pauses in the recording. Restricting the `TsGroup` sets its `time_support` to these intervals, and the loader will keep every batch inside one of them.
+
+```{code-cell} ipython3
+recording = nap.IntervalSet(start=[0.0, 25.0, 42.0], end=[20.0, 40.0, 50.0])
+units = units.restrict(recording)
+units.time_support
+```
+
 ## Define `PynappleDataLoader`
 
-+++
+Each batch is one contiguous chunk of a single recording interval. We build the batches by splitting each interval into equal-duration chunks -- a chunk never spans a gap -- and visit them in a fresh random order every epoch. Reshuffling the chunk order each epoch decorrelates successive gradient steps and covers every chunk exactly once per pass, while keeping each chunk's samples in their original temporal order, which the convolution depends on.
 
-Batches of inputs and outputs will be created the following way:
-1. Use `pynapple` to sample random 1 s intervals and bin spikes into counts.
-2. Pass the counts through a convolutional basis to build a design matrix.
+Convolving a chunk in isolation would leave its first `window_size` bins without preceding history, so [`compute_features`](nemos.basis.RaisedCosineLogConv.compute_features) fills them with NaNs. Rather than discarding that fraction of every batch, we prepend one convolution window of preceding data before convolving -- `window_size` bins, converted to seconds as `window_size * bin_size` and clipped at the interval start so the context never reaches back across a gap. After convolution the only remaining NaN rows sit at the true interval starts, where no history exists. We leave them in the batch: [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit) drops NaN rows in `_preprocess_inputs`, so a batch spanning `[start, end]` arrives at the solver as exactly its valid rows, each with correct history.
 
-To create a [`DataLoader`](nemos.batching.DataLoader) for use with [`stochastic_fit`](nemos.glm.GLM.stochastic_fit), we have to define 3 things:
-- `__iter__`: called every epoch; yields `(X_batch, y_batch)` tuples. Must return a fresh iterator each call (re-iterable). Note the use of `yield` in the code.
-- `n_samples` property: total number of samples in the dataset.
-- `sample_batch`: called at initialization. Should be cheap to evaluate and deterministic.
-
-:::{note}
-For best performance (i.e. to avoid unnecessary function recompilations), generate batches that all have the same or at least a limited number of distinct sizes.
-:::
+A [`DataLoader`](nemos.batching.DataLoader) needs three methods:
+- `__iter__`: yields `(X_batch, y_batch)` tuples. It is called once at the start of every epoch and must return a fresh iterator each time (using `yield` here makes the method a generator, which does this automatically).
+- `n_samples`: the total number of samples in the dataset.
+- `sample_batch`: a cheap, deterministic batch used once to initialize the solver state.
 
 ```{code-cell} ipython3
 class PynappleDataLoader(nmo.batching.DataLoader):
-    def __init__(self, spike_times, basis, batch_size, bin_size):
+    def __init__(self, spike_times, basis, interval_size, bin_size, shuffle=True, seed=123):
         self.spike_times = spike_times
         self.basis = basis
-        self.batch_size = batch_size
         self.bin_size = bin_size
-        self.n_batches_per_epoch = int(
-            spike_times.time_support.tot_length() // self.batch_size
-        )
-        self.rng = np.random.default_rng(seed=123)
+        # window length is in bins; the left context to prepend is that many bins, in seconds
+        self.context_duration = basis.window_size * bin_size
+        self.shuffle = shuffle
+        self.rng = np.random.default_rng(seed)
 
-        self._sample_batch = None
-
-    def __iter__(self):
-        """
-        Yield one batch per step for a full epoch.
-
-        Defining this is what lets `stochastic_fit` loop over the loader
-        (`for X_batch, y_batch in loader`) one batch at a time.
-        It is called once at the start of every epoch, so it has to begin a
-        fresh pass over the data each time. Using `yield` here (which turns
-        the method into a generator) takes care of that automatically.
-        """
-        for i in range(self.n_batches_per_epoch):
-            yield self._random_batch()
+        # Equal-duration chunks built within each recording interval, so none crosses a gap; the
+        # sub-interval_size tail of an interval is kept as a final short chunk. Each row is
+        # (chunk_start, chunk_end, interval_start): the interval start lets us clip the left
+        # context without reaching back into the previous interval.
+        self._chunks = np.array([
+            (start_chunk, min(start_chunk + interval_size, end), start)
+            for start, end in spike_times.time_support.values
+            for start_chunk in np.arange(start, end, interval_size)
+        ])
 
     @property
     def n_samples(self):
-        """Number of samples in the full dataset"""
-        return int(np.round(self.spike_times.time_support.tot_length() / self.bin_size))
+        """Number of samples in the full dataset."""
+        return int(round(self.spike_times.time_support.tot_length() / self.bin_size))
+
+    def _batch(self, start, end, interval_start):
+        """Count and convolve one chunk, prepending a window of history for the convolution."""
+        start_ext = max(start - self.context_duration, interval_start)
+        counts = self.spike_times.count(self.bin_size, ep=nap.IntervalSet(start_ext, end))
+        return self.basis.compute_features(counts), counts
 
     def sample_batch(self):
-        """Generate a sample batch at the start of the time support."""
-        if self._sample_batch is None:
-            self._sample_batch = self._batch_at_t(self.spike_times.time_support[0, 0])
+        """Deterministic first-chunk batch used to initialize the solver state."""
+        return self._batch(*self._chunks[0])
 
-        return self._sample_batch
-
-    def _batch_at_t(self, t: float):
-        """Generate a batch starting at time t."""
-        ep = nap.IntervalSet(t, t + self.batch_size)
-        counts = self.spike_times.restrict(ep).count(self.bin_size)
-        X = self.basis.compute_features(counts)
-
-        return X, counts
-
-    def _random_batch(self):
-        """Generate a batch at a random time within the time support."""
-        t = self.rng.uniform(
-            self.spike_times.time_support[0, 0],
-            self.spike_times.time_support[0, 1] - self.batch_size,
-        )
-        return self._batch_at_t(t)
+    def __iter__(self):
+        """Yield one batch per chunk, reshuffling the chunk order each epoch."""
+        chunks = self._chunks
+        if self.shuffle:
+            chunks = chunks[self.rng.permutation(len(chunks))]
+        for start, end, interval_start in chunks:
+            yield self._batch(start, end, interval_start)
 ```
 
 ## Create the loader
 
-+++
-
-Spike times will be binned in 5 ms bins and each neuron's firing rate will be predicted from the recent spike history of the whole population.
-We build those history features using a NeMoS convolutional basis with a window size of 200 ms.
+Spikes are binned in 5 ms bins, and each neuron's firing rate is predicted from the recent spike history of the whole population, built with a NeMoS convolutional basis over a 200 ms window. We use 5 s chunks as batches.
 
 ```{code-cell} ipython3
-batch_size = 1  # seconds
 bin_size = 5 / 1000  # seconds
+interval_size = 5.0  # seconds
 
 basis = nmo.basis.RaisedCosineLogConv(5, window_size=int(0.2 / bin_size))
-```
 
-Then use these to create the loader:
-
-```{code-cell} ipython3
-loader = PynappleDataLoader(units, basis, batch_size, bin_size)
+loader = PynappleDataLoader(units, basis, interval_size, bin_size)
 ```
 
 :::{note}
-The convolution sets the first 200 ms of data at the start of a processed interval to NaNs. Applying this separately to each 1-second batch essentially "throws away" a fifth of the data.
-By not storing the results, it also repeats processing the full data each epoch.
-
-It is generally faster to do this processing by iterating through the whole data once and saving the results to disk, then use [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader) as shown in the [basics section](./stochastic_fit.md).
+Prepending the history window means this loses samples only at the start of each recording interval (`window_size` bins each), not at every batch boundary. The loader still re-bins and re-convolves the data on every epoch, so when it fits on disk it is generally faster to preprocess the design matrix once and use [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader), as in the [basics section](./stochastic_fit.md).
 :::
 
-+++
-
 ## Set up logging and run the optimization
-
-+++
 
 We again use the preprocessed full dataset as the test set, but in practice this would be a smaller held-out dataset.
 

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -155,7 +155,7 @@ loader = PynappleDataLoader(units, basis, interval_size, bin_size)
 ```
 
 :::{note}
-Prepending the history window means the loader loses samples only at the start of each recording interval (`window_size` bins each), not at every batch boundary. It does re-bin and re-convolve the data on every pass, though. If the design matrix is larger than RAM but fits on disk, it is faster to compute it once and store it in a memory-mappable format that `pynapple` [loads lazily](https://pynapple.org/user_guide/02_input_output.html) -- Zarr, HDF5, NWB, or similar -- then stream it with [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader), as in the [basics section](./stochastic_fit.md).
+This loader re-bins and re-convolves the data on every pass. If the design matrix is larger than RAM but fits on disk, it is faster to compute it once and store it in a memory-mappable format that `pynapple` [loads lazily](https://pynapple.org/user_guide/02_input_output.html) -- Zarr, HDF5, NWB, or similar -- then stream it with [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader), as in the [basics section](./stochastic_fit.md).
 :::
 
 ## Set up logging and run the optimization

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -29,7 +29,7 @@ warnings.filterwarnings(
 
 In the previous section we loaded preprocessed arrays (`X` and `spike_trains`) straight into a [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader). Here we start one step earlier, from raw spike times on disk, and build the counts and design matrix on the fly inside the loader.
 
-Two features of the data shape the loader. The recording is split into several disjoint intervals -- experiments rarely produce one uninterrupted stretch -- and the design matrix is built by convolution. A batch must therefore be a contiguous span of time that stays within a single recording interval: convolving across the gap between two intervals would mix spike history that is seconds or minutes apart.
+The spikes are loaded and preprocessed with `pynapple`, which supports lazy, out-of-core loading. The example uses a small simulated dataset, but the same loader scales to large recordings without holding them in memory.
 
 ```{code-cell} ipython3
 import jax
@@ -53,7 +53,20 @@ nap.nap_config.suppress_conversion_warnings = True
 np.random.seed(123)
 ```
 
-Load the spike times:
+## The `DataLoader` interface
+
+A [`DataLoader`](nemos.batching.DataLoader) is any object that streams `(X_batch, y_batch)` pairs to [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit). It has to provide three methods:
+- `__iter__`: yields `(X_batch, y_batch)` tuples. It is called once at the start of every epoch and must return a fresh iterator each time (using `yield` here makes the method a generator, which does this automatically).
+- `n_samples`: the total number of samples in the dataset.
+- `sample_batch`: a cheap, deterministic batch used once to initialize the solver state.
+
+Anything that provides these three works. The rest of this page builds one for a specific problem: batching correctly a recording that is split into disjoint temporal intervals.
+
+## Batching discontinuous recordings
+
+### Simulating the dataset
+
+We simulate one continuous recording, write it to disk as an NWB file, and load the spike times back with `pynapple`.
 
 ```{code-cell} ipython3
 _simulate_and_write_to_disk()
@@ -61,7 +74,7 @@ data = nap.load_file(DEFAULT_NWB_PATH)
 units = data["units"]  # contains spike times per unit
 ```
 
-The toy recording is one continuous stretch, so we carve it into three valid intervals with gaps between them to mimic pauses in the recording. Restricting the `TsGroup` sets its `time_support` to these intervals, and the loader will keep every batch inside one of them.
+The simulation is a single uninterrupted stretch. To reproduce a realistic recording, we define three disjoint intervals -- standing in for the valid recording periods, or the experimental condition of interest -- and restrict the spike times to them. Restricting sets the `TsGroup`'s `time_support` to these intervals.
 
 ```{code-cell} ipython3
 recording = nap.IntervalSet(start=[0.0, 25.0, 42.0], end=[20.0, 40.0, 50.0])
@@ -69,20 +82,19 @@ units = units.restrict(recording)
 units.time_support
 ```
 
-## Define `PynappleDataLoader`
+### Batching a fully coupled GLM
 
-Each batch is one contiguous chunk of a single recording interval. We build the batches by splitting each interval into equal-duration chunks -- a chunk never spans a gap -- and visit them in a fresh random order every epoch. Reshuffling the chunk order each epoch decorrelates successive gradient steps and covers every chunk exactly once per pass, while keeping each chunk's samples in their original temporal order, which the convolution depends on.
+The model we want to fit is a fully coupled GLM: each neuron's firing rate is predicted from the recent spike history of the entire population (the [head-direction tutorial](../../tutorials/plot_02_head_direction.md) works through such a model in full). Forming that predictor means convolving the spike counts with a basis to build the design matrix, and it is this convolution that makes batching a discontinuous recording non-trivial: a batch must not convolve across the gap between two intervals, and the batches should be uniform in size.
 
-Convolving a chunk in isolation would leave its first `window_size` bins without preceding history. To avoid discarding that fraction of every batch, we prepend one convolution window of preceding data before convolving -- `window_size` bins, converted to seconds as `window_size * bin_size` and clipped at the interval start so the context never reaches back across a gap. Only the true interval starts, where no prior history exists, keep an unavoidable gap of `window_size` bins.
+The simplest way to keep batches from crossing a gap is to build them as contiguous chunks. We split each recording interval into equal-duration chunks -- so a chunk never spans a gap -- and visit them in a random order on every pass over the dataset. Reshuffling the chunk order each pass decorrelates successive gradient steps and covers every chunk exactly once.
+
+Each feature is a convolution that looks back over the previous `window_size` bins, so the first `window_size` bins of a chunk have no history to convolve when the chunk is processed on its own. To give them that history, before convolving we extend the chunk backward by `window_size` bins -- a *context* window of `window_size * bin_size` seconds -- clipped at the recording interval start so it never reaches back across a gap. These context bins exist only to supply history to the chunk's first real bins; they are not training samples themselves. Only the true interval starts, where no earlier data exists, keep an unavoidable gap of `window_size` bins.
 
 :::{note}
-[`compute_features`](nemos.basis.RaisedCosineLogConv.compute_features) marks bins without a full history window as NaN: the prepended context bins, plus the first `window_size` bins of each recording interval. We leave those rows in each batch and let [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit) drop them in `_preprocess_inputs`, so a batch spanning `[start, end]` reaches the solver as exactly its valid rows, each with correct history.
+[`compute_features`](nemos.basis.RaisedCosineLogConv.compute_features) marks bins without a full history window as NaN: the prepended context bins, plus the first `window_size` bins of each recording interval. We leave those rows in each batch and let [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit) drop them internally.
 :::
 
-A [`DataLoader`](nemos.batching.DataLoader) needs three methods:
-- `__iter__`: yields `(X_batch, y_batch)` tuples. It is called once at the start of every epoch and must return a fresh iterator each time (using `yield` here makes the method a generator, which does this automatically).
-- `n_samples`: the total number of samples in the dataset.
-- `sample_batch`: a cheap, deterministic batch used once to initialize the solver state.
+Putting the pieces together:
 
 ```{code-cell} ipython3
 class PynappleDataLoader(nmo.batching.DataLoader):
@@ -143,7 +155,7 @@ loader = PynappleDataLoader(units, basis, interval_size, bin_size)
 ```
 
 :::{note}
-Prepending the history window means this loses samples only at the start of each recording interval (`window_size` bins each), not at every batch boundary. The loader still re-bins and re-convolves the data on every epoch, so when it fits on disk it is generally faster to preprocess the design matrix once and use [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader), as in the [basics section](./stochastic_fit.md).
+Prepending the history window means the loader loses samples only at the start of each recording interval (`window_size` bins each), not at every batch boundary. It does re-bin and re-convolve the data on every pass, though. If the design matrix is larger than RAM but fits on disk, it is faster to compute it once and store it in a memory-mappable format that `pynapple` [loads lazily](https://pynapple.org/user_guide/02_input_output.html) -- Zarr, HDF5, NWB, or similar -- then stream it with [`LazyArrayDataLoader`](nemos.batching.LazyArrayDataLoader), as in the [basics section](./stochastic_fit.md).
 :::
 
 ## Set up logging and run the optimization
@@ -165,12 +177,12 @@ glm = nmo.glm.PopulationGLM(
     solver_name="GradientDescent",
     regularizer="Ridge",
     regularizer_strength=0.01,
-    solver_kwargs={"stepsize": 0.1, "acceleration": False},
+    solver_kwargs={"stepsize": 0.05, "acceleration": False},
 )
 ```
 
 ```{code-cell} ipython3
-glm.stochastic_fit(loader, num_epochs=100, callbacks=batch_logger)
+glm.stochastic_fit(loader, num_epochs=30, callbacks=batch_logger)
 ```
 
 ```{code-cell} ipython3

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -62,7 +62,7 @@ A [`DataLoader`](nemos.batching.DataLoader) is any object that streams `(X_batch
 
 Anything that provides these three works. The rest of this page builds one for a specific problem: batching correctly a recording that is split into disjoint temporal intervals.
 
-## Batching discontinuous recordings
+## Custom `DataLoader` for discontinuous recordings
 
 ### Simulating the dataset
 

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -60,11 +60,15 @@ np.random.seed(123)
 ## The `DataLoader` interface
 
 A [`DataLoader`](nemos.batching.DataLoader) is any object that streams `(X_batch, y_batch)` pairs to [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit). It has to provide three methods:
-- `__iter__`: yields `(X_batch, y_batch)` tuples. It is called once at the start of every epoch and must return a fresh iterator each time (using `yield` here makes the method a generator, which does this automatically).
-- `n_samples`: the total number of samples in the dataset.
+- `__iter__`: yields `(X_batch, y_batch)` tuples. It is called once at the start of every pass and must return a fresh iterator each time (using `yield` here makes the method a generator, which does this automatically).
 - `sample_batch`: a cheap, deterministic batch used once to initialize the solver state.
+- `n_samples`: the total number of samples in the dataset.
 
 Anything that provides these three works.
+
+:::{note}
+The optimization itself is driven only by `__iter__` and `sample_batch`: `stochastic_fit` iterates the loader for each pass and draws a single `sample_batch` to initialize the solver state. `n_samples` is used *after* fitting, to estimate the residual degrees of freedom and, from those, the scale parameter that the log-likelihood and pseudo-$R^2$ scores depend on. This total count cannot be recovered from a single batch, nor -- for a loader that never materializes the full design matrix -- read off any array's `shape`, so the loader has to report it directly. For observation models with a fixed scale (e.g. Poisson, Bernoulli) the scale is a known constant and this count is never used.
+:::
 
 ## A Simple Example: `PynappleDataLoader`
 
@@ -100,11 +104,11 @@ class PynappleDataLoader(nmo.batching.DataLoader):
 
     def __iter__(self):
         """
-        Yield one batch per step for a full epoch.
+        Yield one batch per step for a full pass.
 
         Defining this is what lets `stochastic_fit` loop over the loader
         (`for X_batch, y_batch in loader`) one batch at a time.
-        It is called once at the start of every epoch, so it has to begin a
+        It is called once at the start of every pass, so it has to begin a
         fresh pass over the data each time. Using `yield` here (which turns
         the method into a generator) takes care of that automatically.
         """
@@ -216,6 +220,28 @@ The design matrix comes from convolving the spike counts with a basis, and it is
 
 The simplest way to keep batches from crossing a gap is to build them as contiguous chunks. We split each recording interval into equal-duration chunks -- so a chunk never spans a gap -- and visit them in a random order on every pass over the dataset. Reshuffling the chunk order each pass decorrelates successive gradient steps and covers every chunk exactly once.
 
+:::{admonition} Chunking with `IntervalSet.split`
+:class: warning
+
+The loader uses `IntervalSet.split`, which chunks each interval into `interval_size` pieces in a single call. Note that it *skips epochs shorter than `interval_size`*: the sub-`interval_size` tail of every interval -- and any recording interval shorter than `interval_size` -- is dropped. `split` also returns only `(start, end)`, so we recover each chunk's parent-interval start with `searchsorted` to clip the left context at the gaps.
+
+If you need every sample, split manually with `numpy` instead. This keeps the short final tail and the parent-interval start in one pass; drop it in place of the `split` call in the constructor:
+
+```python
+def split_intervals(time_support, interval_size):
+    """Split each interval into `interval_size` chunks, keeping the short final tail.
+
+    Each row is ``(chunk_start, chunk_end, interval_start)``; ``interval_start`` lets the
+    loader clip the left context without reaching back into the previous interval.
+    """
+    return np.array([
+        (start_chunk, min(start_chunk + interval_size, end), start)
+        for start, end in time_support.values
+        for start_chunk in np.arange(start, end, interval_size)
+    ])
+```
+:::
+
 As we have seen before, the first `window_size` of each batch is filled with NaNs that will be dropped at fit time. We will enforce an effective batch (batch size after dropping the NaNs) by extending the chunk of data of an extra *context* of `window_size` bin length. These context bins exist only to supply history to the chunk's first real bins; they are not training samples themselves.
 
 The construction is sketched below (bin counts are illustrative, not to scale):
@@ -234,20 +260,20 @@ class MultiEpochPynappleDataLoader(nmo.batching.DataLoader):
         self.spike_times = spike_times
         self.basis = basis
         self.bin_size = bin_size
-        # window length is in bins; the left context to prepend is that many bins, in seconds
+        # the context_duration is the length of the context in seconds
         self.context_duration = basis.window_size * bin_size
         self.shuffle = shuffle
         self.rng = np.random.default_rng(seed)
 
-        # Equal-duration chunks built within each recording interval, so none crosses a gap; the
-        # sub-interval_size tail of an interval is kept as a final short chunk. Each row is
-        # (chunk_start, chunk_end, interval_start): the interval start lets us clip the left
-        # context without reaching back into the previous interval.
-        self._chunks = np.array([
-            (start_chunk, min(start_chunk + interval_size, end), start)
-            for start, end in spike_times.time_support.values
-            for start_chunk in np.arange(start, end, interval_size)
-        ])
+        # Split each recording interval into interval_size chunks with pynapple, so none crosses a
+        # gap. `split` drops the sub-interval_size tail of every interval (and any interval shorter
+        # than interval_size); see the note above for a numpy alternative that keeps them. It returns
+        # only (start, end), so we re-attach each chunk's parent-interval start via searchsorted, used
+        # to clip the left context without reaching back across a gap.
+        chunks = spike_times.time_support.split(interval_size)
+        starts = spike_times.time_support.start
+        interval_start = starts[np.searchsorted(starts, chunks.start, side="right") - 1]
+        self._chunks = np.column_stack([chunks.start, chunks.end, interval_start])
 
     @property
     def n_samples(self):

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -15,6 +15,7 @@ kernelspec:
 :tags: [hide-input]
 
 %matplotlib inline
+%config InlineBackend.figure_format = "svg"
 import warnings
 
 # Ignore the specific warning
@@ -42,7 +43,10 @@ from nemos._documentation_utils._stochastic_optim_toy_data import (
     DEFAULT_NWB_PATH,
     _simulate_and_write_to_disk,
 )
-from nemos._documentation_utils.plotting import plot_loss_history
+from nemos._documentation_utils.plotting import (
+    plot_batching_schematic,
+    plot_loss_history,
+)
 
 jax.config.update("jax_enable_x64", True)
 
@@ -89,6 +93,14 @@ The model we want to fit is a fully coupled GLM: each neuron's firing rate is pr
 The simplest way to keep batches from crossing a gap is to build them as contiguous chunks. We split each recording interval into equal-duration chunks -- so a chunk never spans a gap -- and visit them in a random order on every pass over the dataset. Reshuffling the chunk order each pass decorrelates successive gradient steps and covers every chunk exactly once.
 
 Each feature is a convolution that looks back over the previous `window_size` bins, so the first `window_size` bins of a chunk have no history to convolve when the chunk is processed on its own. To give them that history, before convolving we extend the chunk backward by `window_size` bins -- a *context* window of `window_size * bin_size` seconds -- clipped at the recording interval start so it never reaches back across a gap. These context bins exist only to supply history to the chunk's first real bins; they are not training samples themselves. Only the true interval starts, where no earlier data exists, keep an unavoidable gap of `window_size` bins.
+
+The construction is sketched below (bin counts are illustrative, not to scale):
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+plot_batching_schematic();
+```
 
 :::{note}
 [`compute_features`](nemos.basis.RaisedCosineLogConv.compute_features) marks bins without a full history window as NaN: the prepended context bins, plus the first `window_size` bins of each recording interval. We leave those rows in each batch and let [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit) drop them internally.

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -165,12 +165,12 @@ glm = nmo.glm.PopulationGLM(
     solver_name="GradientDescent",
     regularizer="Ridge",
     regularizer_strength=0.01,
-    solver_kwargs={"stepsize": 0.05, "acceleration": False},
+    solver_kwargs={"stepsize": 0.1, "acceleration": False},
 )
 ```
 
 ```{code-cell} ipython3
-glm.stochastic_fit(loader, num_epochs=30, callbacks=batch_logger)
+glm.stochastic_fit(loader, num_epochs=100, callbacks=batch_logger)
 ```
 
 ```{code-cell} ipython3

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -73,7 +73,11 @@ units.time_support
 
 Each batch is one contiguous chunk of a single recording interval. We build the batches by splitting each interval into equal-duration chunks -- a chunk never spans a gap -- and visit them in a fresh random order every epoch. Reshuffling the chunk order each epoch decorrelates successive gradient steps and covers every chunk exactly once per pass, while keeping each chunk's samples in their original temporal order, which the convolution depends on.
 
-Convolving a chunk in isolation would leave its first `window_size` bins without preceding history, so [`compute_features`](nemos.basis.RaisedCosineLogConv.compute_features) fills them with NaNs. Rather than discarding that fraction of every batch, we prepend one convolution window of preceding data before convolving -- `window_size` bins, converted to seconds as `window_size * bin_size` and clipped at the interval start so the context never reaches back across a gap. After convolution the only remaining NaN rows sit at the true interval starts, where no history exists. We leave them in the batch: [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit) drops NaN rows in `_preprocess_inputs`, so a batch spanning `[start, end]` arrives at the solver as exactly its valid rows, each with correct history.
+Convolving a chunk in isolation would leave its first `window_size` bins without preceding history. To avoid discarding that fraction of every batch, we prepend one convolution window of preceding data before convolving -- `window_size` bins, converted to seconds as `window_size * bin_size` and clipped at the interval start so the context never reaches back across a gap. Only the true interval starts, where no prior history exists, keep an unavoidable gap of `window_size` bins.
+
+:::{note}
+[`compute_features`](nemos.basis.RaisedCosineLogConv.compute_features) marks bins without a full history window as NaN: the prepended context bins, plus the first `window_size` bins of each recording interval. We leave those rows in each batch and let [`stochastic_fit`](nemos.glm.PopulationGLM.stochastic_fit) drop them in `_preprocess_inputs`, so a batch spanning `[start, end]` reaches the solver as exactly its valid rows, each with correct history.
+:::
 
 A [`DataLoader`](nemos.batching.DataLoader) needs three methods:
 - `__iter__`: yields `(X_batch, y_batch)` tuples. It is called once at the start of every epoch and must return a fresh iterator each time (using `yield` here makes the method a generator, which does this automatically).

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -218,29 +218,7 @@ units.time_support
 
 The design matrix comes from convolving the spike counts with a basis, and it is this convolution that makes batching a discontinuous recording non-trivial: a batch must not convolve across the gap between two intervals, and the batches should have a small number of distinct sizes (each new size recompiles the update step).
 
-The simplest way to keep batches from crossing a gap is to build them as contiguous chunks. We split each recording interval into equal-duration chunks -- so a chunk never spans a gap -- and visit them in a random order on every pass over the dataset. Reshuffling the chunk order each pass decorrelates successive gradient steps and covers every chunk exactly once.
-
-:::{admonition} Chunking with `IntervalSet.split`
-:class: warning
-
-The loader uses `IntervalSet.split`, which chunks each interval into `interval_size` pieces in a single call. Note that it *skips epochs shorter than `interval_size`*: the sub-`interval_size` tail of every interval -- and any recording interval shorter than `interval_size` -- is dropped. `split` also returns only `(start, end)`, so we recover each chunk's parent-interval start with `searchsorted` to clip the left context at the gaps.
-
-If you need every sample, split manually with `numpy` instead. This keeps the short final tail and the parent-interval start in one pass; drop it in place of the `split` call in the constructor:
-
-```python
-def split_intervals(time_support, interval_size):
-    """Split each interval into `interval_size` chunks, keeping the short final tail.
-
-    Each row is ``(chunk_start, chunk_end, interval_start)``; ``interval_start`` lets the
-    loader clip the left context without reaching back into the previous interval.
-    """
-    return np.array([
-        (start_chunk, min(start_chunk + interval_size, end), start)
-        for start, end in time_support.values
-        for start_chunk in np.arange(start, end, interval_size)
-    ])
-```
-:::
+The simplest way to keep batches from crossing a gap is to build them as contiguous chunks. We use pynapple's `IntervalSet.split` to cut each recording interval into equal-duration chunks -- so a chunk never spans a gap -- and visit them in a random order on every pass over the dataset. Reshuffling the chunk order each pass decorrelates successive gradient steps and covers every chunk exactly once. Because `split` emits only full `interval_size` pieces, it drops the leftover tail whenever `interval_size` does not divide an interval's duration, along with any interval shorter than `interval_size`; the *Use all samples* note after the loader shows how to keep them.
 
 As we have seen before, the first `window_size` of each batch is filled with NaNs that will be dropped at fit time. We will enforce an effective batch (batch size after dropping the NaNs) by extending the chunk of data of an extra *context* of `window_size` bin length. These context bins exist only to supply history to the chunk's first real bins; they are not training samples themselves.
 
@@ -298,6 +276,28 @@ class MultiEpochPynappleDataLoader(nmo.batching.DataLoader):
         for start, end, interval_start in chunks:
             yield self._batch(start, end, interval_start)
 ```
+
+:::{dropdown} Use all samples
+:color: info
+
+As mentioned in the main text, `split` may drop some time points. To train on the whole sample axis, replace the `split`/`searchsorted` lines in the constructor with a manual `numpy` split that keeps the short final tail and each chunk's parent-interval start:
+
+```python
+def split_intervals(time_support, interval_size):
+    """Split each interval into `interval_size` chunks, keeping the short final tail.
+
+    Each row is ``(chunk_start, chunk_end, interval_start)``; ``interval_start`` lets the
+    loader clip the left context without reaching back into the previous interval.
+    """
+    return np.array([
+        (start_chunk, min(start_chunk + interval_size, end), start)
+        for start, end in time_support.values
+        for start_chunk in np.arange(start, end, interval_size)
+    ])
+```
+
+It returns the same `(chunk_start, chunk_end, interval_start)` rows the loader expects, so `self._chunks = split_intervals(spike_times.time_support, interval_size)` is a drop-in replacement for those three lines.
+:::
 
 ### Defining the Loader & Running The Optimization
 

--- a/docs/how_to_guide/batching/custom_dataloader.md
+++ b/docs/how_to_guide/batching/custom_dataloader.md
@@ -91,6 +91,19 @@ Now we are ready to set up the data loader.
 ```{code-cell} ipython3
 class PynappleDataLoader(nmo.batching.DataLoader):
     def __init__(self, spike_times, basis, batch_size, bin_size):
+        """Build design-matrix batches on the fly from spike times.
+
+        Parameters
+        ----------
+        spike_times : pynapple.TsGroup
+            Spike times, one entry per unit.
+        basis : nemos.basis.Basis
+            Convolutional basis used to build the design matrix from binned counts.
+        batch_size : float
+            Batch duration, in seconds.
+        bin_size : float
+            Bin width for counting spikes, in seconds.
+        """
         self.spike_times = spike_times
         self.basis = basis
         self.batch_size = batch_size
@@ -235,6 +248,23 @@ Putting the pieces together:
 ```{code-cell} ipython3
 class MultiEpochPynappleDataLoader(nmo.batching.DataLoader):
     def __init__(self, spike_times, basis, interval_size, bin_size, shuffle=True, seed=123):
+        """Build gap-safe design-matrix batches from a discontinuous recording.
+
+        Parameters
+        ----------
+        spike_times : pynapple.TsGroup
+            Spike times, one entry per unit; its ``time_support`` may hold multiple intervals.
+        basis : nemos.basis.Basis
+            Convolutional basis used to build the design matrix from binned counts.
+        interval_size : float
+            Chunk duration, in seconds.
+        bin_size : float
+            Bin width for counting spikes, in seconds.
+        shuffle : bool, default True
+            Whether to reshuffle the chunk order on every pass.
+        seed : int, default 123
+            Seed for the chunk-shuffling RNG.
+        """
         self.spike_times = spike_times
         self.basis = basis
         self.bin_size = bin_size

--- a/docs/how_to_guide/batching/manual_batching_loop.md
+++ b/docs/how_to_guide/batching/manual_batching_loop.md
@@ -88,7 +88,7 @@ glm = nmo.glm.PopulationGLM(
 Basic SGD can effectively be reproduced by the following manual loop with score logging included after every batch:
 
 ```{code-cell} ipython3
-n_epochs = 10
+n_passes = 10
 ```
 
 ```{code-cell} ipython3
@@ -97,7 +97,7 @@ params = glm.initialize_params(X_sample, y_sample)
 opt_state = glm.initialize_optimizer_and_state(params, X_sample, y_sample)
 
 scores = []
-for i in range(n_epochs):
+for i in range(n_passes):
     for X_batch, y_batch in loader:
         params, opt_state = glm.update(params, opt_state, X_batch, y_batch)
         scores.append(glm.score(X, spike_trains))

--- a/docs/how_to_guide/batching/stochastic_fit.md
+++ b/docs/how_to_guide/batching/stochastic_fit.md
@@ -187,7 +187,7 @@ Other solvers that can be used for stochastic optimization can be listed with [`
 
 We are ready to start the optimization using the GLM's `stochastic_fit` method.
 
-`stochastic_fit` uses `n_passes` to control the training duration and does not stop on convergence by default. Unless a callback requests a stop, it will run for the full number of passes.
+`stochastic_fit` uses `n_passes` to control the number of passes over the full dataset and does not stop on convergence by default. Unless a callback requests a stop, it will run for the full number of passes.
 \
 Note that the `max_steps` solver kwarg used in `GLM.fit` is also ignored.
 

--- a/docs/how_to_guide/batching/stochastic_fit.md
+++ b/docs/how_to_guide/batching/stochastic_fit.md
@@ -187,12 +187,12 @@ Other solvers that can be used for stochastic optimization can be listed with [`
 
 We are ready to start the optimization using the GLM's `stochastic_fit` method.
 
-`stochastic_fit` uses `num_epochs` to control the training duration and does not stop on convergence by default. Unless a callback requests a stop, it will run for the full number of epochs.
+`stochastic_fit` uses `n_passes` to control the training duration and does not stop on convergence by default. Unless a callback requests a stop, it will run for the full number of passes.
 \
 Note that the `max_steps` solver kwarg used in `GLM.fit` is also ignored.
 
 ```{code-cell} ipython3
-glm.stochastic_fit(loader, num_epochs=5, callbacks=batch_logger)
+glm.stochastic_fit(loader, n_passes=5, callbacks=batch_logger)
 ```
 
 ```{code-cell} ipython3
@@ -210,7 +210,7 @@ To continue from where we left off, pass the current parameters as `init_params`
 ```{code-cell} ipython3
 glm.stochastic_fit(
     loader,
-    num_epochs=10,
+    n_passes=10,
     init_params=glm.get_model_params(),
     # using the same callback so the new loss values are appended to the existing history
     callbacks=batch_logger,

--- a/docs/how_to_guide/batching/stochastic_fit.md
+++ b/docs/how_to_guide/batching/stochastic_fit.md
@@ -142,7 +142,7 @@ In a [later section](./custom_dataloader.md) we show how to build a custom datal
 
 To monitor training progress and the optimization's state during the fitting run, NeMoS has a callback system, allowing to execute custom code on the following events:
 - beginning and end of training
-- before and after each epoch
+- before and after each pass over the data
 - before and after each batch
 
 +++
@@ -151,7 +151,7 @@ One of the callbacks included is [`TestLossLogger`](nemos.callbacks.TestLossLogg
 
 Since the dataset is small, we will use all of it for loss logging and evaluate at the beginning of training, then after every batch.
 \
-In practice this would be expensive to do, and you would typically evaluate on a held-out test set every N-th batch or at the end of each epoch.
+In practice this would be expensive to do, and you would typically evaluate on a held-out test set every N-th batch or at the end of each pass.
 
 ```{code-cell} ipython3
 batch_logger = nmo.callbacks.TestLossLogger(

--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -150,6 +150,7 @@ VALID_PAIRS = [
     {"event", "events"},
     {"X_test", "y_test"},
     {"basis_coeff", "basis_col"},
+    {"n_classes", "n_passes"},
 ]
 
 

--- a/src/nemos/_documentation_utils/plotting.py
+++ b/src/nemos/_documentation_utils/plotting.py
@@ -1274,3 +1274,109 @@ def plot_loss_history(loss_history: list[tuple], ax=None):
     sns.despine(ax=ax)
 
     return ax
+
+
+def plot_batching_schematic():
+    """
+    Sketch how a batch is built from a chunk plus a left context window.
+
+    Illustrative and not to scale: shows one recording interval split into equal
+    chunks, and the batch for the second chunk formed by prepending a context
+    window that supplies the convolution history and is then dropped.
+
+    Used for the custom data loader notebook.
+
+    Returns
+    -------
+    fig :
+        The schematic figure.
+    """
+    n_bins, chunk, window = 30, 10, 3
+    h = 0.8
+    c_bin, c_ctx, c_batch = "#eef2f7", "#f4c98a", "#9db8ee"
+
+    fig, ax = plt.subplots(figsize=(9, 3.6))
+
+    # top: one recording interval split into equal chunks (the second is highlighted)
+    y = 3.6
+    for i in range(n_bins):
+        ax.add_patch(
+            Rectangle((i, y), 1, h, facecolor=c_bin, edgecolor="white", lw=0.6)
+        )
+    for c in range(0, n_bins + 1, chunk):
+        ax.plot([c, c], [y - 0.05, y + h + 0.05], color="#475569", lw=1.6)
+    for k in range(n_bins // chunk):
+        ax.text(
+            k * chunk + chunk / 2,
+            y + h + 0.14,
+            f"chunk {k + 1}",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+    ax.add_patch(
+        Rectangle((chunk, y), chunk, h, facecolor="none", edgecolor="#1d4ed8", lw=2.2)
+    )
+    ax.text(
+        n_bins / 2,
+        y - 0.34,
+        "one recording interval, split into equal chunks",
+        ha="center",
+        va="top",
+        fontsize=10,
+        color="#334155",
+    )
+
+    # bottom: the batch for chunk 2, drawn beneath it (context spills into the previous chunk)
+    yb = 0.55
+    start, end = chunk, 2 * chunk
+    ctx0 = start - window
+    for i in range(ctx0, start):
+        ax.add_patch(
+            Rectangle(
+                (i, yb), 1, h, facecolor=c_ctx, edgecolor="white", lw=0.6, hatch="///"
+            )
+        )
+    for i in range(start, end):
+        ax.add_patch(
+            Rectangle((i, yb), 1, h, facecolor=c_batch, edgecolor="white", lw=0.6)
+        )
+    ax.text(
+        (ctx0 + start) / 2,
+        yb - 0.32,
+        "context\n(window_size bins,\ndropped)",
+        ha="center",
+        va="top",
+        fontsize=8.5,
+        color="#8a5a12",
+    )
+    ax.text(
+        (start + end) / 2,
+        yb - 0.32,
+        "batch = chunk 2\n(valid history)",
+        ha="center",
+        va="top",
+        fontsize=9,
+        color="#1d4ed8",
+    )
+    ax.annotate(
+        "",
+        xy=(start + 1, yb + h + 0.35),
+        xytext=(ctx0, yb + h + 0.35),
+        arrowprops=dict(arrowstyle="<->", color="#475569", lw=1.4),
+    )
+    ax.text(
+        (ctx0 + start + 1) / 2,
+        yb + h + 0.46,
+        "convolution window for the first batch bin",
+        ha="center",
+        va="bottom",
+        fontsize=8,
+        color="#334155",
+    )
+
+    ax.set_xlim(-1.5, n_bins + 1.5)
+    ax.set_ylim(-1.1, y + h + 0.9)
+    ax.axis("off")
+
+    return fig

--- a/src/nemos/_documentation_utils/plotting.py
+++ b/src/nemos/_documentation_utils/plotting.py
@@ -1210,7 +1210,7 @@ def plot_basis_filter(basis, model, current_history_duration_sec=0.2):
 
 def plot_loss_history(loss_history: list[tuple], ax=None):
     """
-    Plot ``loss_history`` per batch, marking epoch boundaries.
+    Plot ``loss_history`` per batch, marking pass boundaries.
 
     Used for stochastic optimization notebooks.
 
@@ -1237,14 +1237,14 @@ def plot_loss_history(loss_history: list[tuple], ax=None):
         (i, t) for i, t in enumerate(loss_history) if t[0] == "train_begin"
     ]
 
-    epoch_end_losses = []
+    pass_end_losses = []
     for i in range(len(batch_end_losses) - 1):
         curr_idx, curr_tup = batch_end_losses[i]
         next_idx, next_tup = batch_end_losses[i + 1]
         if curr_tup[1] is None or next_tup[1] is None:
             continue
         if next_tup[1] - curr_tup[1] == 1:
-            epoch_end_losses.append((curr_idx, curr_tup))
+            pass_end_losses.append((curr_idx, curr_tup))
 
     if batch_end_losses:
         ax.plot(
@@ -1259,11 +1259,11 @@ def plot_loss_history(loss_history: list[tuple], ax=None):
             [t[1][3] for t in train_begin_losses],
             label="Loss at training start",
         )
-    if epoch_end_losses:
+    if pass_end_losses:
         ax.scatter(
-            [t[0] for t in epoch_end_losses],
-            [t[1][3] for t in epoch_end_losses],
-            label="Loss at epoch boundaries",
+            [t[0] for t in pass_end_losses],
+            [t[1][3] for t in pass_end_losses],
+            label="Loss at pass boundaries",
             zorder=100,
         )
 
@@ -1361,12 +1361,12 @@ def plot_batching_schematic():
     )
     ax.annotate(
         "",
-        xy=(start + 1, yb + h + 0.35),
+        xy=(start, yb + h + 0.35),
         xytext=(ctx0, yb + h + 0.35),
         arrowprops=dict(arrowstyle="<->", color="#475569", lw=1.4),
     )
     ax.text(
-        (ctx0 + start + 1) / 2,
+        (ctx0 + start) / 2,
         yb + h + 0.46,
         "convolution window for the first batch bin",
         ha="center",

--- a/src/nemos/batching.py
+++ b/src/nemos/batching.py
@@ -41,8 +41,8 @@ class DataLoader(Protocol):
     Requirements:
 
     - Must be re-iterable: calling ``__iter__()`` must return a fresh iterator
-      each time. This is required for ``num_epochs > 1`` and because SVRG's full
-      gradient computation iterates through the data an additional time per epoch.
+      each time. This is required for ``n_passes > 1`` and because SVRG's full
+      gradient computation iterates through the data an additional time per pass.
     - ``sample_batch()`` should be cheap and deterministic (e.g., the first batch
       that contains valid data).
     - Batches should have consistent, non-zero sizes. Note that the solver's ``update``
@@ -86,7 +86,7 @@ class _BaseArrayDataLoader:
     Four shuffle strategies are supported (see ``SHUFFLE_STRATEGIES``):
 
     - ``"none"``: sequential, contiguous batches.
-    - ``"chunk_order"``: contiguous batches whose order is shuffled each epoch, with
+    - ``"chunk_order"``: contiguous batches whose order is shuffled each pass, with
       the samples kept in their original order within each batch. Batch membership is
       fixed, so this only requires contiguous reads. Because each batch is an intact,
       in-order segment, this is the strategy to use when wrapping the loader to do
@@ -321,7 +321,7 @@ class LazyArrayDataLoader(_BaseArrayDataLoader):
     than dataset size.
 
     The default shuffle strategy is ``"chunk_order"`` (approximate): chunk order is
-    randomized each epoch, but samples within the same chunk always stay together in
+    randomized each pass, but samples within the same chunk always stay together in
     the same batch and keep their original order. Use ``"chunk_and_samples"`` to also
     permute samples within each batch. Both require only contiguous reads. Passing
     ``shuffle="full"`` shuffles the whole dataset like ``ArrayDataLoader``. This

--- a/src/nemos/callbacks.py
+++ b/src/nemos/callbacks.py
@@ -137,7 +137,7 @@ class Callback:
 
     def on_pass_begin(self, ctx: TrainingContext) -> None:
         """
-        Run at the start of an pass.
+        Run at the start of a pass.
 
         This hook is called after the training loop advances ``ctx.pass_idx`` and
         before the first batch of that pass is processed. It marks the start

--- a/src/nemos/callbacks.py
+++ b/src/nemos/callbacks.py
@@ -20,23 +20,27 @@ class StochasticFitSummary:
     ``stochastic_fit`` completes. This summary is runtime state and is not
     serialized by ``save_params()``.
 
+    In machine-learning terminology, a pass over the data is what is usually
+    called an *epoch*; NeMoS says "pass" to avoid clashing with pynapple's
+    recording epochs.
+
     Parameters
     ----------
-    epoch_idx :
-        Final epoch index reached by the training loop.
+    pass_idx :
+        Final pass index reached by the training loop.
     batch_idx :
-        Final batch index reached within the last epoch.
-    num_epochs :
-        Total number of epochs requested for the run.
+        Final batch index reached within the last pass.
+    n_passes :
+        Total number of passes requested for the run.
     should_stop :
         Whether a callback requested early stopping.
     stop_reason :
         Human-readable stop reason, if any.
     """
 
-    epoch_idx: int | None = None
+    pass_idx: int | None = None
     batch_idx: int | None = None
-    num_epochs: int = 0
+    n_passes: int = 0
     should_stop: bool = False
     stop_reason: str = ""
 
@@ -61,12 +65,12 @@ class TrainingContext:
         Current solver state.
     aux :
         Auxiliary output from the last batch.
-    epoch_idx :
-        Current epoch index (0-based).
+    pass_idx :
+        Current pass index (0-based).
     batch_idx :
-        Current batch index within the epoch.
-    num_epochs :
-        Total number of epochs requested.
+        Current batch index within the pass.
+    n_passes :
+        Total number of passes requested.
     """
 
     model: Any = None
@@ -74,9 +78,9 @@ class TrainingContext:
     params: Any = None
     state: Any = None
     aux: Any = None
-    epoch_idx: int | None = None
+    pass_idx: int | None = None
     batch_idx: int | None = None
-    num_epochs: int = 0
+    n_passes: int = 0
 
     # signals for stopping optimization,
     # controlled through methods, not included in constructor
@@ -108,9 +112,9 @@ class TrainingContext:
     def to_summary(self) -> StochasticFitSummary:
         """Create a post-fit summary from the current training context."""
         return StochasticFitSummary(
-            epoch_idx=self.epoch_idx,
+            pass_idx=self.pass_idx,
             batch_idx=self.batch_idx,
-            num_epochs=self.num_epochs,
+            n_passes=self.n_passes,
             should_stop=self.should_stop,
             stop_reason=self.stop_reason,
         )
@@ -131,23 +135,23 @@ class Callback:
         """Run once at the end of training."""
         pass
 
-    def on_epoch_begin(self, ctx: TrainingContext) -> None:
+    def on_pass_begin(self, ctx: TrainingContext) -> None:
         """
-        Run at the start of an epoch.
+        Run at the start of an pass.
 
-        This hook is called after the training loop advances ``ctx.epoch_idx`` and
-        before the first batch of that epoch is processed. It marks the start
-        of epoch-level work from the callback perspective.
+        This hook is called after the training loop advances ``ctx.pass_idx`` and
+        before the first batch of that pass is processed. It marks the start
+        of pass-level work from the callback perspective.
 
-        Solver-specific epoch preparation may still occur after this hook and
+        Solver-specific pass preparation may still occur after this hook and
         before the first batch update. Callbacks should therefore treat this
-        hook as notification that a new epoch is starting, not as a guarantee
-        that all solver-internal epoch setup has already completed.
+        hook as notification that a new pass is starting, not as a guarantee
+        that all solver-internal pass setup has already completed.
         """
         pass
 
-    def on_epoch_end(self, ctx: TrainingContext) -> None:
-        """Run at the end of each epoch."""
+    def on_pass_end(self, ctx: TrainingContext) -> None:
+        """Run at the end of each pass."""
         pass
 
     def on_batch_begin(self, ctx: TrainingContext) -> None:
@@ -182,15 +186,15 @@ class CallbackList(Callback):
         for cb in self._callbacks:
             cb.on_train_end(ctx)
 
-    def on_epoch_begin(self, ctx: TrainingContext) -> None:
-        """Dispatch epoch-begin hook to all callbacks."""
+    def on_pass_begin(self, ctx: TrainingContext) -> None:
+        """Dispatch pass-begin hook to all callbacks."""
         for cb in self._callbacks:
-            cb.on_epoch_begin(ctx)
+            cb.on_pass_begin(ctx)
 
-    def on_epoch_end(self, ctx: TrainingContext) -> None:
-        """Dispatch epoch-end hook to all callbacks."""
+    def on_pass_end(self, ctx: TrainingContext) -> None:
+        """Dispatch pass-end hook to all callbacks."""
         for cb in self._callbacks:
-            cb.on_epoch_end(ctx)
+            cb.on_pass_end(ctx)
 
     def on_batch_begin(self, ctx: TrainingContext) -> None:
         """Dispatch batch-begin hook to all callbacks."""
@@ -208,7 +212,7 @@ class SolverConvergenceCallback(Callback):
     Delegate convergence checking to the solver's built-in criterion.
 
     Calls ``ctx.solver.stochastic_convergence_criterion(...)`` at the end of
-    each epoch and requests a stop if it returns ``True``.
+    each pass and requests a stop if it returns ``True``.
 
     Tracks previous params and state internally so the context doesn't have to.
     """
@@ -217,12 +221,12 @@ class SolverConvergenceCallback(Callback):
         self._prev_params = None
         self._prev_state = None
 
-    def on_epoch_begin(self, ctx: TrainingContext) -> None:
-        """Save current params and state before the epoch runs."""
+    def on_pass_begin(self, ctx: TrainingContext) -> None:
+        """Save current params and state before the pass runs."""
         self._prev_params = ctx.params
         self._prev_state = ctx.state
 
-    def on_epoch_end(self, ctx: TrainingContext) -> None:
+    def on_pass_end(self, ctx: TrainingContext) -> None:
         """Check solver convergence criterion and request stop if met."""
         converged = ctx.solver.stochastic_convergence_criterion(
             ctx.params,
@@ -230,7 +234,7 @@ class SolverConvergenceCallback(Callback):
             ctx.state,
             self._prev_state,
             ctx.aux,
-            ctx.epoch_idx,
+            ctx.pass_idx,
         )
         if converged:
             ctx.request_stop("Satisfied the solver's convergence criterion.")
@@ -251,13 +255,13 @@ class TestLossLogger(Callback):
         Test target (e.g. spike counts).
     events :
         Event name or names at which to log the test score. Each must be one
-        of ``{"train_begin", "train_end", "epoch_begin", "epoch_end",
+        of ``{"train_begin", "train_end", "pass_begin", "pass_end",
         "batch_begin", "batch_end"}``.
 
     Attributes
     ----------
     loss_history :
-        List of ``(event, epoch_idx, batch_idx, test_score)`` tuples, one per
+        List of ``(event, pass_idx, batch_idx, test_score)`` tuples, one per
         logged event, recording which event fired and the training position at
         the time.
     """
@@ -270,8 +274,8 @@ class TestLossLogger(Callback):
         {
             "train_begin",
             "train_end",
-            "epoch_begin",
-            "epoch_end",
+            "pass_begin",
+            "pass_end",
             "batch_begin",
             "batch_end",
         }
@@ -306,7 +310,7 @@ class TestLossLogger(Callback):
             self.X_test,
             self.y_test,
         )
-        self.loss_history.append((event, ctx.epoch_idx, ctx.batch_idx, test_score))
+        self.loss_history.append((event, ctx.pass_idx, ctx.batch_idx, test_score))
 
 
 def _normalize_callbacks(

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -218,7 +218,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         State of the solver after fitting. May include details like optimization error.
     stochastic_fit_summary_ :
         Summary of the most recent stochastic training run, including the
-        final epoch and batch indices and any callback stop reason.
+        final pass and batch indices and any callback stop reason.
     scale_:
         Scale parameter for the model. The scale parameter is the constant :math:`\Phi`, for which
         :math:`\text{Var} \left( y \right) = \Phi V(\mu)`. This parameter, together with the estimate
@@ -966,7 +966,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         data: DataLoader,
         *,
         init_params: Optional[GLMUserParams] = None,
-        num_epochs: int = 1,
+        n_passes: int = 1,
         callbacks: "Callback | list[Callback] | None" = None,
     ):
         """
@@ -980,7 +980,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         ----------
         data :
             Data loader yielding (X_batch, y_batch) tuples.
-            Must be re-iterable for ``num_epochs > 1``.
+            Must be re-iterable for ``n_passes > 1``.
 
             Note that NaNs are dropped per batch. The optimizer's update method
             will be re-compiled for each unique batch size, slowing down computation.
@@ -990,14 +990,16 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             Initial parameters (coefficients, intercept).
             If None, initialized from ``sample_batch()``.
             To continue fitting, pass the current parameters (``model.get_model_params()``)
-        num_epochs :
+        n_passes :
             Maximum number of passes over the data. Must be >= 1.
             Optimization may stop earlier if a callback requests a stop.
+            This parameter is commonly referred to as the number of (training) epochs
+            in the machine-learning literature.
 
             There is no convergence-based stopping by default. To stop
             automatically when the solver's convergence criterion is met,
             pass ``callbacks=SolverConvergenceCallback()``. Otherwise the
-            fit will run for the full ``num_epochs``.
+            fit will run for the full ``n_passes``.
         callbacks :
             Training callbacks. Accepts a single ``Callback``, a list of
             ``Callback`` objects, or ``None`` (default, no callbacks).
@@ -1005,7 +1007,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             To stop optimization when the solver's built-in convergence
             criterion is met pass ``nmo.callbacks.SolverConvergenceCallback()``.
             This is the recommended way to avoid running for the full
-            ``num_epochs`` when the model has already converged.
+            ``n_passes`` when the model has already converged.
 
         Returns
         -------
@@ -1033,7 +1035,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         >>> model = nmo.glm.GLM(solver_name="GradientDescent", solver_kwargs={"stepsize": 0.01, "acceleration" : False})
         >>> # Stop early when the solver's convergence criterion is met.
         >>> model = model.stochastic_fit(
-        ...     loader, num_epochs=10, callbacks=SolverConvergenceCallback()
+        ...     loader, n_passes=10, callbacks=SolverConvergenceCallback()
         ... )
         """
         # Validate solver supports stochastic
@@ -1089,7 +1091,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         params, state, aux = self._solver.stochastic_run(
             init_params,
             preprocessed_loader,
-            num_epochs=num_epochs,
+            n_passes=n_passes,
             callback=_normalize_callbacks(callbacks),
             ctx=ctx,
         )
@@ -1799,7 +1801,7 @@ class PopulationGLM(GLM):
         State of the solver after fitting. May include details like optimization error.
     stochastic_fit_summary_ :
         Summary of the most recent stochastic training run, including the
-        final epoch and batch indices and any callback stop reason.
+        final pass and batch indices and any callback stop reason.
 
     Raises
     ------

--- a/src/nemos/solvers/_abstract_solver.py
+++ b/src/nemos/solvers/_abstract_solver.py
@@ -143,7 +143,7 @@ class AbstractSolver(abc.ABC, Generic[SolverState]):
         self,
         init_params: Params,
         data_loader: DataLoader,
-        num_epochs: int,
+        n_passes: int,
         callback: Callback | None = None,
         ctx: TrainingContext | None = None,
     ) -> StepResult:
@@ -157,8 +157,9 @@ class AbstractSolver(abc.ABC, Generic[SolverState]):
         data_loader
             Data loader providing batches and metadata.
             Must be re-iterable (each ``__iter__`` call returns fresh iterator).
-        num_epochs
-            Number of passes over the data. Must be >= 1.
+        n_passes
+            Number of passes over the data (one pass is what the machine-learning
+            literature calls an *epoch*). Must be >= 1.
         callback :
             Training callback. A single ``Callback`` instance (use
             ``CallbackList`` for multiple callbacks).
@@ -177,14 +178,14 @@ class AbstractSolver(abc.ABC, Generic[SolverState]):
         NotImplementedError
             If the solver does not support stochastic optimization.
         ValueError
-            If num_epochs < 1.
+            If n_passes < 1.
         """
         if not self._supports_stochastic:
             raise NotImplementedError(
                 f"{self.__class__.__name__} does not support stochastic optimization. "
             )
-        if num_epochs < 1:
-            raise ValueError("num_epochs must be >= 1")
+        if n_passes < 1:
+            raise ValueError("n_passes must be >= 1")
         if callback is None:
             callback = Callback()
         if ctx is None:
@@ -192,12 +193,12 @@ class AbstractSolver(abc.ABC, Generic[SolverState]):
 
         ctx.solver = self
         ctx.params = init_params
-        ctx.num_epochs = num_epochs
+        ctx.n_passes = n_passes
 
         return self._stochastic_run_impl(
             init_params,
             data_loader,
-            num_epochs,
+            n_passes,
             callback=callback,
             ctx=ctx,
         )
@@ -206,7 +207,7 @@ class AbstractSolver(abc.ABC, Generic[SolverState]):
         self,
         init_params: Params,
         data_loader: DataLoader,
-        num_epochs: int,
+        n_passes: int,
         callback: Callback,
         ctx: TrainingContext | None = None,
     ) -> StepResult:
@@ -226,28 +227,28 @@ class AbstractSolver(abc.ABC, Generic[SolverState]):
         state: SolverState,
         prev_state: SolverState,
         aux: Any,
-        epoch: int,
+        pass_idx: int,
     ) -> bool:
         """
         Evaluate convergence criterion for stochastic optimization.
 
-        Called once per epoch. Subclasses that support stochastic optimization
+        Called once per pass. Subclasses that support stochastic optimization
         should override this to provide a meaningful default.
 
         Parameters
         ----------
         params :
-            Parameter values at end of current epoch.
+            Parameter values at end of current pass.
         prev_params :
-            Parameter values at end of previous epoch.
+            Parameter values at end of previous pass.
         state :
-            Solver state at end of current epoch.
+            Solver state at end of current pass.
         prev_state :
-            Solver state at end of previous epoch.
+            Solver state at end of previous pass.
         aux :
-            Auxiliary output from the last batch of the current epoch.
-        epoch :
-            Current epoch index (0-based).
+            Auxiliary output from the last batch of the current pass.
+        pass_idx :
+            Current pass index (0-based).
 
         Returns
         -------

--- a/src/nemos/solvers/_stochastic_mixins.py
+++ b/src/nemos/solvers/_stochastic_mixins.py
@@ -40,14 +40,14 @@ class StochasticSolverMixin(abc.ABC):
     Mixin providing standard stochastic optimization loop.
 
     This mixin provides a default implementation of ``_stochastic_run_impl``
-    that iterates over the data loader for the specified number of epochs,
+    that iterates over the data loader for the specified number of passes,
     calling ``update`` on each batch.
 
-    Solver-specific epoch preparation can be implemented through
-    ``_epoch_prep(...)``. This is mainly intended for algorithms with
-    epoch-level outer-loop work, such as SVRG-like methods.
+    Solver-specific per-pass preparation can be implemented through
+    ``_pass_prep(...)``. This is mainly intended for algorithms with
+    pass-level outer-loop work, such as SVRG-like methods.
 
-    Supports optional callbacks for per-epoch and per-batch hooks.
+    Supports optional callbacks for per-pass and per-batch hooks.
 
     Classes using this mixin must implement ``init_state`` and ``update`` methods.
     """
@@ -74,22 +74,22 @@ class StochasticSolverMixin(abc.ABC):
                 "Turn off linesearch and set explicit stepsizes for stochastic optimization."
             )
 
-    def _epoch_prep(
+    def _pass_prep(
         self,
         params: Params,
         state: SolverAdapterState,
         data_loader: DataLoader,
     ) -> tuple[Params, SolverAdapterState]:
         """
-        Perform solver-specific preparation for the upcoming epoch.
+        Perform solver-specific preparation for the upcoming pass.
 
-        This hook is called once per epoch after the epoch counter is advanced
-        and before the first batch update of that epoch. It is intended for
-        algorithms that require epoch-level setup, such as SVRG.
+        This hook is called once per pass after the pass counter is advanced
+        and before the first batch update of that pass. It is intended for
+        algorithms that require per-pass setup, such as SVRG.
 
         Implementations may return updated ``params`` and ``state``. The returned
         values define the initial optimization state used for the batch updates
-        of the current epoch.
+        of the current pass.
 
         This hook is internal to the solver loop. It is not a callback hook and
         should be used for algorithmic preparation rather than user-facing logging
@@ -101,7 +101,7 @@ class StochasticSolverMixin(abc.ABC):
         self,
         init_params: Params,
         data_loader: DataLoader,
-        num_epochs: int,
+        n_passes: int,
         callback: Callback,
         ctx: TrainingContext,
     ) -> StepResult:
@@ -114,7 +114,7 @@ class StochasticSolverMixin(abc.ABC):
             Initial parameter values.
         data_loader :
             Data loader providing batches and metadata.
-        num_epochs :
+        n_passes :
             Number of passes over the data (maximum if convergence monitoring
             is enabled).
         callback :
@@ -138,13 +138,13 @@ class StochasticSolverMixin(abc.ABC):
 
         callback.on_train_begin(ctx)
 
-        for epoch in range(num_epochs):
-            ctx.epoch_idx = epoch
+        for pass_idx in range(n_passes):
+            ctx.pass_idx = pass_idx
 
-            callback.on_epoch_begin(ctx)
+            callback.on_pass_begin(ctx)
 
             # SVRG has to run through the data to update the full gradient at the anchor point
-            params, state = self._epoch_prep(params, state, data_loader)
+            params, state = self._pass_prep(params, state, data_loader)
             ctx.params, ctx.state = params, state
 
             for batch_idx, batch_data in enumerate(data_loader):
@@ -159,7 +159,7 @@ class StochasticSolverMixin(abc.ABC):
                     callback.on_train_end(ctx)
                     return (params, state, aux)
 
-            callback.on_epoch_end(ctx)
+            callback.on_pass_end(ctx)
             if ctx.should_stop:
                 callback.on_train_end(ctx)
                 return (params, state, aux)
@@ -173,7 +173,7 @@ class OptimistixStochasticSolverMixin(StochasticSolverMixin):
     """
     Mixin for Optimistix solvers that updates stats after optimization.
 
-    Defines per-epoch convergence criterion as the Cauchy criterion
+    Defines per-pass convergence criterion as the Cauchy criterion
     on the parameters only (i.e. ignoring function value).
     """
 
@@ -184,10 +184,10 @@ class OptimistixStochasticSolverMixin(StochasticSolverMixin):
         state: SolverState,
         prev_state: SolverState,
         aux: Any,
-        epoch: int,
+        pass_idx: int,
     ):
         """Cauchy criterion on parameters using the solver's atol and rtol."""
-        del state, prev_state, aux, epoch
+        del state, prev_state, aux, pass_idx
         # solver needs to have tol and rtol
         # function evaluation on the whole data might be too expensive
         return _params_only_cauchy_criterion(params, prev_params, self.tol, self.rtol)
@@ -215,9 +215,9 @@ def _stepsize_normalized_convergence(
     Parameters
     ----------
     params :
-        Parameter values at end of current epoch.
+        Parameter values at end of current pass.
     prev_params :
-        Parameter values at end of previous epoch.
+        Parameter values at end of previous pass.
     stepsize :
         Step size used for the gradient updates.
     tol :
@@ -248,10 +248,10 @@ class JaxoptStochasticSolverMixin(StochasticSolverMixin):
         state: SolverState,
         prev_state: SolverState,
         aux: Any,
-        epoch: int,
+        pass_idx: int,
     ):
         """Step-size-normalized parameter change: ||params - prev_params|| / stepsize <= tol."""
-        del prev_state, aux, epoch
+        del prev_state, aux, pass_idx
         return _stepsize_normalized_convergence(
             params, prev_params, state.solver_state.stepsize, self.tol
         )

--- a/src/nemos/solvers/_svrg.py
+++ b/src/nemos/solvers/_svrg.py
@@ -40,7 +40,7 @@ class SVRGState(NamedTuple):
     Attributes
     ----------
     iter_num :
-        Current epoch or iteration number.
+        Current pass or iteration number.
     key :
         Random key to use when sampling data points or mini-batches.
     error :
@@ -102,14 +102,14 @@ class ProxSVRG:
         It should be of the form ``prox(params, hyperparams_prox, scale=1.0)``.
         See ``nemos.proximal_operator`` for examples.
     maxiter : int
-        Maximum number of epochs to run the optimization for.
+        Maximum number of passes over the data to run the optimization for.
     key : jax.random.PRNGkey
         jax PRNGKey to start with. Used for sampling random data points.
     stepsize : float
         Constant step size to use.
     tol : float
         Tolerance level for the error when comparing parameters
-        at the end of consecutive epochs to check for convergence.
+        at the end of consecutive passes to check for convergence.
     batch_size : int
         Number of data points to sample per inner loop iteration.
 
@@ -348,7 +348,7 @@ class ProxSVRG:
         *args: Any,
     ) -> OptStep:
         """
-        Update parameters given a mini-batch of data and increment iteration/epoch number in state.
+        Update parameters given a mini-batch of data and increment iteration/pass number in state.
 
         Note that this method doesn't update `state.reference_point`, `state.full_grad_at_reference_point`,
         that has to be done outside.
@@ -406,7 +406,7 @@ class ProxSVRG:
         *args: Any,
     ) -> OptStep:
         """
-        Run a whole optimization until convergence or until `maxiter` epochs are reached.
+        Run a whole optimization until convergence or until `maxiter` passes are reached.
 
         Called by `BaseRegressor._optimizer_run` (e.g. as called by `GLM.fit`) and assumes
         that X and y are the full data set.
@@ -454,7 +454,7 @@ class ProxSVRG:
         *args: Any,
     ) -> OptStep:
         """
-        Run a whole optimization until convergence or until `maxiter` epochs are reached.
+        Run a whole optimization until convergence or until `maxiter` passes are reached.
 
         Called by `BaseRegressor._optimizer_run` (e.g. as called by `GLM.fit`) and assumes that
         X and y are the full data set.
@@ -521,7 +521,7 @@ class ProxSVRG:
 
             return OptStep(params=reference_point, state=state)
 
-        # at the end of each epoch, check for convergence or reaching the max number of epochs
+        # at the end of each pass, check for convergence or reaching the max number of passes
         def cond_fun(step):
             _, state = step
             return (state.iter_num <= self.maxiter) & (state.error >= self.tol)
@@ -591,7 +591,7 @@ class ProxSVRG:
         """
         Perform the inner loop of Prox-SVRG.
 
-        Performs the inner loop of Prox-SVRG sweeping through approximately one full epoch,
+        Performs the inner loop of Prox-SVRG sweeping through approximately one full pass,
         updating the parameters after sampling a mini-batch on each iteration.
 
         Parameters
@@ -702,14 +702,14 @@ class SVRG(ProxSVRG):
         Note that this loss function has to be an average of losses across data points,
         i.e. f(x) = 1/N * sum(f(x_i)).
     maxiter : int
-        Maximum number of epochs to run the optimization for.
+        Maximum number of passes over the data to run the optimization for.
     key : jax.random.PRNGkey
         jax PRNGKey to start with. Used for sampling random data points.
     stepsize : float
         Constant step size to use.
     tol : float
         Tolerance level for the error when comparing parameters
-        at the end of consecutive epochs to check for convergence.
+        at the end of consecutive passes to check for convergence.
     batch_size : int
         Number of data points to sample per inner loop iteration.
 
@@ -834,7 +834,7 @@ class SVRG(ProxSVRG):
         *args: Any,
     ) -> OptStep:
         """
-        Run a whole optimization until convergence or until `maxiter` epochs are reached.
+        Run a whole optimization until convergence or until `maxiter` passes are reached.
 
         Called by `BaseRegressor._optimizer_run` (e.g. as called by `GLM.fit`) and assumes that
         X and y are the full data set.

--- a/src/nemos/solvers/_svrg.py
+++ b/src/nemos/solvers/_svrg.py
@@ -884,13 +884,13 @@ class _WrappedSVRGBase(JaxoptStochasticSolverMixin, JaxoptAdapter):
     def linesearch_turned_on(self) -> bool:
         return False
 
-    def _epoch_prep(
+    def _pass_prep(
         self,
         params: Params,
         state: JaxoptAdapterState,
         data_loader: DataLoader,
     ) -> tuple[Params, JaxoptAdapterState]:
-        """Set the full gradient at the reference point in the state before each epoch."""
+        """Set the full gradient at the reference point in the state before each pass."""
         # compute full gradient by streaming through all batches
         full_grad = self._solver._compute_full_gradient_streaming(
             params, data_loader.__iter__

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -319,9 +319,9 @@ class TestGLMStochasticFit:
     @pytest.mark.requires_x64
     @pytest.mark.parametrize("solver", _stochastic_solver_names)
     def test_solver_convergence_callback_stops_early(self, simple_data, solver):
-        """``SolverConvergenceCallback`` enables convergence-based stopping; default (None) runs all epochs."""
+        """``SolverConvergenceCallback`` enables convergence-based stopping; default (None) runs all passes."""
         X, y = simple_data
-        n_epochs = 100
+        n_passes = 100
         batch_size = 100
         loader = ArrayDataLoader(X, y, batch_size=batch_size, shuffle="full")
 
@@ -336,24 +336,24 @@ class TestGLMStochasticFit:
         model_stopping = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_stopping.stochastic_fit(
             loader,
-            n_passes=n_epochs,
+            n_passes=n_passes,
             init_params=final_params,
             callbacks=SolverConvergenceCallback(),
         )
 
-        # Default (no callbacks): runs for all epochs
+        # Default (no callbacks): runs for all passes
         model_no_stopping = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_no_stopping.stochastic_fit(
             loader,
-            n_passes=n_epochs,
+            n_passes=n_passes,
             init_params=final_params,
         )
 
         n_steps_taken_stopping = model_stopping.solver_state_.stats.num_steps
         n_steps_taken_no_stopping = model_no_stopping.solver_state_.stats.num_steps
 
-        batches_per_epoch = int(np.ceil(X.shape[0] / batch_size))
-        assert n_steps_taken_no_stopping == batches_per_epoch * n_epochs
+        batches_per_pass = int(np.ceil(X.shape[0] / batch_size))
+        assert n_steps_taken_no_stopping == batches_per_pass * n_passes
         assert n_steps_taken_stopping < n_steps_taken_no_stopping
 
     @pytest.mark.skipif(not solvers.JAXOPT_AVAILABLE, reason="JAXopt is not installed.")
@@ -388,8 +388,8 @@ class TestGLMStochasticFit:
         assert np.all(np.isfinite(model.intercept_))
 
     @pytest.mark.parametrize("solver", _stochastic_solver_names)
-    def test_custom_epoch_callback_stops_early(self, simple_data, solver):
-        """Test that a custom epoch callback stops optimization early."""
+    def test_custom_pass_callback_stops_early(self, simple_data, solver):
+        """Test that a custom pass callback stops optimization early."""
         X, y = simple_data
         n_passes = 5
         loader = ArrayDataLoader(X, y, batch_size=32, shuffle="full")
@@ -400,19 +400,19 @@ class TestGLMStochasticFit:
         model_baseline = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_baseline.stochastic_fit(loader, n_passes=n_passes, callbacks=None)
 
-        # Early stop: callback requests stop after first epoch
-        class StopAfterFirstEpoch(Callback):
+        # Early stop: callback requests stop after first pass
+        class StopAfterFirstPass(Callback):
             def on_pass_end(self, ctx):
                 if ctx.pass_idx >= 0:
                     ctx.request_stop("test stop")
 
         model_early = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_early.stochastic_fit(
-            loader, n_passes=n_passes, callbacks=StopAfterFirstEpoch()
+            loader, n_passes=n_passes, callbacks=StopAfterFirstPass()
         )
 
-        batches_per_epoch = int(np.ceil(loader.n_samples / loader.batch_size))
-        assert model_early.solver_state_.stats.num_steps == batches_per_epoch
+        batches_per_pass = int(np.ceil(loader.n_samples / loader.batch_size))
+        assert model_early.solver_state_.stats.num_steps == batches_per_pass
         assert (
             model_early.solver_state_.stats.num_steps
             < model_baseline.solver_state_.stats.num_steps
@@ -420,7 +420,7 @@ class TestGLMStochasticFit:
 
     @pytest.mark.parametrize("solver", _stochastic_solver_names)
     def test_loss_logger_callback_during_fit(self, simple_data, solver):
-        """loss_history accumulates one finite entry per epoch over a real fit."""
+        """loss_history accumulates one finite entry per pass over a real fit."""
         X, y = simple_data
         n_passes = 3
         loader = ArrayDataLoader(X, y, batch_size=32, shuffle="full")
@@ -895,23 +895,23 @@ class TestSolverStochasticRun:
         np.testing.assert_array_almost_equal(params, [1.0, 2.0, 3.0], decimal=0)
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
-    def test_epoch_callback_stops_early(self, simple_loss_and_data, solver_class):
-        """Test that an epoch callback requesting stop halts optimization."""
+    def test_pass_callback_stops_early(self, simple_loss_and_data, solver_class):
+        """Test that a pass callback requesting stop halts optimization."""
         loss, loader = simple_loss_and_data
 
-        class StopAfterEpoch(Callback):
+        class StopAfterPass(Callback):
             def on_pass_end(self, ctx):
                 ctx.request_stop("test")
 
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
         init_params = jnp.zeros(3)
         _, state, _ = solver.stochastic_run(
-            init_params, loader, n_passes=5, callback=StopAfterEpoch()
+            init_params, loader, n_passes=5, callback=StopAfterPass()
         )
 
-        # Should have stopped after 1 epoch
-        batches_per_epoch = int(np.ceil(loader.n_samples / loader.batch_size))
-        assert state.stats.num_steps == batches_per_epoch
+        # Should have stopped after 1 pass
+        batches_per_pass = int(np.ceil(loader.n_samples / loader.batch_size))
+        assert state.stats.num_steps == batches_per_pass
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
     def test_batch_callback_stops_early(self, simple_loss_and_data, solver_class):
@@ -945,7 +945,7 @@ class TestSolverStochasticRun:
             solver.stochastic_run(init_params, loader, n_passes=1)
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
-    def test_invalid_n_passes_raises(self, simple_loss_and_data, solver_class):
+    def test_invalid_n_passesraises(self, simple_loss_and_data, solver_class):
         """Test that n_passes < 1 raises ValueError."""
         loss, loader = simple_loss_and_data
 
@@ -969,8 +969,8 @@ class TestSolverStochasticRun:
         _, state, _ = solver.stochastic_run(init_params, loader, n_passes=n_passes)
 
         n_steps = state.stats.num_steps
-        batches_per_epoch = int(np.ceil(loader.n_samples / loader.batch_size))
-        expected_steps = batches_per_epoch * n_passes
+        batches_per_pass = int(np.ceil(loader.n_samples / loader.batch_size))
+        expected_steps = batches_per_pass * n_passes
         assert n_steps == expected_steps
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
@@ -1016,10 +1016,10 @@ class TestSolverStochasticRun:
         class CounterCallback(Callback):
             def __init__(self, multiplier: float):
                 self.multiplier = multiplier
-                self.epoch_counts = []
+                self.pass_counts = []
 
             def on_pass_end(self, ctx):
-                self.epoch_counts.append(self.multiplier * ctx.pass_idx)
+                self.pass_counts.append(self.multiplier * ctx.pass_idx)
 
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
         init_params = jnp.zeros(3)
@@ -1032,12 +1032,12 @@ class TestSolverStochasticRun:
             n_passes=n_passes,
             callback=CallbackList([cb1, cb2]),
         )
-        assert cb1.epoch_counts == [0, 1, 2]
-        assert cb2.epoch_counts == [0, 2, 4]
+        assert cb1.pass_counts == [0, 1, 2]
+        assert cb2.pass_counts == [0, 2, 4]
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
-    def test_no_callback_runs_all_epochs(self, simple_loss_and_data, solver_class):
-        """Test that default no-op callback runs all epochs without any monitoring."""
+    def test_no_callback_runs_all_passes(self, simple_loss_and_data, solver_class):
+        """Test that default no-op callback runs all passes without any monitoring."""
         loss, loader = simple_loss_and_data
 
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
@@ -1047,8 +1047,8 @@ class TestSolverStochasticRun:
         _, state, _ = solver.stochastic_run(init_params, loader, n_passes=n_passes)
 
         n_steps = state.stats.num_steps
-        batches_per_epoch = int(np.ceil(loader.n_samples / loader.batch_size))
-        expected_steps = batches_per_epoch * n_passes
+        batches_per_pass = int(np.ceil(loader.n_samples / loader.batch_size))
+        expected_steps = batches_per_pass * n_passes
         assert n_steps == expected_steps
 
 

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -80,7 +80,7 @@ if solvers.JAXOPT_AVAILABLE:
     )
 
 
-def _logging_ctx(epoch_idx=0, batch_idx=0, loss=1.0):
+def _logging_ctx(pass_idx=0, batch_idx=0, loss=1.0):
     """
     Build a TrainingContext with a fake model recording compute_loss calls.
 
@@ -96,7 +96,7 @@ def _logging_ctx(epoch_idx=0, batch_idx=0, loss=1.0):
     model = SimpleNamespace(compute_loss=compute_loss)
     params = SimpleNamespace(coef="COEF", intercept="INT")
     ctx = TrainingContext(
-        model=model, params=params, epoch_idx=epoch_idx, batch_idx=batch_idx
+        model=model, params=params, pass_idx=pass_idx, batch_idx=batch_idx
     )
     return ctx, calls
 
@@ -165,8 +165,8 @@ class TestCallbackSystem:
         ctx = TrainingContext(solver=None)
         cb.on_train_begin(ctx)
         cb.on_train_end(ctx)
-        cb.on_epoch_begin(ctx)
-        cb.on_epoch_end(ctx)
+        cb.on_pass_begin(ctx)
+        cb.on_pass_end(ctx)
         cb.on_batch_begin(ctx)
         cb.on_batch_end(ctx)
 
@@ -183,12 +183,12 @@ class TestCallbackSystem:
             def __init__(self, name):
                 self.name = name
 
-            def on_epoch_end(self, ctx):
+            def on_pass_end(self, ctx):
                 calls.append(self.name)
 
         cl = CallbackList([RecordingCallback("a"), RecordingCallback("b")])
         ctx = TrainingContext(solver=None)
-        cl.on_epoch_end(ctx)
+        cl.on_pass_end(ctx)
         assert calls == ["a", "b"]
 
     def test_loss_logger_requires_events(self):
@@ -204,10 +204,10 @@ class TestCallbackSystem:
     @pytest.mark.parametrize(
         "events, wired, not_wired",
         [
-            ("epoch_end", ["on_epoch_end"], ["on_batch_end", "on_train_begin"]),
+            ("pass_end", ["on_pass_end"], ["on_batch_end", "on_train_begin"]),
             (
-                ["epoch_end", "batch_end"],
-                ["on_epoch_end", "on_batch_end"],
+                ["pass_end", "batch_end"],
+                ["on_pass_end", "on_batch_end"],
                 ["on_train_end"],
             ),
         ],
@@ -227,37 +227,37 @@ class TestCallbackSystem:
 
     def test_loss_logger_string_normalized_to_set(self):
         """A single string event is stored as a set."""
-        cb = TestLossLogger(None, None, events="epoch_end")
-        assert cb.events == {"epoch_end"}
+        cb = TestLossLogger(None, None, events="pass_end")
+        assert cb.events == {"pass_end"}
 
     def test_loss_logger_forwards_compute_loss_args(self):
         """compute_loss receives (coef, intercept), X_test, y_test."""
-        cb = TestLossLogger("X", "Y", events="epoch_end")
+        cb = TestLossLogger("X", "Y", events="pass_end")
         ctx, calls = _logging_ctx()
-        cb.on_epoch_end(ctx)
+        cb.on_pass_end(ctx)
         assert calls == [(("COEF", "INT"), "X", "Y")]
 
     def test_loss_logger_records_tuple(self):
-        """Each entry is (event, epoch_idx, batch_idx, score)."""
-        cb = TestLossLogger(None, None, events="epoch_end")
-        ctx, _ = _logging_ctx(epoch_idx=2, batch_idx=5, loss=0.7)
-        cb.on_epoch_end(ctx)
-        assert cb.loss_history == [("epoch_end", 2, 5, 0.7)]
+        """Each entry is (event, pass_idx, batch_idx, score)."""
+        cb = TestLossLogger(None, None, events="pass_end")
+        ctx, _ = _logging_ctx(pass_idx=2, batch_idx=5, loss=0.7)
+        cb.on_pass_end(ctx)
+        assert cb.loss_history == [("pass_end", 2, 5, 0.7)]
 
     def test_loss_logger_disambiguates_events(self):
         """Mixed-event history carries the correct event label per entry."""
-        cb = TestLossLogger(None, None, events=["epoch_end", "batch_end"])
-        ctx, _ = _logging_ctx(epoch_idx=1, batch_idx=3)
+        cb = TestLossLogger(None, None, events=["pass_end", "batch_end"])
+        ctx, _ = _logging_ctx(pass_idx=1, batch_idx=3)
         cb.on_batch_end(ctx)
-        cb.on_epoch_end(ctx)
+        cb.on_pass_end(ctx)
         events = [entry[0] for entry in cb.loss_history]
-        assert events == ["batch_end", "epoch_end"]
+        assert events == ["batch_end", "pass_end"]
 
     def test_loss_logger_works_in_callback_list(self):
         """Dispatched through CallbackList, the wired hook still fires."""
-        cb = TestLossLogger(None, None, events="epoch_end")
+        cb = TestLossLogger(None, None, events="pass_end")
         ctx, _ = _logging_ctx()
-        CallbackList([cb]).on_epoch_end(ctx)
+        CallbackList([cb]).on_pass_end(ctx)
         assert len(cb.loss_history) == 1
 
 
@@ -289,7 +289,7 @@ class TestGLMStochasticFit:
         model = nmo.glm.GLM(
             solver_name=solver, solver_kwargs=self._default_solver_kwargs(solver)
         )
-        model.stochastic_fit(loader, num_epochs=5)
+        model.stochastic_fit(loader, n_passes=5)
 
         assert model.coef_ is not None
         assert model.intercept_ is not None
@@ -312,7 +312,7 @@ class TestGLMStochasticFit:
         init_intercept = jnp.zeros(1)
         init_params = (init_coef, init_intercept)
 
-        model.stochastic_fit(loader, num_epochs=1, init_params=init_params)
+        model.stochastic_fit(loader, n_passes=1, init_params=init_params)
 
         np.testing.assert_allclose(model.coef_, init_coef, atol=1e-2)
 
@@ -336,7 +336,7 @@ class TestGLMStochasticFit:
         model_stopping = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_stopping.stochastic_fit(
             loader,
-            num_epochs=n_epochs,
+            n_passes=n_epochs,
             init_params=final_params,
             callbacks=SolverConvergenceCallback(),
         )
@@ -345,7 +345,7 @@ class TestGLMStochasticFit:
         model_no_stopping = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_no_stopping.stochastic_fit(
             loader,
-            num_epochs=n_epochs,
+            n_passes=n_epochs,
             init_params=final_params,
         )
 
@@ -379,7 +379,7 @@ class TestGLMStochasticFit:
         # Invoking the criterion through the callback must not raise.
         with does_not_raise():
             model.stochastic_fit(
-                loader, num_epochs=2, callbacks=SolverConvergenceCallback()
+                loader, n_passes=2, callbacks=SolverConvergenceCallback()
             )
 
         # check that the fit actually exercised the fixed-step-size path.
@@ -391,24 +391,24 @@ class TestGLMStochasticFit:
     def test_custom_epoch_callback_stops_early(self, simple_data, solver):
         """Test that a custom epoch callback stops optimization early."""
         X, y = simple_data
-        num_epochs = 5
+        n_passes = 5
         loader = ArrayDataLoader(X, y, batch_size=32, shuffle="full")
 
         solver_kwargs = self._default_solver_kwargs(solver, maxiter=10_000)
 
         # Baseline: no callbacks
         model_baseline = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
-        model_baseline.stochastic_fit(loader, num_epochs=num_epochs, callbacks=None)
+        model_baseline.stochastic_fit(loader, n_passes=n_passes, callbacks=None)
 
         # Early stop: callback requests stop after first epoch
         class StopAfterFirstEpoch(Callback):
-            def on_epoch_end(self, ctx):
-                if ctx.epoch_idx >= 0:
+            def on_pass_end(self, ctx):
+                if ctx.pass_idx >= 0:
                     ctx.request_stop("test stop")
 
         model_early = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_early.stochastic_fit(
-            loader, num_epochs=num_epochs, callbacks=StopAfterFirstEpoch()
+            loader, n_passes=n_passes, callbacks=StopAfterFirstEpoch()
         )
 
         batches_per_epoch = int(np.ceil(loader.n_samples / loader.batch_size))
@@ -422,31 +422,31 @@ class TestGLMStochasticFit:
     def test_loss_logger_callback_during_fit(self, simple_data, solver):
         """loss_history accumulates one finite entry per epoch over a real fit."""
         X, y = simple_data
-        num_epochs = 3
+        n_passes = 3
         loader = ArrayDataLoader(X, y, batch_size=32, shuffle="full")
 
         solver_kwargs = self._default_solver_kwargs(solver)
 
-        cb = TestLossLogger(X, y, events="epoch_end")
+        cb = TestLossLogger(X, y, events="pass_end")
         model = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
-        model.stochastic_fit(loader, num_epochs=num_epochs, callbacks=cb)
+        model.stochastic_fit(loader, n_passes=n_passes, callbacks=cb)
 
-        assert len(cb.loss_history) == num_epochs
-        assert [entry[0] for entry in cb.loss_history] == ["epoch_end"] * num_epochs
+        assert len(cb.loss_history) == n_passes
+        assert [entry[0] for entry in cb.loss_history] == ["pass_end"] * n_passes
         assert all(np.isfinite(entry[-1]) for entry in cb.loss_history)
 
     @pytest.mark.parametrize("solver", _stochastic_solver_names)
     def test_batch_callback_stops_early(self, simple_data, solver):
         """Test that a batch callback requesting stop halts optimization early."""
         X, y = simple_data
-        num_epochs = 5
+        n_passes = 5
         loader = ArrayDataLoader(X, y, batch_size=32, shuffle="full")
 
         solver_kwargs = self._default_solver_kwargs(solver, maxiter=10_000)
 
         # Baseline: no callback
         model_baseline = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
-        model_baseline.stochastic_fit(loader, num_epochs=num_epochs, callbacks=None)
+        model_baseline.stochastic_fit(loader, n_passes=n_passes, callbacks=None)
 
         # Early stop: callback requests stops on first batch
         class StopOnFirstBatch(Callback):
@@ -456,7 +456,7 @@ class TestGLMStochasticFit:
         model_early = nmo.glm.GLM(solver_name=solver, solver_kwargs=solver_kwargs)
         model_early.stochastic_fit(
             loader,
-            num_epochs=num_epochs,
+            n_passes=n_passes,
             callbacks=StopOnFirstBatch(),
         )
 
@@ -691,7 +691,7 @@ class TestGLMStochasticFit:
             solver_name="GradientDescent",
             solver_kwargs={"stepsize": 0.001, "maxiter": 100, "acceleration": False},
         )
-        model.stochastic_fit(loader, num_epochs=1)
+        model.stochastic_fit(loader, n_passes=1)
 
         assert model.scale_ is not None
         np.testing.assert_allclose(model.scale_, 1.0)
@@ -719,7 +719,7 @@ class TestGLMStochasticFit:
             solver_name="GradientDescent",
             solver_kwargs={"stepsize": 0.001, "maxiter": 100, "acceleration": False},
         )
-        model.stochastic_fit(loader, num_epochs=1)
+        model.stochastic_fit(loader, n_passes=1)
 
         score = model.score(X, y)
         assert jnp.isfinite(score)
@@ -745,7 +745,7 @@ class TestGLMStochasticFit:
             solver_kwargs={"stepsize": 0.001, "maxiter": 100, "acceleration": False},
         )
         with pytest.warns(UserWarning, match="scale_"):
-            model.stochastic_fit(loader, num_epochs=1)
+            model.stochastic_fit(loader, n_passes=1)
 
         assert model.scale_ is None
         assert model.dof_resid_ is None
@@ -766,7 +766,7 @@ class TestGLMStochasticFit:
             solver_kwargs={"stepsize": 0.001, "maxiter": 100, "acceleration": False},
         )
         model.set_classes(np.arange(model.n_classes))
-        model.stochastic_fit(loader, num_epochs=1)
+        model.stochastic_fit(loader, n_passes=1)
 
         assert model.scale_ is not None
         np.testing.assert_allclose(model.scale_, 1.0)
@@ -788,12 +788,12 @@ class TestGLMStochasticFit:
             solver_name="GradientDescent",
             solver_kwargs={"stepsize": 0.001, "maxiter": 100, "acceleration": False},
         )
-        model.stochastic_fit(loader, num_epochs=5, callbacks=StopAfterFirstBatch())
+        model.stochastic_fit(loader, n_passes=5, callbacks=StopAfterFirstBatch())
 
         assert isinstance(model.stochastic_fit_summary_, StochasticFitSummary)
-        assert model.stochastic_fit_summary_.epoch_idx == 0
+        assert model.stochastic_fit_summary_.pass_idx == 0
         assert model.stochastic_fit_summary_.batch_idx == 0
-        assert model.stochastic_fit_summary_.num_epochs == 5
+        assert model.stochastic_fit_summary_.n_passes == 5
         assert model.stochastic_fit_summary_.should_stop
         assert model.stochastic_fit_summary_.stop_reason == "stop after first batch"
 
@@ -810,7 +810,7 @@ class TestGLMStochasticFit:
             solver_name="GradientDescent",
             solver_kwargs={"stepsize": 0.001, "maxiter": 100, "acceleration": False},
         )
-        model.stochastic_fit(loader, num_epochs=2, callbacks=StopImmediately())
+        model.stochastic_fit(loader, n_passes=2, callbacks=StopImmediately())
 
         save_path = tmp_path / "stochastic_model.npz"
         model.save_params(save_path)
@@ -842,7 +842,7 @@ class TestPopulationGLMStochasticFit:
             solver_kwargs["acceleration"] = False
 
         model = nmo.glm.PopulationGLM(solver_name=solver, solver_kwargs=solver_kwargs)
-        model.stochastic_fit(loader, num_epochs=5)
+        model.stochastic_fit(loader, n_passes=5)
 
         assert model.coef_ is not None
         assert model.intercept_ is not None
@@ -888,7 +888,7 @@ class TestSolverStochasticRun:
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
 
         init_params = jnp.zeros(3)
-        params, state, aux = solver.stochastic_run(init_params, loader, num_epochs=10)
+        params, state, aux = solver.stochastic_run(init_params, loader, n_passes=10)
 
         assert params.shape == (3,)
         # Should have learned something close to [1, 2, 3]
@@ -900,13 +900,13 @@ class TestSolverStochasticRun:
         loss, loader = simple_loss_and_data
 
         class StopAfterEpoch(Callback):
-            def on_epoch_end(self, ctx):
+            def on_pass_end(self, ctx):
                 ctx.request_stop("test")
 
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
         init_params = jnp.zeros(3)
         _, state, _ = solver.stochastic_run(
-            init_params, loader, num_epochs=5, callback=StopAfterEpoch()
+            init_params, loader, n_passes=5, callback=StopAfterEpoch()
         )
 
         # Should have stopped after 1 epoch
@@ -925,7 +925,7 @@ class TestSolverStochasticRun:
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
         init_params = jnp.zeros(3)
         _, state, _ = solver.stochastic_run(
-            init_params, loader, num_epochs=5, callback=StopOnFirstBatch()
+            init_params, loader, n_passes=5, callback=StopOnFirstBatch()
         )
         assert state.stats.num_steps == 1
 
@@ -942,35 +942,35 @@ class TestSolverStochasticRun:
 
         init_params = jnp.zeros(3)
         with pytest.raises(NotImplementedError, match="does not support stochastic"):
-            solver.stochastic_run(init_params, loader, num_epochs=1)
+            solver.stochastic_run(init_params, loader, n_passes=1)
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
-    def test_invalid_num_epochs_raises(self, simple_loss_and_data, solver_class):
-        """Test that num_epochs < 1 raises ValueError."""
+    def test_invalid_n_passes_raises(self, simple_loss_and_data, solver_class):
+        """Test that n_passes < 1 raises ValueError."""
         loss, loader = simple_loss_and_data
 
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
 
         init_params = jnp.zeros(3)
-        with pytest.raises(ValueError, match="num_epochs must be >= 1"):
-            solver.stochastic_run(init_params, loader, num_epochs=0)
+        with pytest.raises(ValueError, match="n_passes must be >= 1"):
+            solver.stochastic_run(init_params, loader, n_passes=0)
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
     def test_maxiter_does_not_stop_stochastic(self, simple_loss_and_data, solver_class):
-        """Test that maxiter does not limit stochastic optimization; only num_epochs does."""
+        """Test that maxiter does not limit stochastic optimization; only n_passes does."""
         loss, loader = simple_loss_and_data
 
         solver_kwargs = self._default_solver_kwargs(solver_class)
         # Set maxiter=1, which would stop after 1 step if it were respected
         solver = solver_class(loss, maxiter=1, **solver_kwargs)
 
-        num_epochs = 3
+        n_passes = 3
         init_params = jnp.zeros(3)
-        _, state, _ = solver.stochastic_run(init_params, loader, num_epochs=num_epochs)
+        _, state, _ = solver.stochastic_run(init_params, loader, n_passes=n_passes)
 
         n_steps = state.stats.num_steps
         batches_per_epoch = int(np.ceil(loader.n_samples / loader.batch_size))
-        expected_steps = batches_per_epoch * num_epochs
+        expected_steps = batches_per_epoch * n_passes
         assert n_steps == expected_steps
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
@@ -988,7 +988,7 @@ class TestSolverStochasticRun:
 
         init_params = jnp.zeros(3)
         with pytest.raises(ValueError, match="Turn off acceleration"):
-            solver.stochastic_run(init_params, loader, num_epochs=10)
+            solver.stochastic_run(init_params, loader, n_passes=10)
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
     def test_linesearch_not_allowed(self, simple_loss_and_data, solver_class):
@@ -1006,7 +1006,7 @@ class TestSolverStochasticRun:
 
         init_params = jnp.zeros(3)
         with pytest.raises(ValueError, match="Turn off linesearch"):
-            solver.stochastic_run(init_params, loader, num_epochs=10)
+            solver.stochastic_run(init_params, loader, n_passes=10)
 
     @pytest.mark.parametrize("solver_class", _stochastic_solver_classes)
     def test_multiple_callbacks(self, simple_loss_and_data, solver_class):
@@ -1018,18 +1018,18 @@ class TestSolverStochasticRun:
                 self.multiplier = multiplier
                 self.epoch_counts = []
 
-            def on_epoch_end(self, ctx):
-                self.epoch_counts.append(self.multiplier * ctx.epoch_idx)
+            def on_pass_end(self, ctx):
+                self.epoch_counts.append(self.multiplier * ctx.pass_idx)
 
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
         init_params = jnp.zeros(3)
-        num_epochs = 3
+        n_passes = 3
         cb1 = CounterCallback(1)
         cb2 = CounterCallback(2)
         solver.stochastic_run(
             init_params,
             loader,
-            num_epochs=num_epochs,
+            n_passes=n_passes,
             callback=CallbackList([cb1, cb2]),
         )
         assert cb1.epoch_counts == [0, 1, 2]
@@ -1042,13 +1042,13 @@ class TestSolverStochasticRun:
 
         solver = solver_class(loss, **self._default_solver_kwargs(solver_class))
         init_params = jnp.zeros(3)
-        num_epochs = 3
+        n_passes = 3
 
-        _, state, _ = solver.stochastic_run(init_params, loader, num_epochs=num_epochs)
+        _, state, _ = solver.stochastic_run(init_params, loader, n_passes=n_passes)
 
         n_steps = state.stats.num_steps
         batches_per_epoch = int(np.ceil(loader.n_samples / loader.batch_size))
-        expected_steps = batches_per_epoch * num_epochs
+        expected_steps = batches_per_epoch * n_passes
         assert n_steps == expected_steps
 
 


### PR DESCRIPTION
## Summary

This PR focuses on two aims:

- Drop the machine-learning `epoch` terminology that conflicts with `pynapple`'s recording epochs. Since `pynapple` is ubiquitous in the documentation, the conflicting terminology was too confusing, especially for neuroscientist not familiar with the ML literature.
- Improve the custom pynapple data loader doc note. In particular, a new, multi-(pynapple)epoch friendly dataloader is provided. This loader can be used as a template of how to handle stochastic fits and batching in the presence of a disjoint time series.

## Major changes

- `epoch` in the machine-learning sense has been replaced with `passes` throughout the package.
- A new session setting up a `MultiEpochPynappleDataLoader` class is added to `custom_data_loader.md`. The whole note has been restructured for flow and clarity.
