### PR TITLE
Generalize observation model docstrings beyond neural spiking

### DIFF
--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -489,10 +489,10 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         See Also
         --------
         :meth:`nemos.glm.GLM.score`
-            Score predicted rates against target spike counts.
+            Score predicted rates against the observations.
 
         :meth:`nemos.glm.GLM.simulate`
-            Simulate neural activity in response to a feed-forward input (feed-forward only).
+            Simulate observations in response to a feed-forward input (feed-forward only).
 
         :func:`nemos.simulation.simulate_recurrent`
             Simulate neural activity in response to a feed-forward input
@@ -901,10 +901,10 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         Returns
         -------
         simulated_activity :
-            Simulated activity (spike counts for Poisson GLMs) for the neuron over time.
+            Simulated observations (spike counts for a Poisson GLM) over time.
             Shape: ``(n_time_bins, )``.
         firing_rates :
-            Simulated rates for the neuron over time. Shape, ``(n_time_bins, )``.
+            Simulated rates over time. Shape, ``(n_time_bins, )``.
 
         Raises
         ------

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -198,7 +198,7 @@ class Observations(Base, abc.ABC):
     @abc.abstractmethod
     def deviance(
         self,
-        spike_counts: jnp.ndarray,
+        observations: jnp.ndarray,
         predicted_rate: jnp.ndarray,
         scale: Union[float, jnp.ndarray] = 1.0,
     ):
@@ -206,7 +206,7 @@ class Observations(Base, abc.ABC):
 
         Parameters
         ----------
-        spike_counts:
+        observations:
             The observations. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         predicted_rate:
             The predicted firing rates. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
@@ -582,7 +582,7 @@ class PoissonObservations(Observations):
 
     def deviance(
         self,
-        spike_counts: jnp.ndarray,
+        observations: jnp.ndarray,
         predicted_rate: jnp.ndarray,
         scale: Union[float, jnp.ndarray] = 1.0,
     ) -> jnp.ndarray:
@@ -590,7 +590,7 @@ class PoissonObservations(Observations):
 
         Parameters
         ----------
-        spike_counts:
+        observations:
             The observations. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         predicted_rate:
             The predicted firing rates. Shape ``(n_time_bins, )``  or ``(n_time_bins, n_neurons)`` for
@@ -620,9 +620,9 @@ class PoissonObservations(Observations):
         """
         # this takes care of 0s in the log
         ratio = jnp.clip(
-            spike_counts / predicted_rate, jnp.finfo(predicted_rate.dtype).eps, jnp.inf
+            observations / predicted_rate, jnp.finfo(predicted_rate.dtype).eps, jnp.inf
         )
-        deviance = 2 * (spike_counts * jnp.log(ratio) - (spike_counts - predicted_rate))
+        deviance = 2 * (observations * jnp.log(ratio) - (observations - predicted_rate))
         return deviance
 
     def estimate_scale(
@@ -797,7 +797,7 @@ class GammaObservations(Observations):
 
     def deviance(
         self,
-        neural_activity: jnp.ndarray,
+        observations: jnp.ndarray,
         predicted_rate: jnp.ndarray,
         scale: Union[float, jnp.ndarray] = 1.0,
     ) -> jnp.ndarray:
@@ -805,7 +805,7 @@ class GammaObservations(Observations):
 
         Parameters
         ----------
-        neural_activity:
+        observations:
             The observations. Shape (n_time_bins, ) or (n_time_bins, n_neurons) for population models.
         predicted_rate:
             The predicted firing rates. Shape (n_time_bins, ) or (n_time_bins, n_neurons) for population models.
@@ -833,9 +833,9 @@ class GammaObservations(Observations):
         log-likelihood. Lower values of deviance indicate a better fit.
 
         """
-        y_mu = jnp.clip(neural_activity / predicted_rate, min=jnp.finfo(float).eps)
+        y_mu = jnp.clip(observations / predicted_rate, min=jnp.finfo(float).eps)
         resid_dev = 2 * (
-            -jnp.log(y_mu) + (neural_activity - predicted_rate) / predicted_rate
+            -jnp.log(y_mu) + (observations - predicted_rate) / predicted_rate
         )
         return resid_dev / scale
 
@@ -1653,7 +1653,7 @@ class GaussianObservations(Observations):
 
     def deviance(
         self,
-        neural_activity: jnp.ndarray,
+        observations: jnp.ndarray,
         predicted_rate: jnp.ndarray,
         scale: Union[float, jnp.ndarray] = 1.0,
     ) -> jnp.ndarray:
