### PR TITLE
Expose session to validate

### DIFF
--- a/src/nemos/base_validator.py
+++ b/src/nemos/base_validator.py
@@ -299,6 +299,7 @@ class RegressorValidator(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParams
         self,
         X: Optional[DESIGN_INPUT_TYPE] = None,
         y: Optional[jnp.ndarray | Tsd | TsdFrame] = None,
+        **kwargs,
     ):
         """
         Validate input data dimensions and sample consistency.
@@ -313,6 +314,11 @@ class RegressorValidator(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParams
             Input features. Should have dimensionality matching X_dimensionality.
         y : jnp.ndarray, optional
             Output/target data. Should have dimensionality matching y_dimensionality.
+        **kwargs
+            Ignored here. Accepted so that this check can run as a step of a validation
+            sequence whose steps all receive the same arguments, such as the session
+            boundaries threaded by
+            :meth:`~nemos.hmm.validation.HMMValidator.validate_and_cast_inputs`.
 
         Raises
         ------

--- a/src/nemos/glm_hmm/glm_hmm.py
+++ b/src/nemos/glm_hmm/glm_hmm.py
@@ -775,13 +775,13 @@ class GLMHMM(
         setup : Configure the initializers used when ``init_params is None``.
         update : Run a single EM iteration (advanced, manual loop).
         """
