### PR TITLE
Dof fix

### DIFF
--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -973,7 +973,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
 
     Specify which features predict each neuron:
 
-    >>> feature_mask = jnp.array([[[1, 1, 1], [0, 0, 0]], [[1, 1, 1], [1, 1, 1]]])
+    >>> feature_mask = jnp.array([[1, 0], [1, 1]])
     >>> y = jnp.array([[0, 0], [0, 1], [1, 0], [1, 2], [2, 1], [2, 2]])
     >>> model = nmo.glm.ClassifierPopulationGLM(
     ...     n_classes=3,

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -331,7 +331,6 @@ class ClassifierMixin:
                     f"Type {type(n_samples)} provided instead!"
                 )
 
-        n_features = sum(x.shape[1] for x in x_leaf)
         # Effective degrees of freedom is n_classes - 1 due to probability simplex constraint
         n_m1_classes = self._label_encoder.n_classes - 1
         params = self._get_model_params()
@@ -355,18 +354,15 @@ class ClassifierMixin:
             )
             return jnp.atleast_1d(n_samples - resid_dof - n_m1_classes)
 
-        elif isinstance(self.regularizer, Ridge):
+        # each estimated feature costs one coefficient per free class
+        design = jnp.concatenate(x_leaf, axis=1)
+        if isinstance(self.regularizer, Ridge):
             # For Ridge, use total parameters
-            return (n_samples - n_m1_classes * n_features - n_m1_classes) * jnp.ones(
-                n_neurons
-            )
-
+            n_est = self._n_estimated_features(design)
         else:
             # For UnRegularized, use the rank