@@ -1661,7 +1661,7 @@ class GaussianObservations(Observations):
 
         Parameters
         ----------
-        neural_activity:
+        observations:
             The observations. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         predicted_rate:
             The predicted firing rates. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
@@ -1685,7 +1685,7 @@ class GaussianObservations(Observations):
         the scale (variance) of the model. Lower values of deviance indicate a better fit.
 
         """
-        resid_dev = jnp.power(neural_activity - predicted_rate, 2)
+        resid_dev = jnp.power(observations - predicted_rate, 2)
         return resid_dev / scale
 
     def estimate_scale(

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -87,12 +87,12 @@ class Observations(Base, abc.ABC):
         r"""Compute the observation model negative log-likelihood.
 
         This computes the negative log-likelihood of the predicted rates
-        for the observed neural activity up to a constant.
+        for the observed data up to a constant.
 
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons)..
+            The observations to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons)..
         predicted_rate :
             The predicted rate of the current model. Shape (n_time_bins, ), or (n_time_bins, n_neurons)..
 
@@ -114,12 +114,12 @@ class Observations(Base, abc.ABC):
         r"""Compute the observation model log-likelihood.
 
         This computes the log-likelihood of the predicted rates
-        for the observed neural activity including the normalization constant
+        for the observed data including the normalization constant
 
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
+            The observations to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         predicted_rate :
             The predicted rate of the current model. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         scale :
@@ -144,12 +144,12 @@ class Observations(Base, abc.ABC):
         r"""Compute the observation model likelihood.
 
         This computes the likelihood of the predicted rates
-        for the observed neural activity including the normalization constant.
+        for the observed data including the normalization constant.
 
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
+            The observations to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         predicted_rate :
             The predicted rate of the current model. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         scale :
@@ -207,7 +207,7 @@ class Observations(Base, abc.ABC):
         Parameters
         ----------
         spike_counts:
-            The spike counts. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
+            The observations. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         predicted_rate:
             The predicted firing rates. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         scale:
@@ -274,9 +274,9 @@ class Observations(Base, abc.ABC):
         Parameters
         ----------
         y:
-            The neural activity. Expected shape: ``(n_time_bins, )``
+            The observations. Expected shape: ``(n_time_bins, )``
         predicted_rate:
-            The mean neural activity. Expected shape: ``(n_time_bins, )``
+            The predicted mean. Expected shape: ``(n_time_bins, )``
         score_type:
             The pseudo-:math:`R^2` type.
         scale:
@@ -351,9 +351,9 @@ class Observations(Base, abc.ABC):
         Parameters
         ----------
         y:
-            The neural activity. Expected shape: ``(n_time_bins, )``.
+            The observations. Expected shape: ``(n_time_bins, )``.
         predicted_rate:
-            The mean neural activity. Expected shape: ``(n_time_bins, )``
+            The predicted mean. Expected shape: ``(n_time_bins, )``
 
         Returns
         -------
@@ -385,9 +385,9 @@ class Observations(Base, abc.ABC):
         Parameters
         ----------
         y:
-            The neural activity. Expected shape: (n_time_bins, ), or (n_time_bins, n_neurons).
+            The observations. Expected shape: (n_time_bins, ), or (n_time_bins, n_neurons).
         predicted_rate:
-            The mean neural activity. Expected shape: (n_time_bins, ), or (n_time_bins, n_neurons).
+            The predicted mean. Expected shape: (n_time_bins, ), or (n_time_bins, n_neurons).
         scale:
             The scale parameter of the model.
 
@@ -415,9 +415,9 @@ class PoissonObservations(Observations):
     """
     Model observations as Poisson random variables.
 
-    The PoissonObservations is designed to model the observed spike counts based on a Poisson distribution
-    with a given rate. It provides methods for computing the negative log-likelihood, generating samples,
-    and computing the residual deviance for the given spike count data.
+    The PoissonObservations is designed to model count observations, such as neural spike counts, based on
+    a Poisson distribution with a given rate. It provides methods for computing the negative log-likelihood,
+    generating samples, and computing the residual deviance for the given count data.
 
     Notes
     -----
@@ -460,12 +460,12 @@ class PoissonObservations(Observations):
         r"""Compute the Poisson negative log-likelihood.
 
         This computes the Poisson negative log-likelihood of the predicted rates
-        for the observed spike counts up to a constant.
+        for the observed counts up to a constant.
 
         Parameters
         ----------
         y :
-            The target spikes to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
+            The observations to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         predicted_rate :
             The predicted rate of the current model. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
 