-        self._validator.validate_inputs(X=X, y=y)
-        # validate and cast session boundaries, shifting markers off NaN samples
-        session_starts = self._validator.validate_and_cast_session_starts(
+        # validate inputs, cast the session boundaries shifting markers off NaN samples,
+        # then check continuity within each session
+        session_starts = self._validator.validate_and_cast_inputs(
             X, y, session_starts=session_starts
         )
 
-        # validate the inputs & initialize solver
+        # initialize solver
         # initialize params if no params are provided
         if init_params is None:
             init_params = self._model_specific_initialization(X, y, session_starts)
@@ -1551,8 +1551,7 @@ class GLMHMM(
         >>> new_params, new_state = model.update(init_params, opt_state, X, y)
         """
         # validate inputs and session boundaries
-        self._validator.validate_inputs(X=X, y=y)
-        session_starts = self._validator.validate_and_cast_session_starts(
+        session_starts = self._validator.validate_and_cast_inputs(
             X, y, session_starts=session_starts
         )
 

--- a/src/nemos/hmm/hmm.py
+++ b/src/nemos/hmm/hmm.py
@@ -647,12 +647,11 @@ class BaseHMM(
         self._check_is_fit()
         params = self._get_model_params()
 
-        # validate inputs
-        self._validator.validate_inputs(X=X, y=y)
-        self._validator.validate_consistency(params, X=X, y=y)
-        session_starts = self._validator.validate_and_cast_session_starts(
+        # validate inputs and session boundaries
+        session_starts = self._validator.validate_and_cast_inputs(
             X=X, y=y, session_starts=session_starts
         )
+        self._validator.validate_consistency(params, X=X, y=y)
         return params, X, y, session_starts
 
     @abc.abstractmethod

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -8,10 +8,10 @@ from typing import Any, Optional, Tuple
 import jax
 import jax.numpy as jnp
 import lazy_loader as lazy
+import numpy as np
 
 from .. import validation
 from ..base_validator import RegressorValidator
-from ..tree_utils import pytree_map_and_reduce
 from ..type_casting import is_pynapple_tsd
 from ..typing import DESIGN_INPUT_TYPE, ArrayLike
 from .params import HMMModelParamsT, HMMParams, HMMUserParams, HMMUserProvidedParamsT
@@ -23,26 +23,80 @@ from .utils import (
 nap = lazy.load("pynapple")
 
 
-def has_nans_only_at_border(arr):
-    """Check if NaNs appear only at the start and end along axis=0."""
-    # Check which rows have any NaN values
-    is_nan = jnp.any(jnp.isnan(arr.reshape(arr.shape[0], -1)), axis=1)
+def nan_sample_mask(X: DESIGN_INPUT_TYPE, y: Optional[ArrayLike] = None) -> jnp.ndarray:
+    """Flag the samples containing NaNs in any leaf of ``X`` or in ``y``.
 
-    # If no NaNs, it's valid
-    if not jnp.any(is_nan):
-        return True
+    Parameters
+    ----------
+    X :
+        Input data/design matrix, shape ``(n_samples, n_features)``, or a pytree of
+        such arrays. Pynapple time series are accepted.
+    y :
+        Output data/observations, shape ``(n_samples, ...)``. If None (e.g. during
+        simulation), only ``X`` is inspected.
 
-    # If all NaNs, it's valid
-    if jnp.all(is_nan):
-        return True
+    Returns
+    -------
+    :
+        Boolean array of shape ``(n_samples,)``, True where any feature or
+        observation of that sample is NaN.
+    """
 
-    # Find first and last non-NaN positions
-    non_nan_indices = jnp.where(~is_nan)[0]
-    first_valid = non_nan_indices[0]
-    last_valid = non_nan_indices[-1]
+    def _is_nan(x):
+        x = jnp.asarray(x)
+        return jnp.any(jnp.isnan(x.reshape(x.shape[0], -1)), axis=1)
 
-    # Check if there are any NaNs between first and last valid values
-    return not jnp.any(is_nan[first_valid : last_valid + 1])
+    is_nan = jax.tree_util.tree_reduce(jnp.logical_or, jax.tree.map(_is_nan, X))
+    if y is not None:
+        is_nan = is_nan | _is_nan(y)
+    return is_nan
+
+
+def has_interior_nans(is_nan: ArrayLike, session_starts: ArrayLike) -> bool:
+    """Check if any session holds a NaN sample between two valid samples.
+
+    A session is acceptable when its valid samples form a single contiguous run:
+    dropping NaNs at its head or tail shortens the session without reordering it, while
+    dropping an interior NaN would splice together bins that are not adjacent in time.
+
+    Counting the runs over the whole recording answers this without a per-session scan.
+    A session holding valid samples contributes one run when they are contiguous and at
+    least two when a NaN splits them; an all-NaN session contributes none. The total
+    number of runs therefore exceeds the number of sessions holding a valid sample if
+    and only if some session is split.
+
+    The two counts run on the host: they reduce one boolean per sample, which costs less
+    than the ``jax`` dispatch needed to place them on a device.
+
+    Parameters
+    ----------
+    is_nan :
+        Boolean array flagging the NaN samples, shape ``(n_samples,)``, as returned by
+        :func:`nan_sample_mask`.
+    session_starts :
+        Boolean array of session-start indicators, shape ``(n_samples,)``. The first
+        element must be True.
+
+    Returns
+    -------
+    :
+        True if at least one session holds a NaN between two valid samples. Sessions
+        that are entirely NaN, and sessions holding a single valid sample, hold none.
+    """
+    is_nan = np.asarray(is_nan)
+    session_starts = np.asarray(session_starts)
+    is_valid = ~is_nan
+
+    # a run opens at a valid sample with no valid predecessor inside its session, that
+    # is one preceded by a NaN or one starting a session. The slices pair sample i with
+    # its predecessor i - 1, which leaves out sample 0: it opens a run when it is valid.
+    opens_run = is_valid[1:] & (is_nan[:-1] | session_starts[1:])
+    n_runs = np.count_nonzero(opens_run) + is_valid[0]
+
+    # reduceat sums is_valid between consecutive session starts, giving one valid-sample
+    # count per session, so its non-zero entries are the sessions holding valid samples
+    n_valid_per_session = np.add.reduceat(is_valid, np.flatnonzero(session_starts))
+    return n_runs > np.count_nonzero(n_valid_per_session)
 
 
 def to_hmm_params(user_params: HMMUserParams) -> HMMParams:
@@ -81,6 +135,14 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
         ("check_init_and_transition_prob_shape", None),
         ("check_init_and_transition_prob_sum_to_1", None),
+    )
+    # tuples [(meth, kwargs), ...]; see validate_and_cast_inputs for the step contract
+    inputs_validation_sequence: Tuple[
+        Tuple[str, None] | Tuple[str, dict[str, Any]], ...
+    ] = (
+        ("validate_inputs", None),
+        ("validate_and_cast_session_starts", None),
+        ("check_is_continuous", None),
     )
 
     def check_user_params_structure(
@@ -155,52 +217,93 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
             )
         return params
 
-    def validate_inputs(
+    def validate_and_cast_inputs(
         self,
-        X: Optional[DESIGN_INPUT_TYPE] = None,
-        y: Optional[jnp.ndarray | nap.Tsd | nap.TsdFrame] = None,
-    ):
-        """Validate inputs for HMM model."""
-        super().validate_inputs(X, y)
+        X: DESIGN_INPUT_TYPE,
+        y: Optional[ArrayLike] = None,
+        session_starts: Optional[ArrayLike | nap.IntervalSet] = None,
+        **validation_kwargs,
+    ) -> jnp.ndarray:
+        """Run ``inputs_validation_sequence`` in order, returning the cast boundaries.
 
-        # Additional checks due to the time-series structure.
-        # (the forward-backward implementation assumes no nans in the inputs)
-        # Skip NaN border check if y is None (e.g., during simulation)
-        if y is None:
-            if X is not None and not pytree_map_and_reduce(
-                has_nans_only_at_border, all, X
-            ):
-                raise ValueError(
-                    "HMM requires continuous time-series data. NaN values must only "
-                    "appear at the beginning or end of the data, not in the middle."
-                )
+        Every step is called with the inputs and the session boundaries known so far. A
+        step returning a value replaces the boundaries for the steps that follow, which
+        is how :meth:`validate_and_cast_session_starts` hands the cast indicators to
+        :meth:`check_is_continuous`; a step returning None leaves them untouched.
+
+        Parameters
+        ----------
+        X :
+            Input data/design matrix, shape ``(n_samples, n_features)``, or a pytree
+            of such arrays.
+        y :
+            Output data/observations, shape ``(n_samples, ...)``. If None (e.g. during
+            simulation), the checks that need it are skipped.
+        session_starts :
+            User-provided session boundaries, see
+            :func:`~nemos.hmm.utils.initialize_session_starts`.
+        **validation_kwargs
+            Extra keyword arguments forwarded to every step of the sequence.
+
+        Returns
+        -------
+        :
+            Boolean array of session-start indicators, shape ``(n_samples,)``.
+        """
+        for method_name, method_kwargs in self.inputs_validation_sequence:
+            method_kwargs = {} if method_kwargs is None else method_kwargs
+            # Merge default kwargs with any user-provided kwargs
+            merged_kwargs = {**method_kwargs, **validation_kwargs}
+            out = getattr(self, method_name)(
+                X, y, session_starts=session_starts, **merged_kwargs
+            )
+            if out is not None:
+                session_starts = out
+
+        return session_starts
+
+    def check_is_continuous(
+        self,
+        X: DESIGN_INPUT_TYPE,
+        y: Optional[ArrayLike],
+        session_starts: jnp.ndarray,
+    ) -> None:
+        """Check that each session is a contiguous stretch of valid samples.
+
+        The forward-backward recursions run over the samples of a session in order, so
+        a NaN in the middle of a session would break the message passing. NaNs at the
+        borders of a session are dropped before inference without altering the
+        ordering, and are therefore allowed.
+
+        Sessions are delimited by ``session_starts``, not by the epochs of a pynapple
+        input: the boundaries that inference will use are the ones that matter, and the
+        two differ whenever the caller passes explicit boundaries alongside a pynapple
+        time series.
+
+        Parameters
+        ----------
+        X :
+            Input data/design matrix, shape ``(n_samples, n_features)``, or a pytree
+            of such arrays.
+        y :
+            Output data/observations, shape ``(n_samples, ...)``. If None (e.g. during
+            simulation), only ``X`` is checked.
+        session_starts :
+            Boolean array of session-start indicators, shape ``(n_samples,)``, as
+            returned by :meth:`validate_and_cast_session_starts`.
+
+        Raises
+        ------
+        ValueError
+            If any session holds a NaN sample between two valid samples.
+        """
+        is_nan = np.asarray(nan_sample_mask(X, y))
+
+        # nothing to check when the data holds no NaN
+        if not is_nan.any():
             return
 
-        if is_pynapple_tsd(X):
-            # loop over epochs and check that nans are all at the border
-            epoch_slices = [
-                X.get_slice(ep.start[0], ep.end[0]) for ep in X.time_support
-            ]
-            y_array = jnp.asarray(y)
-            is_continuous = all(
-                has_nans_only_at_border(X.d[s]) and has_nans_only_at_border(y_array[s])
-                for s in epoch_slices
-            )
-        elif is_pynapple_tsd(y):
-            # loop over epochs and check that nans are all at the border
-            epoch_slices = [
-                y.get_slice(ep.start[0], ep.end[0]) for ep in y.time_support
-            ]
-            is_continuous = all(
-                has_nans_only_at_border(X[s]) and has_nans_only_at_border(y.d[s])
-                for s in epoch_slices
-            )
-        else:
-            # check nans at the border
-            is_continuous = pytree_map_and_reduce(
-                has_nans_only_at_border, all, X
-            ) and has_nans_only_at_border(y)
-        if not is_continuous:
+        if has_interior_nans(is_nan, session_starts):
             raise ValueError(
                 f"{self.model_class} requires continuous time-series data. NaN values must only "
                 "appear at the beginning or end of the data, not in the middle. "
@@ -212,7 +315,28 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
     def validate_and_cast_session_starts(
         self, X, y, session_starts: Optional[ArrayLike | nap.IntervalSet] = None
     ) -> jnp.ndarray:
-        """Validate and cast session_starts to a binary array of shape (n_samples,)."""
+        """Validate and cast session_starts to a binary array of shape (n_samples,).
+
+        Parameters
+        ----------
+        X :
+            Input data/design matrix, shape ``(n_samples, n_features)``, or a pytree
+            of such arrays.
+        y :
+            Output data/observations, shape ``(n_samples, ...)``. If None (e.g. during
+            simulation), the sample count is read off ``X``.
+        session_starts :
+            User-provided session boundaries, see
+            :func:`~nemos.hmm.utils.initialize_session_starts`. If None, the pynapple
+            time support of ``y`` or ``X`` is used when available, otherwise the data
+            is treated as a single session.
+
+        Returns
+        -------
+        :
+            Boolean array of session-start indicators, shape ``(n_samples,)``, with the
+            markers falling on NaN samples shifted to the next valid sample.
+        """
         if session_starts is None:
             if is_pynapple_tsd(y):
                 session_starts = y.time_support
@@ -222,17 +346,7 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
         session_starts = initialize_session_starts(X, y, session_starts)
 
         # shift any True values that fall on NaN samples to the next valid sample
-        def _is_nan(x):
-            return jnp.any(jnp.isnan(jnp.asarray(x)).reshape(x.shape[0], -1), axis=1)
-
-        nan_x = jax.tree_util.tree_reduce(jnp.logical_or, jax.tree.map(_is_nan, X))
-
-        if y is not None:
-            nan_y = jnp.any(jnp.isnan(jnp.asarray(y)).reshape(y.shape[0], -1), axis=1)
-            combined_nans = nan_x | nan_y
-        else:
-            combined_nans = nan_x
-        return shift_nan_session_starts(session_starts, combined_nans)
+        return shift_nan_session_starts(session_starts, nan_sample_mask(X, y))
 
     def get_empty_params(self, X, y) -> HMMModelParamsT:
         """Return the param shape given the input data."""

--- a/src/nemos/hmm/validation.py
+++ b/src/nemos/hmm/validation.py
@@ -255,7 +255,7 @@ class HMMValidator(RegressorValidator[HMMUserProvidedParamsT, HMMModelParamsT]):
             # Merge default kwargs with any user-provided kwargs
             merged_kwargs = {**method_kwargs, **validation_kwargs}
             out = getattr(self, method_name)(
-                X, y, session_starts=session_starts, **merged_kwargs
+                X=X, y=y, session_starts=session_starts, **merged_kwargs
             )
             if out is not None:
                 session_starts = out

--- a/tests/test_glm_hmm_class.py
+++ b/tests/test_glm_hmm_class.py
@@ -300,6 +300,29 @@ def _spy_calls(monkeypatch, container, attr_name):
     return calls
 
 
+def _spy_call_order(monkeypatch, container, *attr_names):
+    """Wrap several attributes of ``container`` with spies sharing one call log.
+
+    Returns a list holding the name of each attribute in the order it was called,
+    forwarding to the real callables. Complements ``_spy_calls``, which logs the
+    arguments of a single attribute and so cannot capture the relative order of two.
+    """
+    order = []
+
+    def make_spy(attr_name, real):
+        def spy(*args, **kwargs):
+            order.append(attr_name)
+            return real(*args, **kwargs)
+
+        return spy
+
+    for attr_name in attr_names:
+        monkeypatch.setattr(
+            container, attr_name, make_spy(attr_name, getattr(container, attr_name))
+        )
+    return order
+
+
 def _make_model_params(n_features, n_states, n_neurons=None):
     """Build a minimal GLMHMMModelParams (zeros). ``n_neurons=None`` for single-neuron."""
     if n_neurons is None:
@@ -705,6 +728,49 @@ class TestFitDelegation:
 
         mock.assert_called_once()
 
+    def test_fit_calls_check_is_continuous(
+        self, glm_hmm_data, mock_glm_hmm_optimizer_run, monkeypatch
+    ):
+        """fit() forwards X, y and the cast boundaries to check_is_continuous."""
+        calls = _spy_calls(monkeypatch, GLMHMMValidator, "check_is_continuous")
+
+        model = GLMHMM(n_states=glm_hmm_data["n_states"])
+        model.fit(
+            glm_hmm_data["X"],
+            glm_hmm_data["y"],
+            init_params=glm_hmm_data["init_params"],
+        )
+
+        assert len(calls) == 1
+        _, kwargs = calls[0]
+        assert kwargs["X"] is glm_hmm_data["X"]
+        assert kwargs["y"] is glm_hmm_data["y"]
+        assert kwargs["session_starts"].shape == (glm_hmm_data["X"].shape[0],)
+
+    def test_simulate_calls_check_is_continuous(
+        self,
+        glm_hmm_data,
+        mock_glm_hmm_optimizer_run,
+        stub_glmhmm_simulate,
+        monkeypatch,
+    ):
+        """simulate() checks the feedforward input, with no observations to pair it to."""
+        n = glm_hmm_data["X"].shape[0]
+        X = glm_hmm_data["X"]
+
+        model = GLMHMM(n_states=glm_hmm_data["n_states"])
+        model.fit(X, glm_hmm_data["y"], init_params=glm_hmm_data["init_params"])
+
+        calls = _spy_calls(monkeypatch, GLMHMMValidator, "check_is_continuous")
+        stub_glmhmm_simulate(n)
+
+        model.simulate(jax.random.key(0), X)
+
+        assert len(calls) == 1
+        _, kwargs = calls[0]
+        assert kwargs["X"] is X
+        assert kwargs["y"] is None
+
     def test_fit_calls_validate_inputs(
         self, glm_hmm_data, mock_glm_hmm_optimizer_run, monkeypatch
     ):
@@ -810,6 +876,90 @@ class TestFitDelegation:
         calls = _spy_calls(monkeypatch, GLMHMMValidator, "validate_and_cast_params")
         model.fit(glm_hmm_data["X"], glm_hmm_data["y"])
         assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestValidationSequence — order of the input validation steps
+# ---------------------------------------------------------------------------
+
+
+VALIDATION_SEQUENCE = [
+    method_name for method_name, _ in GLMHMMValidator.inputs_validation_sequence
+]
+
+
+class TestValidationSequence:
+    """Every entry point runs the declared inputs_validation_sequence, in order. The
+    order is load bearing: check_is_continuous reads the boundaries that
+    validate_and_cast_session_starts produces, NaN shifts included, so running it
+    earlier would check a session partition other than the one inference uses."""
+
+    def test_declared_sequence(self):
+        """The sequence the entry points are expected to run, spelled out."""
+        assert VALIDATION_SEQUENCE == [
+            "validate_inputs",
+            "validate_and_cast_session_starts",
+            "check_is_continuous",
+        ]
+
+    @pytest.fixture
+    def fitted_model(self, glm_hmm_data, mock_glm_hmm_optimizer_run):
+        model = GLMHMM(n_states=glm_hmm_data["n_states"])
+        model.fit(
+            glm_hmm_data["X"],
+            glm_hmm_data["y"],
+            init_params=glm_hmm_data["init_params"],
+        )
+        return model
+
+    def test_fit(self, glm_hmm_data, mock_glm_hmm_optimizer_run, monkeypatch):
+        order = _spy_call_order(monkeypatch, GLMHMMValidator, *VALIDATION_SEQUENCE)
+
+        GLMHMM(n_states=glm_hmm_data["n_states"]).fit(
+            glm_hmm_data["X"],
+            glm_hmm_data["y"],
+            init_params=glm_hmm_data["init_params"],
+        )
+
+        assert order == VALIDATION_SEQUENCE
+
+    def test_update(self, glm_hmm_data, patch_optimizer_update, monkeypatch):
+        patch_optimizer_update(GLMHMM)
+        X, y, init_params = (
+            glm_hmm_data["X"],
+            glm_hmm_data["y"],
+            glm_hmm_data["init_params"],
+        )
+        model = GLMHMM(n_states=glm_hmm_data["n_states"])
+        opt_state = model.initialize_optimizer_and_state(init_params, X, y)
+
+        # spy after the setup calls, so that only update() is recorded
+        order = _spy_call_order(monkeypatch, GLMHMMValidator, *VALIDATION_SEQUENCE)
+        model.update(init_params, opt_state, X, y)
+
+        assert order == VALIDATION_SEQUENCE
+
+    @pytest.mark.parametrize(
+        "method_name", ["score", "smooth_proba", "filter_proba", "decode_state"]
+    )
+    def test_inference_methods(
+        self, method_name, fitted_model, glm_hmm_data, monkeypatch
+    ):
+        order = _spy_call_order(monkeypatch, GLMHMMValidator, *VALIDATION_SEQUENCE)
+
+        getattr(fitted_model, method_name)(glm_hmm_data["X"], glm_hmm_data["y"])
+
+        assert order == VALIDATION_SEQUENCE
+
+    def test_simulate(
+        self, fitted_model, glm_hmm_data, stub_glmhmm_simulate, monkeypatch
+    ):
+        stub_glmhmm_simulate(glm_hmm_data["X"].shape[0])
+        order = _spy_call_order(monkeypatch, GLMHMMValidator, *VALIDATION_SEQUENCE)
+
+        fitted_model.simulate(jax.random.key(0), glm_hmm_data["X"])
+
+        assert order == VALIDATION_SEQUENCE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hmm_validator.py
+++ b/tests/test_hmm_validator.py
@@ -5,7 +5,43 @@ import pynapple as nap
 import pytest
 
 from conftest import MockHMM, all_subclasses
-from nemos.hmm.validation import HMMValidator
+from nemos.hmm.validation import HMMValidator, has_interior_nans
+
+
+def _check_continuity(model, X, y, session_starts=None):
+    """Cast the session boundaries and run the continuity check on them, as models do."""
+    session_starts = model._validator.validate_and_cast_session_starts(
+        X, y, session_starts=session_starts
+    )
+    model._validator.check_is_continuous(X, y, session_starts)
+
+
+def _validate_and_check_continuity(model, X, y, session_starts=None):
+    """Run the validation sequence models apply to their inputs.
+
+    Mirrors ``BaseHMM._validate_and_prepare_inputs``: shape and NaN checks first, then
+    the session boundaries, then continuity within each session.
+    """
+    model._validator.validate_inputs(X, y)
+    _check_continuity(model, X, y, session_starts)
+
+
+def _nan_design(nan_at, n_samples=6):
+    """A ``(n_samples, 1)`` design matrix holding NaNs at the given sample indices."""
+    X = np.zeros((n_samples, 1))
+    X[list(nan_at)] = np.nan
+    return X
+
+
+def _reference_has_interior_nans(is_nan, session_starts):
+    """Naive per-session scan, as a reference for the run-counting implementation."""
+    starts = np.flatnonzero(session_starts)
+    for start, end in zip(starts, np.append(starts[1:], len(is_nan))):
+        block = is_nan[start:end]
+        valid = np.flatnonzero(~block)
+        if valid.size and block[valid[0] : valid[-1] + 1].any():
+            return True
+    return False
 
 
 class TestHMMValidator:
@@ -97,10 +133,10 @@ class TestHMMValidator:
         ],
     )
     def test_nans_only_at_border(self, X, y, expectation):
-        """Test that validate_inputs allows NaNs only at the borders of the data."""
+        """Test that the validation sequence allows NaNs only at the borders of the data."""
         model = MockHMM(n_states=3)
         with expectation:
-            model._validator.validate_inputs(X, y)
+            _validate_and_check_continuity(model, X, y)
 
     @pytest.mark.parametrize(
         "X_ndim, expectation",
@@ -249,6 +285,195 @@ class TestHMMValidator:
         ],
     )
     def test_nan_at_boundary_allowed_in_middle_rejected(self, X, y, expectation):
-        validator = MockHMM(n_states=3)._validator
+        model = MockHMM(n_states=3)
         with expectation:
-            validator.validate_inputs(X, y)
+            _validate_and_check_continuity(model, X, y)
+
+
+class TestCheckIsContinuous:
+    """NaNs may sit at the borders of a session, never between two of its valid samples."""
+
+    @pytest.mark.parametrize(
+        "nan_at, expectation",
+        [
+            ((), does_not_raise()),  # no NaN, nothing to check
+            ((0,), does_not_raise()),  # head
+            ((0, 1), does_not_raise()),
+            ((5,), does_not_raise()),  # tail
+            ((4, 5), does_not_raise()),
+            ((0, 5), does_not_raise()),  # both borders
+            ((0, 1, 2, 3, 4, 5), does_not_raise()),  # entirely NaN
+            ((3,), pytest.raises(ValueError, match="requires continuous")),
+            ((2, 3), pytest.raises(ValueError, match="requires continuous")),
+            ((0, 3, 5), pytest.raises(ValueError, match="requires continuous")),
+        ],
+    )
+    def test_single_session(self, nan_at, expectation):
+        """Without boundaries the whole recording is one session."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            _check_continuity(model, _nan_design(nan_at), np.zeros(6))
+
+    @pytest.mark.parametrize(
+        "session_starts, expectation",
+        [
+            (None, pytest.raises(ValueError, match="requires continuous")),
+            (np.array([0, 3]), does_not_raise()),  # the NaN heads the second session
+            (np.array([0, 4]), does_not_raise()),  # the NaN tails the first session
+            (np.array([0, 2]), pytest.raises(ValueError, match="requires continuous")),
+        ],
+    )
+    def test_boundaries_decide_the_verdict(self, session_starts, expectation):
+        """The same NaN is interior or at a border depending on where sessions start."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            _check_continuity(
+                model, _nan_design((3,)), np.zeros(6), session_starts=session_starts
+            )
+
+    @pytest.mark.parametrize(
+        "session_starts",
+        [
+            np.array([0, 3]),  # indices
+            np.array([True, False, False, True, False, False]),  # per-sample indicator
+            np.array([1, 0, 0, 1, 0, 0]),  # integer 0/1 indicator
+        ],
+    )
+    def test_boundary_formats_agree(self, session_starts):
+        """Equivalent boundaries give the same verdict whatever format they come in."""
+        model = MockHMM(n_states=3)
+        _check_continuity(model, _nan_design((3,)), np.zeros(6), session_starts)
+        with pytest.raises(ValueError, match="requires continuous"):
+            _check_continuity(model, _nan_design((4,)), np.zeros(6), session_starts)
+
+    @pytest.mark.parametrize(
+        "nan_at, expectation",
+        [
+            ((0,), does_not_raise()),
+            ((5,), does_not_raise()),
+            ((3,), pytest.raises(ValueError, match="requires continuous")),
+        ],
+    )
+    def test_y_is_none(self, nan_at, expectation):
+        """During simulation only the feedforward input is available to check."""
+        model = MockHMM(n_states=3)
+        with expectation:
+            _check_continuity(model, _nan_design(nan_at), None)
+
+    @pytest.mark.parametrize(
+        "nan_at, expectation",
+        [
+            ((0,), does_not_raise()),
+            ((5,), does_not_raise()),
+            ((3,), pytest.raises(ValueError, match="requires continuous")),
+        ],
+    )
+    def test_nan_in_y(self, nan_at, expectation):
+        """NaNs in the observations are as disqualifying as NaNs in the design matrix."""
+        model = MockHMM(n_states=3)
+        y = np.zeros(6)
+        y[list(nan_at)] = np.nan
+        with expectation:
+            _check_continuity(model, np.zeros((6, 1)), y)
+
+    def test_single_sample_sessions(self):
+        """A session of one sample can hold no NaN between two valid samples."""
+        model = MockHMM(n_states=3)
+        _check_continuity(
+            model,
+            _nan_design((1, 3)),
+            np.zeros(6),
+            session_starts=np.ones(6, dtype=bool),
+        )
+
+    @pytest.mark.parametrize("nan_at", [(0, 1, 2), (3, 4, 5)])
+    def test_entirely_nan_session_allowed(self, nan_at):
+        """A session with no valid sample cannot break the recursion."""
+        model = MockHMM(n_states=3)
+        _check_continuity(
+            model, _nan_design(nan_at), np.zeros(6), session_starts=np.array([0, 3])
+        )
+
+    @pytest.mark.parametrize(
+        "nan_a, nan_b, expectation",
+        [
+            ((0,), (5,), does_not_raise()),  # each leaf keeps its NaNs at a border
+            ((3,), (), pytest.raises(ValueError, match="requires continuous")),
+            # NaNs in different leaves combine into a single interior gap
+            ((2,), (3,), pytest.raises(ValueError, match="requires continuous")),
+        ],
+    )
+    def test_pytree_leaves_combine(self, nan_a, nan_b, expectation):
+        """A sample is missing when any leaf of the pytree is missing it."""
+        model = MockHMM(n_states=3)
+        X = {"a": _nan_design(nan_a), "b": _nan_design(nan_b)}
+        with expectation:
+            _check_continuity(model, X, np.zeros(6))
+
+    @pytest.mark.parametrize(
+        "session_starts, expectation",
+        [
+            (None, does_not_raise()),  # epochs of the time support delimit the sessions
+            (np.array([0]), pytest.raises(ValueError, match="requires continuous")),
+        ],
+    )
+    def test_pynapple_time_support_vs_explicit_boundaries(
+        self, session_starts, expectation
+    ):
+        """Explicit boundaries take over from the time support, and can invalidate it."""
+        model = MockHMM(n_states=3)
+        X = nap.TsdFrame(
+            t=np.arange(5),
+            d=np.array([[0], [0], [np.nan], [0], [0]], dtype=float),
+            time_support=nap.IntervalSet([0, 3], [2, 5]),
+        )
+        with expectation:
+            _check_continuity(model, X, np.zeros(5), session_starts=session_starts)
+
+
+class TestHasInteriorNans:
+    """Run-counting identity behind the continuity check."""
+
+    @pytest.mark.parametrize(
+        "is_nan, session_starts, expected",
+        [
+            # single session
+            ([0, 0, 0], [1, 0, 0], False),
+            ([1, 0, 0], [1, 0, 0], False),  # head
+            ([0, 0, 1], [1, 0, 0], False),  # tail
+            ([1, 1, 1], [1, 0, 0], False),  # entirely NaN
+            ([0, 1, 0], [1, 0, 0], True),  # interior
+            ([0, 1, 1, 0], [1, 0, 0, 0], True),  # consecutive interior NaNs
+            ([1, 0, 1, 0, 1], [1, 0, 0, 0, 0], True),  # borders plus an interior NaN
+            # the same NaN pattern, cut into two sessions at the NaN
+            ([0, 1, 0], [1, 1, 0], False),  # NaN heads the second session
+            ([0, 1, 0], [1, 0, 1], False),  # NaN tails the first session
+            # NaNs at both borders of the second session
+            ([1, 0, 1, 0, 1], [1, 0, 1, 0, 0], False),
+            # a session with no valid sample alongside a valid one
+            ([1, 1, 0, 0], [1, 0, 1, 0], False),
+            # every sample its own session
+            ([0, 1, 0], [1, 1, 1], False),
+            # a valid run spanning a boundary, with the next session split
+            ([0, 0, 0, 1, 0], [1, 0, 1, 0, 0], True),
+            # interior NaN in the second of two sessions
+            ([0, 0, 1, 0], [1, 0, 0, 0], True),
+            ([0, 1, 0, 0], [1, 0, 0, 1], True),
+        ],
+    )
+    def test_truth_table(self, is_nan, session_starts, expected):
+        is_nan = np.asarray(is_nan, dtype=bool)
+        session_starts = np.asarray(session_starts, dtype=bool)
+        assert has_interior_nans(is_nan, session_starts) == expected
+
+    def test_matches_per_session_reference(self):
+        """Cross-check the counting identity against a naive per-session scan."""
+        rng = np.random.default_rng(0)
+        for _ in range(500):
+            n_samples = int(rng.integers(1, 20))
+            is_nan = rng.random(n_samples) < rng.choice([0.0, 0.2, 0.5, 0.9, 1.0])
+            session_starts = rng.random(n_samples) < rng.choice([0.0, 0.3, 0.8])
+            session_starts[0] = True
+            assert has_interior_nans(is_nan, session_starts) == (
+                _reference_has_interior_nans(is_nan, session_starts)
+            ), f"is_nan={is_nan.astype(int)}, session_starts={session_starts.astype(int)}"


### PR DESCRIPTION
This PR we checks the session continuity based on:
- `session_starts` when provided
- `time_support` if `session_starts` not provided and a pynapple object is an input

Additionally, the input validation sequence is consolidated at the validator level, by specifying a list of methods to be called. This prevents divergence of `update`, `fit` etc.

The check for the presence of nans has been sped up using C-level `np.add.reduceat` to sum over chunks split by an array of indices marking the session starts.