-            rank = jnp.linalg.matrix_rank(jnp.concatenate(x_leaf, axis=1))
-            return (n_samples - rank * n_m1_classes - n_m1_classes) * jnp.ones(
-                n_neurons
-            )
+            n_est = self._design_rank(design)
+        return (n_samples - n_est * n_m1_classes - n_m1_classes) * jnp.ones(n_neurons)
 
     def simulate(
         self,

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -60,6 +60,16 @@ REGRESSION_GLM_TYPES = Union[
 ]
 
 
+def _broadcast_mask_to(mask: jnp.ndarray, coef: jnp.ndarray) -> jnp.ndarray:
+    """Add trailing singleton axes so ``mask`` broadcasts against ``coef``.
+
+    The mask is spelled ``(n_features, n_neurons)``: it says which features reach which
+    neuron and knows nothing about axes the coefficients add beyond that (the classes of
+    a classifier). A no-op when the two already share a shape.
+    """
+    return mask.reshape(mask.shape + (1,) * (coef.ndim - mask.ndim))
+
+
 def _glm_hessian_block(
     X,
     eta,
@@ -1334,12 +1344,32 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             return n_samples - resid_dof - 1
 
         elif isinstance(self.regularizer, Ridge):
-            # for Ridge, use the tot parameters (X.shape[1] + intercept)
-            return (n_samples - X.shape[1] - 1) * jnp.ones_like(params.intercept)
+            # for Ridge, use the tot parameters (estimated features + intercept)
+            return (n_samples - self._n_estimated_features(X) - 1) * jnp.ones_like(
+                params.intercept
+            )
         else:
             # for UnRegularized, use the rank
-            rank = jnp.linalg.matrix_rank(X)
-            return (n_samples - rank - 1) * jnp.ones_like(params.intercept)
+            return (n_samples - self._design_rank(X) - 1) * jnp.ones_like(
+                params.intercept
+            )
+
+    def _n_estimated_features(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Count the coefficients the model estimates, as a scalar or one per neuron.
+
+        Every column of the design contributes a coefficient here. ``PopulationGLM``
+        overrides this: a masked-out feature is not estimated for that neuron.
+        """
+        return X.shape[1]
+
+    def _design_rank(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Rank of the design, as a scalar or one per neuron.
+
+        The rank, rather than the column count, is what an unpenalized fit consumes:
+        collinear columns share degrees of freedom. ``PopulationGLM`` overrides this to
+        take the rank per neuron, since the mask gives each neuron its own design.
+        """
+        return jnp.linalg.matrix_rank(X)
 
     def _initialize_optimizer_and_state(
         self,
@@ -1997,13 +2027,39 @@ class PopulationGLM(GLM):
             # then sum across all features and add the intercept, before
             # passing to the inverse link function
             tree_utils.pytree_map_and_reduce(
-                lambda x, w, m: jnp.einsum("ti, i...->t...", x, w * m),
+                lambda x, w, m: jnp.einsum(
+                    "ti, i...->t...", x, w * _broadcast_mask_to(m, w)
+                ),
                 sum,
                 X,
                 params.coef,
                 feature_mask,
             )
             + params.intercept
+        )
+
+    def _n_estimated_features(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Count the features the mask lets through, per neuron.
+
+        A masked-out coefficient contributes nothing to the rate and is never estimated,
+        so it must not be charged against the residual degrees of freedom.
+        """
+        if self._feature_mask is None:
+            return super()._n_estimated_features(X)
+        mask = jnp.concatenate(jax.tree_util.tree_leaves(self._feature_mask), axis=0)
+        return jnp.sum(mask, axis=0)
+
+    def _design_rank(self, X: jnp.ndarray) -> jnp.ndarray:
+        """Rank of each neuron's own design, after its masked columns are dropped.
+
+        Zeroing the masked columns leaves the rank unchanged relative to deleting them,
+        so this stays a plain array op rather than a boolean index.
+        """
+        if self._feature_mask is None:
+            return super()._design_rank(X)
+        mask = jnp.concatenate(jax.tree_util.tree_leaves(self._feature_mask), axis=0)
+        return jax.vmap(lambda m: jnp.linalg.matrix_rank(X * m), in_axes=1, out_axes=0)(
+            mask
         )
 
     def _get_hess_fn(self):

--- a/src/nemos/glm/validation.py
+++ b/src/nemos/glm/validation.py
@@ -275,7 +275,7 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
         )
 
         shape_match = pytree_map_and_reduce(
-            lambda fm, coef: fm.shape == coef.shape,
+            lambda fm, coef: fm.shape == self._expected_mask_shape(coef),
             all,
             feature_mask,
             params.coef,
@@ -283,11 +283,22 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
         if not shape_match:
             raise ValueError(
                 "The ``feature_mask`` must match the shape of the ``coef``, leaf by leaf. "
-                f"Expected {jax.tree_util.tree_map(lambda c: c.shape, params.coef)}, "
+                f"Expected "
+                f"{jax.tree_util.tree_map(lambda c: self._expected_mask_shape(c), params.coef)}, "
                 f"got {jax.tree_util.tree_map(lambda m: m.shape, feature_mask)} instead. "
                 "A pytree mask holding one entry per neuron is no longer accepted; broadcast "
                 "it to the shape of the coefficients."
             )
+
+    @staticmethod
+    def _expected_mask_shape(coef: jnp.ndarray) -> tuple[int, ...]:
+        """Shape a ``feature_mask`` leaf must have to mask ``coef``.
+
+        The mask selects features, so it carries one entry per coefficient the model
+        estimates. Subclasses whose coefficients carry an axis the mask does not
+        distinguish (the classes of a classifier) drop that axis here.
+        """
+        return coef.shape
 
     def get_empty_params(self, X, y) -> GLMParams:
         """Return the param shape given the input data."""
@@ -386,6 +397,19 @@ class ClassifierGLMValidator(GLMValidator):
     extra_params: Dict[Literal["n_classes"], int] = field(kw_only=True)
     expected_param_dims: Tuple[int] = (2, 1)
     model_class: str = "ClassifierGLM"
+
+    @staticmethod
+    def _expected_mask_shape(coef: jnp.ndarray) -> tuple[int, ...]:
+        """Drop the trailing class axis: a feature is masked for a neuron or not at all.
+
+        Coefficients carry a class axis, but nothing distinguishes the classes when
+        deciding whether a feature reaches a neuron, and a mask free to vary across
+        classes would make the per-neuron residual degrees of freedom ambiguous. The
+        mask is therefore ``(n_features, n_neurons)`` (or ``(n_features,)`` for the
+        single-neuron classifier) and broadcasts over classes at prediction time.
+        """
+        return coef.shape[:-1]
+
     params_validation_sequence: Tuple[Tuple[str, None] | Tuple[str, dict[str, Any]]] = (
         *RegressorValidator.params_validation_sequence[:2],
         (

--- a/src/nemos/regularizer.py
+++ b/src/nemos/regularizer.py
@@ -592,8 +592,8 @@ class Ridge(Regularizer):
             The Ridge penalization value.
         """
 
-        def l2_penalty(coeff: jnp.ndarray, leaf_strength: jnp.ndarray):
-            return 0.5 * jnp.sum(leaf_strength * jnp.square(coeff))
+        def l2_penalty(coef: jnp.ndarray, leaf_strength: jnp.ndarray):
+            return 0.5 * jnp.sum(leaf_strength * jnp.square(coef))
 
         return tree_utils.pytree_map_and_reduce(
             l2_penalty,
@@ -637,8 +637,8 @@ class Lasso(Regularizer):
             The Lasso penalization value.
         """
 
-        def l1_penalty(coeff: jnp.ndarray, leaf_strength: jnp.ndarray):
-            return jnp.sum(leaf_strength * jnp.abs(coeff))
+        def l1_penalty(coef: jnp.ndarray, leaf_strength: jnp.ndarray):
+            return jnp.sum(leaf_strength * jnp.abs(coef))
 
         return tree_utils.pytree_map_and_reduce(
             l1_penalty,
@@ -713,10 +713,10 @@ class ElasticNet(Regularizer):
             The Elastic Net penalization value.
         """
 
-        def net_penalty(coeff, leaf_strength):
+        def net_penalty(coef, leaf_strength):
             s, r = leaf_strength
-            quad = 0.5 * (1.0 - r) * jnp.square(coeff)
-            l1 = r * jnp.abs(coeff)
+            quad = 0.5 * (1.0 - r) * jnp.square(coef)
+            l1 = r * jnp.abs(coef)
             return jnp.sum(s * (quad + l1))
 
         return tree_utils.pytree_map_and_reduce(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,9 +239,7 @@ ModelFixture = namedtuple(
 )
 
 
-def initialize_feature_mask_for_population_glm(
-    X, n_neurons: int, n_classes: int = 0, coef=None
-):
+def initialize_feature_mask_for_population_glm(X, n_neurons: int, coef=None):
     """
     Create a feature mask of ones for PopulationGLM testing.
 
@@ -256,24 +254,19 @@ def initialize_feature_mask_for_population_glm(
         Number of neurons (determines the second dimension of the mask).
         Ignored if coef is provided.
     coef :
-        Optional coefficient array/pytree. If provided, the mask shape will match
-        coef shape exactly (required for ClassifierPopulationGLM).
-    n_classes:
-        Number of classes (determines the second dimension of the mask).
+        Optional coefficient array/pytree. If provided, the mask leaves are shaped like
+        the features-by-neurons block of the coefficients.
 
     Returns
     -------
     :
-        A feature mask with all ones, shaped like the coefficients it masks. If coef is
-        provided, returns ones_like(coef). Otherwise each leaf of X contributes a mask of
-        shape (n_features_in_leaf, n_neurons, *extra_shape).
+        A feature mask with all ones, of shape (n_features_in_leaf, n_neurons) leaf by
+        leaf. Classifier coefficients carry a trailing class axis, which the mask does
+        not distinguish and therefore drops.
     """
-    extra_shape = (n_classes,) if n_classes else ()
     if coef is not None:
-        return jax.tree_util.tree_map(lambda c: jnp.ones(c.shape), coef)
-    return jax.tree_util.tree_map(
-        lambda x: jnp.ones((x.shape[1], n_neurons, *extra_shape)), X
-    )
+        return jax.tree_util.tree_map(lambda c: jnp.ones(c.shape[:2]), coef)
+    return jax.tree_util.tree_map(lambda x: jnp.ones((x.shape[1], n_neurons)), X)
 
 
 DEFAULT_KWARGS = {

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -2682,89 +2682,56 @@ class TestPopulationGLM:
             model.feature_mask = mask
 
     @pytest.fixture
-    def feature_mask_compatibility_fit_expectation(self, model_instantiation):
+    def feature_mask_compatibility_fit_expectation(self):
         """
-        Fixture to return the expected exceptions for test_feature_mask_compatibility_fit
-        based on the model type (classifier vs non-classifier).
+        Fixture to return the expected exceptions for test_feature_mask_compatibility_fit.
 
-        For classifier models, the feature_mask shape is (n_features, n_neurons, n_classes)
-        which means all the test masks (which lack the n_classes dimension) will fail
-        shape validation.
+        Every model expects a feature_mask of shape (n_features, n_neurons): a classifier
+        masks a feature for a neuron across all of its classes, so a mask carrying the
+        trailing class axis of the coefficients is rejected like any other wrong shape.
         """
-        is_classifier = "classifier" in model_instantiation
-
         type_error_match = "feature_mask and X must have the same structure"
         # every model now reports a leaf-by-leaf shape mismatch the same way
         shape_mismatch_match = (
             "The ``feature_mask`` must match the shape of the ``coef``, leaf by leaf"
         )
 
-        if is_classifier:
-            # Classifier models expect feature_mask shape (n_features, n_neurons, n_classes)
-            # Masks without n_classes dimension fail shape validation
-            return {
-                "correct_shape_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_classifier_np": does_not_raise(),
-                "wrong_n_features_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_neurons_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_classifier_pytree": does_not_raise(),
-                "wrong_n_neurons_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "missing_key_pytree": pytest.raises(TypeError, match=type_error_match),
-                "missing_key_wrong_shape_pytree": pytest.raises(
-                    TypeError, match=type_error_match
-                ),
-            }
-        else:
-            # Non-classifier models expect feature_mask shape (n_features, n_neurons)
-            return {
-                "correct_shape_np": does_not_raise(),
-                "correct_shape_classifier_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_features_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_neurons_np": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "correct_shape_pytree": does_not_raise(),
-                "correct_shape_classifier_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "wrong_n_neurons_pytree": pytest.raises(
-                    ValueError, match=shape_mismatch_match
-                ),
-                "missing_key_pytree": pytest.raises(TypeError, match=type_error_match),
-                "missing_key_wrong_shape_pytree": pytest.raises(
-                    TypeError, match=type_error_match
-                ),
-            }
+        return {
+            "correct_shape_np": does_not_raise(),
+            "extra_class_axis_np": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "wrong_n_features_np": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "wrong_n_neurons_np": pytest.raises(ValueError, match=shape_mismatch_match),
+            "correct_shape_pytree": does_not_raise(),
+            "extra_class_axis_pytree": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "wrong_n_neurons_pytree": pytest.raises(
+                ValueError, match=shape_mismatch_match
+            ),
+            "missing_key_pytree": pytest.raises(TypeError, match=type_error_match),
+            "missing_key_wrong_shape_pytree": pytest.raises(
+                TypeError, match=type_error_match
+            ),
+        }
 
     # Parametrization for test_feature_mask_compatibility_fit masks
     feature_mask_compatibility_fit_masks = (
         "mask, mask_key_np, mask_key_pytree",
         [
-            # Non-classifier correct shape: (n_features, n_neurons) = (5, 3)
+            # Correct shape: (n_features, n_neurons) = (5, 3)
             (
                 np.array([0, 1, 1] * 5).reshape(5, 3),
                 "correct_shape_np",
                 "missing_key_pytree",  # pytree expects dict, not array
             ),
-            # Classifier correct shape: (n_features, n_neurons, n_classes) = (5, 3, 3)
+            # One class axis too many: (n_features, n_neurons, n_classes) = (5, 3, 3)
             (
                 np.ones((5, 3, 3), dtype=int),
-                "correct_shape_classifier_np",
+                "extra_class_axis_np",
                 "missing_key_pytree",  # pytree expects dict, not array
             ),
             (
@@ -2777,7 +2744,7 @@ class TestPopulationGLM:
                 "wrong_n_neurons_np",
                 "missing_key_pytree",
             ),
-            # Non-classifier pytree correct shape: {'input_1': (3, 3), 'input_2': (2, 3)}
+            # Pytree correct shape: {'input_1': (3, 3), 'input_2': (2, 3)}
             (
                 {
                     "input_1": np.array([[0, 1, 0]] * 3),
@@ -2786,14 +2753,14 @@ class TestPopulationGLM:
                 "missing_key_pytree",  # np expects array, not dict
                 "correct_shape_pytree",
             ),
-            # Classifier pytree correct shape: {'input_1': (3, 3, 3), 'input_2': (2, 3, 3)}
+            # Pytree with one class axis too many: {'input_1': (3, 3, 3), 'input_2': (2, 3, 3)}
             (
                 {
                     "input_1": np.ones((3, 3, 3), dtype=int),
                     "input_2": np.ones((2, 3, 3), dtype=int),
                 },
                 "missing_key_pytree",  # np expects array, not dict
-                "correct_shape_classifier_pytree",
+                "extra_class_axis_pytree",
             ),
             # one neuron too many in every leaf
             (
@@ -3030,6 +2997,136 @@ def test_estimate_dof_resid(n_samples, reg, request, glm_type, model_instantiati
     expected = n_samples - dof - n_m1_classes
     num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
     assert np.allclose(num, expected)
+
+
+# A design whose last column duplicates the previous one: a neuron keeping both spends
+# two coefficients on one dimension, which is what separates the Ridge count from the
+# UnRegularized rank.
+_DOF_MASK_DESIGN = (
+    jnp.eye(_DOF_N_FEATURES).at[:, -1].set(jnp.eye(_DOF_N_FEATURES)[:, -2])
+)
+# neuron 0 keeps every feature, neuron 1 the first three, neuron 2 the collinear pair
+_DOF_MASK = jnp.array([[1, 1, 0], [1, 1, 0], [1, 1, 0], [1, 0, 1], [1, 0, 1]])
+_DOF_MASK_COUNT = jnp.array([5, 3, 2])  # features the mask lets through, per neuron
+_DOF_MASK_RANK = jnp.array([4, 3, 1])  # rank of each neuron's own design
+_DOF_MASK_NONZERO = jnp.array([3, 1, 1])  # non-zero coefficients set below, per neuron
+
+
+def _set_masked_state(model, is_cls, as_pytree):
+    """Assign a coef_/intercept_ and feature_mask, and return the matching design.
+
+    The non-zero coefficients sit at features the mask lets through, as a fitted model's
+    would; for the classifier they all sit in the first class, so the per-neuron counts
+    match the non-classifier case.
+    """
+    nf, nn = _DOF_N_FEATURES, _DOF_N_NEURONS
+    if is_cls:
+        coef = jnp.zeros((nf, nn, _DOF_N_CLASSES))
+        coef = coef.at[:3, 0, 0].set(1.0).at[:1, 1, 0].set(1.0).at[3:4, 2, 0].set(1.0)
+        intercept = jnp.zeros((nn, _DOF_N_CLASSES))
+    else:
+        coef = jnp.zeros((nf, nn))
+        coef = coef.at[:3, 0].set(1.0).at[:1, 1].set(1.0).at[3:4, 2].set(1.0)
+        intercept = jnp.zeros((nn,))
+
+    X, mask = _DOF_MASK_DESIGN, _DOF_MASK
+    if as_pytree:
+        # leaves are traversed in sorted-key order, matching the column order of X
+        X = {"input_1": X[:, :3], "input_2": X[:, 3:]}
+        mask = {"input_1": mask[:3], "input_2": mask[3:]}
+        coef = {"input_1": coef[:3], "input_2": coef[3:]}
+
+    # the mask goes in first: its setter refuses a model that already holds parameters
+    model.feature_mask = mask
+    model.coef_ = coef
+    model.intercept_ = intercept
+    return X
+
+
+@pytest.mark.parametrize(
+    "model_instantiation",
+    [
+        "population_poissonGLM_model_instantiation",
+        "population_classifierGLM_model_instantiation",
+    ],
+)
+@pytest.mark.parametrize("as_pytree", [False, True])
+@pytest.mark.parametrize(
+    "reg, dof_per_neuron, scales_with_classes",
+    [
+        (nmo.regularizer.UnRegularized(), _DOF_MASK_RANK, True),
+        (nmo.regularizer.Lasso(), _DOF_MASK_NONZERO, False),
+        (nmo.regularizer.Ridge(), _DOF_MASK_COUNT, True),
+    ],
+)
+@pytest.mark.parametrize("n_samples", [20])
+@pytest.mark.requires_x64
+def test_estimate_dof_resid_feature_mask(
+    n_samples,
+    reg,
+    dof_per_neuron,
+    scales_with_classes,
+    as_pytree,
+    request,
+    model_instantiation,
+):
+    """A masked-out feature is not charged against a neuron's residual DOF.
+
+    Each neuron sees its own design, so the result is one DOF per neuron. The Lasso
+    branch reads the non-zero coefficients and is therefore mask-independent.
+    """
+    _, _, model, _, _ = request.getfixturevalue(
+        model_instantiation + ("_pytree" if as_pytree else "")
+    )
+    model.set_params(regularizer=reg)
+
+    is_cls = "classifier" in model_instantiation
+    X = _set_masked_state(model, is_cls, as_pytree)
+
+    n_m1_classes = getattr(model, "n_classes", 2) - 1
+    dof = dof_per_neuron * n_m1_classes if scales_with_classes else dof_per_neuron
+    expected = n_samples - dof - n_m1_classes
+
+    num = model._estimate_resid_degrees_of_freedom(X, n_samples=n_samples)
+    np.testing.assert_allclose(num, expected)
+
+
+@pytest.mark.parametrize(
+    "reg, dof_per_neuron",
+    [
+        (nmo.regularizer.UnRegularized(), _DOF_MASK_RANK),
+        (nmo.regularizer.Lasso(), _DOF_MASK_NONZERO),
+        (nmo.regularizer.Ridge(), _DOF_MASK_COUNT),
+    ],
+)
+@pytest.mark.requires_x64
+def test_dof_resid_after_fit_feature_mask(
+    reg, dof_per_neuron, request, patch_optimizer_run
+):
+    """fit stores the per-neuron DOF of the masked model.
+
+    The solver is a no-op returning ``init_params``, so the fitted coefficients are the
+    injected ones and the DOF is fully determined.
+    """
+    _, _, model, _, _ = request.getfixturevalue(
+        "population_poissonGLM_model_instantiation"
+    )
+    patch_optimizer_run(nmo.glm.PopulationGLM)
+    model.set_params(
+        regularizer=reg,
+        regularizer_strength=(
+            None if isinstance(reg, nmo.regularizer.UnRegularized) else 1.0
+        ),
+    )
+
+    X = _set_masked_state(model, False, as_pytree=False)
+    # hand the sparse state to fit as the starting point, leaving the model unfitted
+    init_params = (model.coef_, model.intercept_)
+    model.coef_, model.intercept_ = None, None
+    y = np.ones((X.shape[0], _DOF_N_NEURONS))
+
+    model.fit(X, y, init_params=init_params)
+    np.testing.assert_allclose(model.dof_resid_, X.shape[0] - dof_per_neuron - 1)
 
 
 @pytest.mark.parametrize("glm_type", ["", "population_"])
@@ -4008,7 +4105,7 @@ class TestClassifierGLM:
         )
         model.inverse_link_function = inv_link
         if is_population_glm_type(glm_type):
-            model.feature_mask = jnp.ones((X.shape[1], y.shape[1], model.n_classes))
+            model.feature_mask = jnp.ones((X.shape[1], y.shape[1]))
             model.scale_ = jnp.ones((y.shape[1]))
             shape_log_proba = (X.shape[0], y.shape[1], model.n_classes)
         else:


### PR DESCRIPTION
Fix DOF calculation in the presence of a mask. The feature mask pins some of the coefficients to 0. This reduces the dof of the model. The calculation introduced here accounts for it. 

Added parametrized tests that check the effect of masks on PopulationGLM and ClassifierPopulationGLM.