@@ -510,12 +510,12 @@ class PoissonObservations(Observations):
         r"""Compute the Poisson negative log-likelihood.
 
         This computes the Poisson negative log-likelihood of the predicted rates
-        for the observed spike counts up to a constant.
+        for the observed counts up to a constant.
 
         Parameters
         ----------
         y :
-            The target spikes to compare against. Shape ``(n_time_bins, )``, or ``(n_time_bins, n_neurons)``.
+            The observations to compare against. Shape ``(n_time_bins, )``, or ``(n_time_bins, n_neurons)``.
         predicted_rate :
             The predicted rate of the current model. Shape ``(n_time_bins, )``, or ``(n_time_bins, n_neurons)``.
         scale :
@@ -591,7 +591,7 @@ class PoissonObservations(Observations):
         Parameters
         ----------
         spike_counts:
-            The spike counts. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
+            The observations. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         predicted_rate:
             The predicted firing rates. Shape ``(n_time_bins, )``  or ``(n_time_bins, n_neurons)`` for
             population models.
@@ -647,7 +647,7 @@ class PoissonObservations(Observations):
         Parameters
         ----------
         y :
-            Observed spike counts.
+            The observations.
         predicted_rate :
             The predicted rate values. This is not used in the Poisson model for estimating scale,
             but is retained for compatibility with the abstract method signature.
@@ -661,9 +661,9 @@ class GammaObservations(Observations):
     """
     Model observations as Gamma random variables.
 
-    The GammaObservations is designed to model the observed spike counts based on a Gamma distribution
-    with a given rate. It provides methods for computing the negative log-likelihood, generating samples,
-    and computing the residual deviance for the given spike count data.
+    The GammaObservations is designed to model positive continuous observations, such as calcium
+    fluorescence traces, based on a Gamma distribution with a given rate. It provides methods for computing
+    the negative log-likelihood, generating samples, and computing the residual deviance for the given data.
 
     Notes
     -----
@@ -708,12 +708,12 @@ class GammaObservations(Observations):
         r"""Compute the Gamma negative log-likelihood.
 
         This computes the Gamma negative log-likelihood of the predicted rates
-        for the observed neural activity up to a constant.
+        for the observed data up to a constant.
 
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
+            The observations to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         predicted_rate :
             The predicted rate of the current model. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         aggregate_sample_scores :
@@ -742,12 +742,12 @@ class GammaObservations(Observations):
         r"""Compute the Gamma negative log-likelihood.
 
         This computes the Gamma negative log-likelihood of the predicted rates
-        for the observed neural activity including the normalization constant.
+        for the observed data including the normalization constant.
 
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape (n_time_bins, ) or (n_time_bins, n_neurons).
+            The observations to compare against. Shape (n_time_bins, ) or (n_time_bins, n_neurons).
         predicted_rate :
             The predicted rate of the current model. Shape (n_time_bins, ) or (n_time_bins, n_neurons).
         scale :
@@ -806,7 +806,7 @@ class GammaObservations(Observations):
         Parameters
         ----------
         neural_activity:
-            The spike coun activity. Shape (n_time_bins, ) or (n_time_bins, n_neurons) for population models.
+            The observations. Shape (n_time_bins, ) or (n_time_bins, n_neurons) for population models.
         predicted_rate:
             The predicted firing rates. Shape (n_time_bins, ) or (n_time_bins, n_neurons) for population models.
         scale:
@@ -860,7 +860,7 @@ class GammaObservations(Observations):
         Parameters
         ----------
         y :
-            Observed neural activity.
+            The observations.
         predicted_rate :
             The predicted rate values.
         dof_resid :
@@ -1109,7 +1109,7 @@ class BernoulliObservations(Observations):
         Parameters
         ----------
         y :
-            Observed spike counts.
+            The observations.
         predicted_rate :
             The predicted rate values (success probabilities). This is not used in the Bernoulli model for estimating
             scale, but is retained for compatibility with the abstract method signature.
@@ -1130,12 +1130,12 @@ class BernoulliObservations(Observations):
         r"""Compute the Binomial model likelihood.
 
         This computes the likelihood of the predicted rates
-        for the observed neural activity including the normalization constant.
+        for the observed data including the normalization constant.
 
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
+            The observations to compare against. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         predicted_rate :
             The predicted rate of the current model. Shape (n_time_bins, ), or (n_time_bins, n_neurons).
         scale :
@@ -1489,7 +1489,7 @@ class NegativeBinomialObservations(Observations):
         Parameters
         ----------
         y :
-            Observed spike counts.
+            The observations.
         predicted_rate :
             The predicted mean of the distribution.
         dof_resid :
@@ -1511,7 +1511,7 @@ class GaussianObservations(Observations):
 
     The GaussianObservations is designed to model data based on a Gaussian distribution
     with a given mean (predicted rate) and variance (scale). It provides methods for computing the negative
-    log-likelihood, generating samples, and computing the residual deviance for the given spike count data.
+    log-likelihood, generating samples, and computing the residual deviance for the given data.
 
     Notes
     -----
@@ -1557,12 +1557,12 @@ class GaussianObservations(Observations):
         r"""Compute the Gaussian negative log-likelihood.
 
         This computes the Gaussian negative log-likelihood of the predicted rates
-        for the observed neural activity up to a constant.
+        for the observed data up to a constant.
 
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape ``(n_time_bins, )``, or ``(n_time_bins, n_neurons)``.
+            The observations to compare against. Shape ``(n_time_bins, )``, or ``(n_time_bins, n_neurons)``.
         predicted_rate :
             The predicted rate of the current model. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)``.
         aggregate_sample_scores :
@@ -1586,7 +1586,7 @@ class GaussianObservations(Observations):
         r"""Compute the Gaussian negative log-likelihood.
 
         Compute the Gaussian log-likelihood of the predicted rates
-        for the observed neural activity up to a constant.
+        for the observed data up to a constant.
 
         The formula for the Gaussian log-likelihood is given by:
 
@@ -1599,7 +1599,7 @@ class GaussianObservations(Observations):
         Parameters
         ----------
         y :
-            The target activity to compare against. Shape ``(n_time_bins, )``, or ``(n_time_bins, n_neurons)``.
+            The observations to compare against. Shape ``(n_time_bins, )``, or ``(n_time_bins, n_neurons)``.
         predicted_rate :
             The predicted rate of the current model. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)``.
         scale :
@@ -1662,7 +1662,7 @@ class GaussianObservations(Observations):
         Parameters
         ----------
         neural_activity:
-            The spike count activity. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
+            The observations. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         predicted_rate:
             The predicted firing rates. Shape ``(n_time_bins, )`` or ``(n_time_bins, n_neurons)`` for population models.
         scale:
@@ -1712,7 +1712,7 @@ class GaussianObservations(Observations):
         Parameters
         ----------
         y :
-            Observed spike counts.
+            The observations.
         predicted_rate :
             The predicted rate values.
         dof_resid :


### PR DESCRIPTION
Refs #569. This covers `observation_models.py` and `glm/glm.py`, not the whole codebase, so I have left the issue open rather than closing it.

Now that the GLM and GLM-HMM accept Bernoulli, Gaussian, Gamma, Negative Binomial and Categorical observations, the target variable is not necessarily neural spiking. In several places the old language was not just neuro centric but wrong for the family being documented. `GammaObservations` was described as modelling "the observed spike counts", and `GaussianObservations` as computing the deviance "for the given spike count data".

**The first commit is docstrings only.** The `y` and `predicted_rate` descriptions now talk about observations and the predicted mean, and each family summary describes the data it actually models, keeping neural spiking as the example for Poisson where it belongs. It also fixes a typo, "The spike coun activity", in the Gamma deviance docstring. Shape notation such as `(n_time_bins, n_neurons)` is left alone, since that is established API vocabulary and renaming it is a much larger change.

**The second commit is separable and touches public signatures, so please feel free to drop it on its own if you would rather handle the rename separately or not at all.** The first argument of `Observations.deviance` is currently called `spike_counts` on the abstract class and Poisson, `neural_activity` on Gamma and Gaussian, and `observations` on Bernoulli, Negative Binomial and Categorical. The keyword a caller must use therefore depends on which family they picked, and two of the three names assume the observations are neural. It renames them all to `observations`, the name the three most recently added families already use.

Every `deviance` call site inside nemos, in `src` and in `tests`, passes the argument positionally, so nothing internal breaks. The risk is external callers using the old keyword.

Read straight out of git, the first argument of `deviance` across the 7 classes:

```
BEFORE (main):
   2   neural_activity: jnp.ndarray,
   3   observations: jnp.ndarray,
   2   spike_counts: jnp.ndarray,

AFTER:
   7   observations: jnp.ndarray,
```

A fail before check does not apply to a docstring sweep, and I am not going to manufacture one. The rename has the checkable before state shown above.

Verification: doctests for both edited modules pass at 17. `tests/test_observation_models.py` plus `tests/test_glm.py` give 8190 passed and 581 skipped. The full non solver suite, run to completion, gives 40379 passed and 1236 skipped. black, isort, flake8, ruff and `check_parameter_naming.py` are all clean.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
