### PR TITLE
Partial param spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ filterwarnings = [
     'ignore:Tolerance of -?\d\.\d+e-\d\d reached:RuntimeWarning',
     # mpl must be non-interctive for testing otherwise doctests will freeze
     'ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning',
+    # expected whenever a test pins every parameter; `pytest.warns` still sees it
+    'ignore:Every parameter is fixed:UserWarning',
 ]
 markers = [
   "solver_related: tests that interact with solvers",

--- a/scripts/check_parameter_naming.py
+++ b/scripts/check_parameter_naming.py
@@ -156,7 +156,11 @@ VALID_PAIRS = [
     {"true_intercept", "rec_intercept"},
     {"true_trans", "rec_trans"},
     {"n_classes", "n_passes"},
+    {"fix_params", "fit_params"},
+    {"active_coef", "active_cols"},
     {"true_intercept", "fit_intercept"},
+    {"frozen_intercept", "rec_intercept"},
+    {"frozen_intercept", "true_intercept"},
 ]
 
 

--- a/src/nemos/_params_builder.py
+++ b/src/nemos/_params_builder.py
@@ -1,0 +1,60 @@
+"""Utility functions for creating parameter container objects."""
+
+from .glm.params import GLMParams
+from .glm_hmm.params import GLMHMMModelParams, GLMHMMParams
+from .hmm.params import HMMParams
+
+AVAILABLE_PARAM_CONTAINERS = [
+    "GLMParams",
+    "HMMParams",
+    "GLMHMMParams",
+    "GLMHMMModelParams",
+]
+
+# Mapping for O(1) lookup
+_PARAM_CONTAINER_MAP = {
+    "GLMParams": GLMParams,
+    "HMMParams": HMMParams,
+    "GLMHMMParams": GLMHMMParams,
+    "GLMHMMModelParams": GLMHMMModelParams,
+}
+
+
+def instantiate_param_container(name: str, **kwargs):
+    """
+    Create a parameter container from a given name.
+
+    Parameter containers are equinox modules holding a model's parameters, e.g.
+    ``GLMParams(coef, intercept)``. They reach saved files as the values of other
+    parameters — a structured ``GroupLasso`` mask, for instance — and are rebuilt from
+    their class name at load time. Only the containers listed in
+    ``AVAILABLE_PARAM_CONTAINERS`` can be built, so loading never calls an arbitrary
+    constructor.
+
+    Parameters
+    ----------
+    name :
+        The string name of the container to create, either bare or as a full module
+        path. Must name one of ``AVAILABLE_PARAM_CONTAINERS``.
+    **kwargs :
+        Additional keyword arguments are passed to the container constructor, one per
+        field of the container.
+
+    Returns
+    -------
+    :
+        The parameter container instance.
+
+    Raises
+    ------
+    ValueError
+        If the ``name`` provided does not match any available container.
+    """
+    basename = name.split(".")[-1]
+    if basename in _PARAM_CONTAINER_MAP:
+        return _PARAM_CONTAINER_MAP[basename](**kwargs)
+
+    raise ValueError(
+        f"Unknown parameter container: {name}. "
+        f"Container must be one of {AVAILABLE_PARAM_CONTAINERS} or their full module path."
+    )

--- a/src/nemos/base_regressor.py
+++ b/src/nemos/base_regressor.py
@@ -24,6 +24,7 @@ from .regularizer import GroupLasso, Regularizer
 from .solvers import SolverProtocol, SolverSpec
 from .solvers._hess import HessianTag
 from .solvers._newton import Newton
+from .solvers._no_op import NoOpSolver
 from .type_casting import cast_to_jax, is_numpy_array_like
 from .typing import (
     DESIGN_INPUT_TYPE,
@@ -363,6 +364,19 @@ class BaseRegressor(
         self._optimizer_init_state = None
         self._optimizer_update = None
         self._optimizer_run = None
+
+    def _no_op_optimizer(self) -> SolverState:
+        """Install :class:`NoOpSolver`, for when the active parameter tree is empty."""
+        warnings.warn(
+            "Every parameter is fixed, through `fix_params` and/or `fit_intercept=False`; "
+            "no optimization will run and the fixed values are returned unchanged.",
+            UserWarning,
+        )
+        self._solver = NoOpSolver()
+        self._optimizer_init_state = self._solver.init_state
+        self._optimizer_update = self._solver.update
+        self._optimizer_run = self._solver.run
+        return self._optimizer_init_state(None)
 
     def _partition_active(
         self, params: ModelParamsT

--- a/src/nemos/base_validator.py
+++ b/src/nemos/base_validator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from numpy.typing import DTypeLike
 
 if TYPE_CHECKING:
@@ -199,6 +200,8 @@ class RegressorValidator(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParams
         for par, exp_dim in zip(
             self.wrap_user_params(params), self.expected_param_dims
         ):
+            if par is None:
+                continue
             dim_match = pytree_map_and_reduce(lambda x: x.ndim == exp_dim, all, par)
             is_empty = pytree_map_and_reduce(lambda x: x.size == 0, all, par)
             if not dim_match or is_empty:
@@ -294,6 +297,81 @@ class RegressorValidator(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParams
             )
 
         return validated_params
+
+    def validate_param_specs(
+        self, params: Optional[UserProvidedParamsT]
+    ) -> ModelParamsT:
+        """
+        Validate a partial ("fix") parameter specification and cast to model params.
+
+        Unlike ``validate_and_cast_params``, ``None`` leaves are allowed: they mark
+        parameters that will be learned rather than fixed. A top-level ``None`` expands
+        to a model-params object with ``None`` for every parameter.
+
+        The structural, type, and dimensionality checks are shared across all
+        regressors; model-specific checks are added by overriding
+        ``additional_validation_param_specs``.
+
+        Parameters
+        ----------
+        params : UserProvidedParamsT or None
+            Partial parameter specification (arrays and/or ``None`` leaves), or
+            ``None`` to leave every parameter learnable.
+
+        Returns
+        -------
+        ModelParamsT
+            The validated specification as a model-parameter object.
+
+        Raises
+        ------
+        ValueError, TypeError
+            If any validation step fails.
+        """
+        if params is None:
+            return self.to_model_params([None] * len(self.expected_param_dims))
+
+        self.check_user_params_structure(params)
+        self.check_partial_params_specs_type(params)
+        params = self.convert_to_jax_arrays(params)
+        # reuse the ``check_array_dimensions`` kwargs configured for this validator
+        dim_kwargs = next(
+            (
+                kwargs
+                for name, kwargs in self.params_validation_sequence
+                if name == "check_array_dimensions"
+            ),
+            None,
+        )
+        self.check_array_dimensions(params, **(dim_kwargs or {}))
+        params = self.to_model_params(params)
+        return self.additional_validation_param_specs(params)
+
+    def additional_validation_param_specs(
+        self, params: ModelParamsT, **kwargs
+    ) -> ModelParamsT:
+        """
+        Additional validation for parameter specs.
+
+        Hook for model-specific validation of a partial parameter specification.
+
+        Called at the end of ``validate_param_specs`` on the cast model-parameter
+        object. The base implementation is a no-op; subclasses override it to add
+        checks that must tolerate ``None`` (unset) parameters.
+
+        Parameters
+        ----------
+        params : ModelParamsT
+            The cast model-parameter object (leaves may be ``None``).
+        **kwargs
+            Additional keyword arguments (unused in the base implementation).
+
+        Returns
+        -------
+        ModelParamsT
+            The validated parameters, unchanged by the base implementation.
+        """
+        return params
 
     def validate_inputs(
         self,
@@ -418,3 +496,29 @@ class RegressorValidator(abc.ABC, Base, Generic[UserProvidedParamsT, ModelParams
     def get_empty_params(self, X, y) -> ModelParamsT:
         """Return the param shape given the input data."""
         pass
+
+    @staticmethod
+    def check_partial_params_specs_type(params: UserProvidedParamsT):
+        """Check parameter specs typing.
+
+        Flatten tree and check types of all non-None leaves.
+
+        Raises
+        ------
+        ValueError:
+            If parameter specs leaves have type other than array or None.
+        """
+        valid = all(
+            isinstance(p, (np.ndarray, jnp.ndarray))
+            for p in jax.tree_util.tree_leaves(params)
+        )
+        if not valid:
+            invalid_types = [
+                type(p)
+                for p in jax.tree_util.tree_leaves(params)
+                if not isinstance(p, (np.ndarray, jnp.ndarray))
+            ]
+            raise TypeError(
+                "Invalid parameter specification found. Parameters can be jax arrays, "
+                f"numpy arrays or None.\nFound invalid types: {invalid_types}"
+            )

--- a/src/nemos/glm/classifier_glm.py
+++ b/src/nemos/glm/classifier_glm.py
@@ -22,7 +22,7 @@ from ..typing import (
     StepResult,
     UserProvidedParamsT,
 )
-from .glm import GLM, PopulationGLM
+from .glm import GLM, PopulationGLM, _active_columns
 from .params import GLMParams, GLMUserParams
 from .validation import (
     ClassifierGLMValidator,
@@ -340,6 +340,7 @@ class ClassifierMixin:
         # consumes none.
         active, _ = self._partition_active(params)
         intercept_dof = 0 if active.intercept is None else n_m1_classes
+        active_cols = _active_columns(x_leaf, active.coef)
 
         # Infer n_neurons from coef shape:
         # ClassifierGLM: coef is (n_features, n_classes) -> n_neurons = 1
@@ -356,7 +357,7 @@ class ClassifierMixin:
             resid_dof = tree_utils.pytree_map_and_reduce(
                 lambda x: ~jnp.isclose(x, jnp.zeros_like(x)),
                 lambda x: sum([jnp.sum(i, axis=(0, -1)) for i in x]),
-                params.coef,
+                active.coef,
             )
             return jnp.atleast_1d(n_samples - resid_dof - intercept_dof)
 
@@ -364,10 +365,10 @@ class ClassifierMixin:
         design = jnp.concatenate(x_leaf, axis=1)
         if isinstance(self.regularizer, Ridge):
             # For Ridge, use total parameters
-            n_est = self._n_estimated_features(design)
+            n_est = self._n_estimated_features(active_cols)
         else:
             # For UnRegularized, use the rank
-            n_est = self._design_rank(design)
+            n_est = self._design_rank(design, active_cols)
         return (n_samples - n_est * n_m1_classes - intercept_dof) * jnp.ones(n_neurons)
 
     def simulate(
@@ -507,7 +508,7 @@ class ClassifierMixin:
 
     def update(
         self,
-        params: GLMUserParams,
+        params: GLMUserParams[jnp.ndarray | NDArray],
         opt_state: SolverState,
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
@@ -602,6 +603,14 @@ class ClassifierGLM(ClassifierMixin, GLM):
         The strength of the regularization.
     fit_intercept
         When True (default), an intercept term is fit. When False, only the coefficients are fit.
+        An intercept pinned through ``fix_params`` takes precedence over this flag.
+    fix_params :
+        Parameters to hold fixed during fitting, as a ``(coef, intercept)`` tuple with
+        ``coef`` of shape ``(n_features, n_classes)`` and ``intercept`` of shape
+        ``(n_classes,)``. An array pins that parameter at the value provided, ``None``
+        leaves it to be learned. When ``X`` is a pytree, ``coef`` mirrors its structure,
+        its leaves have shape ``(n_features_in_leaf, n_classes)``, and each leaf is
+        pinned or learned on its own. Defaults to ``None``, which learns every parameter.
     solver_name
         The solver to use for optimization.
     solver_kwargs
@@ -744,6 +753,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
         regularizer: Optional[Union[str, Regularizer]] = None,
         regularizer_strength: Any = None,
         fit_intercept: bool = True,
+        fix_params: Optional[GLMUserParams[jnp.ndarray | NDArray | None]] = None,
         solver_name: str = None,
         solver_kwargs: dict = None,
     ):
@@ -757,6 +767,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
             regularizer=regularizer,
             regularizer_strength=regularizer_strength,
             fit_intercept=fit_intercept,
+            fix_params=fix_params,
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
         )
@@ -765,7 +776,7 @@ class ClassifierGLM(ClassifierMixin, GLM):
         self,
         X: Union[DESIGN_INPUT_TYPE, ArrayLike],
         y: ArrayLike,
-        init_params: Optional[GLMUserParams] = None,
+        init_params: Optional[GLMUserParams[jnp.ndarray | NDArray]] = None,
     ):
         """
         Fit the model to training data.
@@ -883,6 +894,15 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
         The strength of the regularization.
     fit_intercept
         When True (default), an intercept term is fit. When False, only the coefficients are fit.
+        An intercept pinned through ``fix_params`` takes precedence over this flag.
+    fix_params :
+        Parameters to hold fixed during fitting, as a ``(coef, intercept)`` tuple with
+        ``coef`` of shape ``(n_features, n_neurons, n_classes)`` and ``intercept`` of
+        shape ``(n_neurons, n_classes)``. An array pins that parameter at the value
+        provided, ``None`` leaves it to be learned. When ``X`` is a pytree, ``coef``
+        mirrors its structure, its leaves have shape
+        ``(n_features_in_leaf, n_neurons, n_classes)``, and each leaf is pinned or
+        learned on its own. Defaults to ``None``, which learns every parameter.
     solver_name
         The solver to use for optimization.
     solver_kwargs
@@ -1031,6 +1051,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
         regularizer: Optional[Union[str, Regularizer]] = None,
         regularizer_strength: Any = None,
         fit_intercept: bool = True,
+        fix_params: Optional[GLMUserParams[jnp.ndarray | NDArray | None]] = None,
         solver_name: str = None,
         solver_kwargs: dict = None,
         feature_mask: Optional[jnp.ndarray] = None,
@@ -1045,6 +1066,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
             regularizer=regularizer,
             regularizer_strength=regularizer_strength,
             fit_intercept=fit_intercept,
+            fix_params=fix_params,
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
             feature_mask=feature_mask,
@@ -1088,7 +1110,7 @@ class ClassifierPopulationGLM(ClassifierMixin, PopulationGLM):
         self,
         X: Union[DESIGN_INPUT_TYPE, ArrayLike],
         y: ArrayLike,
-        init_params: Optional[GLMUserParams] = None,
+        init_params: Optional[GLMUserParams[jnp.ndarray | NDArray]] = None,
     ):
         """
         Fit the model to training data.

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -1604,6 +1604,11 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         >>> opt_state = model.initialize_optimizer_and_state(params, X, y)
         >>> # Now ready to run optimization or update steps
         """
+        # ``eqx.partition`` leaves ``None`` on the frozen leaves and jax drops those, so
+        # an empty leaf list means every parameter is fixed and there is nothing to run.
+        if not jax.tree_util.tree_leaves(init_params):
+            return self._no_op_optimizer()
+
         opt_solver_kwargs = self._optimize_solver_params(X, y)
         #  set up the solver init/run/update attrs
         self._solver = self._instantiate_solver(

--- a/src/nemos/glm/glm.py
+++ b/src/nemos/glm/glm.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Literal, Optional, Tuple, Union
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, NDArray
 from sklearn.utils import InputTags, TargetTags
 
 from .. import observation_models as obs
@@ -71,6 +71,22 @@ def _broadcast_mask_to(mask: jnp.ndarray, coef: jnp.ndarray) -> jnp.ndarray:
     a classifier). A no-op when the two already share a shape.
     """
     return mask.reshape(mask.shape + (1,) * (coef.ndim - mask.ndim))
+
+
+def _active_columns(x_leaves: list, active_coef: Any) -> jnp.ndarray:
+    """Flag the design columns whose coefficient the solver estimates.
+
+    A coefficient frozen through ``fix_params`` is ``None`` in the active tree, so its
+    columns cost no degrees of freedom. The flags follow the column order of the design,
+    which is the leaf order of ``X``.
+    """
+    active_leaves = jax.tree_util.tree_leaves(active_coef, is_leaf=lambda x: x is None)
+    return jnp.concatenate(
+        [
+            jnp.full((x.shape[1],), coef is not None)
+            for x, coef in zip(x_leaves, active_leaves)
+        ]
+    )
 
 
 def _glm_hessian_block(
@@ -211,6 +227,14 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         parameter structure to regularize parameters differentially.
     fit_intercept :
         When True (default), an intercept term is fit. When False, only the coefficients are fit.
+        An intercept pinned through ``fix_params`` takes precedence over this flag.
+    fix_params :
+        Parameters to hold fixed during fitting, as a ``(coef, intercept)`` tuple with
+        ``coef`` of shape ``(n_features,)`` and ``intercept`` of shape ``(1,)``. An array
+        pins that parameter at the value provided, ``None`` leaves it to be learned. When
+        ``X`` is a pytree, ``coef`` mirrors its structure, its leaves have shape
+        ``(n_features_in_leaf,)``, and each leaf is pinned or learned on its own.
+        Defaults to ``None``, which learns every parameter.
     solver_name :
         Solver to use for model optimization. Defines the optimization scheme and related parameters.
         The solver must be an appropriate match for the chosen regularizer.
@@ -299,6 +323,18 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     >>> model.regularizer
     Lasso()
 
+    **Fix some parameters**
+
+    Pin the first feature block's coefficients to ``[1, 1]`` and learn the rest.
+    The ``fix_params`` spec mirrors the ``(coef, intercept)`` structure, with
+    ``None`` marking the parameters to learn:
+
+    >>> fix_params = ([jnp.ones((2,)), None], None)
+    >>> model = nmo.glm.GLM(fix_params=fix_params)
+    >>> model = model.fit([X[:, :2], X[:, 2:]], y)
+    >>> model.coef_[0]
+    Array([1., 1.], dtype=...)
+
     **Select a Solver**
 
     Use LBFGS solver for potentially faster convergence:
@@ -361,6 +397,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         regularizer: Optional[Union[str, Regularizer]] = None,
         regularizer_strength: Any = None,
         fit_intercept: bool = True,
+        fix_params: Optional[GLMUserParams[jnp.ndarray | NDArray | None]] = None,
         solver_name: str = None,
         solver_kwargs: dict = None,
     ):
@@ -373,10 +410,11 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         self.observation_model = observation_model
         self.inverse_link_function = inverse_link_function
 
-        self._validator = self._validator_class(
+        self._validator: GLMValidator = self._validator_class(
             extra_params=self._get_validator_extra_params()
         )
         self.fit_intercept = fit_intercept
+        self.fix_params = fix_params
 
         # initialize to None fit output
         self.intercept_ = None
@@ -386,6 +424,20 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         self.dof_resid_ = None
         self.aux_ = None
         self._solver = None
+
+    @property
+    def fix_params(self) -> GLMUserParams[jnp.ndarray | NDArray | None]:
+        """Parameters held fixed during fitting, as a ``(coef, intercept)`` tuple."""
+        return self._validator.from_model_params(self._fix_params)
+
+    @fix_params.setter
+    def fix_params(self, value: GLMUserParams[jnp.ndarray | NDArray | None] | None):
+        """Setter for ``fix_params`` property.
+
+        Validates the specification (delegated to the validator) and sets it.
+        """
+        self._fix_params = self._validator.validate_param_specs(value)
+        self._invalidate_solver()
 
     @property
     def fit_intercept(self) -> bool:
@@ -562,7 +614,9 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             )
 
     def _predict(
-        self, params: GLMParams, X: Union[dict[str, jnp.ndarray], jnp.ndarray]
+        self,
+        params: GLMParams[jnp.ndarray],
+        X: Union[dict[str, jnp.ndarray], jnp.ndarray],
     ) -> jnp.ndarray:
         """
         Predicts firing rates based on given parameters and design matrix.
@@ -668,7 +722,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
 
     def _compute_loss(
         self,
-        params: GLMParams,
+        params: GLMParams[jnp.ndarray],
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
         *args,
@@ -843,7 +897,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
         **kwargs,
-    ) -> GLMParams:
+    ) -> GLMParams[jnp.ndarray]:
         """Initialize the parameters based on the structure and dimensions X and y.
 
         This method initializes the coefficients (spike basis coefficients) and intercepts (bias terms)
@@ -883,21 +937,38 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         else:
             data = X
 
+        frozen = self._frozen_values(X, y)
+        frozen_coef = frozen.coef
+        frozen_intercept = frozen.intercept
+
         empty_params = self._validator.get_empty_params(data, y)
-        if self._fit_intercept:
+        # Resolution order: if fix params provides an intercept use it as fix, otherwise follow flag.
+        fit_intercept = False if frozen_intercept is not None else self.fit_intercept
+
+        if fit_intercept:
             initial_intercept = initialize_intercept_matching_mean_rate(
-                self._inverse_link_function, y
+                self._inverse_link_function,
+                data,
+                y,
+                frozen_coef=frozen_coef,
             )
             initial_coef = jax.tree_util.tree_map(
                 lambda x: jnp.zeros(x.shape), empty_params.coef
             )
+            initial_coef = eqx.combine(frozen_coef, initial_coef)
         else:
-            initial_intercept = jnp.zeros_like(empty_params.intercept)
+            initial_intercept = (
+                frozen_intercept
+                if frozen_intercept is not None
+                else jnp.zeros_like(empty_params.intercept)
+            )
             initial_coef = initialize_constant_coef_matching_mean_rate(
                 self._inverse_link_function,
                 data,
                 y,
                 empty_params.coef,
+                frozen_coef=frozen_coef,
+                frozen_intercept=frozen_intercept,
             )
 
         init_params = eqx.tree_at(
@@ -912,8 +983,11 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         return init_params
 
     def _normalize_user_params(
-        self, init_params: GLMUserParams, X: DESIGN_INPUT_TYPE, y: jnp.ndarray
-    ) -> GLMUserParams:
+        self,
+        init_params: GLMUserParams[jnp.ndarray | None],
+        X: DESIGN_INPUT_TYPE,
+        y: jnp.ndarray,
+    ) -> GLMUserParams[jnp.ndarray]:
         """Fill the intercept when it is held fixed (``fit_intercept=False``).
 
         When the intercept is not estimated the user may omit it (pass ``None`` as the
@@ -925,7 +999,10 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         """
         if not self._fit_intercept:
             self._validator.check_user_params_structure(init_params)
-            if init_params[-1] is not None:
+            warn = init_params[-1] is not None and not jnp.array_equal(
+                self._frozen_values(X, y).intercept, init_params[-1]
+            )
+            if warn:
                 warnings.warn(
                     "`fit_intercept=False`: the provided intercept is ignored and the "
                     "intercept is held at zero. Set `fit_intercept=True` to estimate it.",
@@ -941,7 +1018,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         self,
         X: Union[DESIGN_INPUT_TYPE, ArrayLike],
         y: ArrayLike,
-        init_params: Optional[GLMUserParams] = None,
+        init_params: Optional[GLMUserParams[jnp.ndarray | NDArray]] = None,
     ):
         """Fit GLM to neural activity.
 
@@ -1069,7 +1146,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         self,
         data: DataLoader,
         *,
-        init_params: Optional[GLMUserParams] = None,
+        init_params: Optional[GLMUserParams[jnp.ndarray | NDArray]] = None,
         n_passes: int = 1,
         callbacks: "Callback | list[Callback] | None" = None,
     ):
@@ -1302,7 +1379,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
             ),
         )
 
-    def _get_model_params(self):
+    def _get_model_params(self) -> GLMParams[jnp.ndarray]:
         """Pack coef_ and intercept_  into a params pytree.
 
         This method should be overwritten in case the parameter structure changes,
@@ -1311,7 +1388,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         # Retrieve parameter tree
         return GLMParams(self.coef_, self.intercept_)
 
-    def _set_model_params(self, params: GLMParams):
+    def _set_model_params(self, params: GLMParams[jnp.ndarray]):
         """Unpack and store params pytree to coef_ and intercept_.
 
         This method should be overwritten in case the parameter structure changes,
@@ -1423,8 +1500,9 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         :
             An estimate of the degrees of freedom of the residuals.
         """
+        x_leaves = jax.tree_util.tree_leaves(X)
         # Convert a pytree to a design-matrix with pytrees
-        X = jnp.hstack(jax.tree_util.tree_leaves(X))
+        X = jnp.hstack(x_leaves)
 
         if n_samples is None:
             n_samples = X.shape[0]
@@ -1441,6 +1519,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         # tree and consume no degrees of freedom.
         active, _ = self._partition_active(params)
         intercept_dof = 0 if active.intercept is None else 1
+        active_cols = _active_columns(x_leaves, active.coef)
         # if the regularizer is lasso use the non-zero
         # coeff as an estimate of the dof
         # see https://arxiv.org/abs/0712.0881
@@ -1455,37 +1534,44 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         elif isinstance(self.regularizer, Ridge):
             # for Ridge, use the tot parameters (estimated features + intercept)
             return (
-                n_samples - self._n_estimated_features(X) - intercept_dof
+                n_samples - self._n_estimated_features(active_cols) - intercept_dof
             ) * jnp.ones_like(params.intercept)
         else:
             # for UnRegularized, use the rank
-            return (n_samples - self._design_rank(X) - intercept_dof) * jnp.ones_like(
-                params.intercept
-            )
+            return (
+                n_samples - self._design_rank(X, active_cols) - intercept_dof
+            ) * jnp.ones_like(params.intercept)
 
-    def _n_estimated_features(self, X: jnp.ndarray) -> jnp.ndarray:
+    def _n_estimated_features(self, active_cols: jnp.ndarray) -> jnp.ndarray:
         """Count the coefficients the model estimates, as a scalar or one per neuron.
 
-        Every column of the design contributes a coefficient here. ``PopulationGLM``
-        overrides this: a masked-out feature is not estimated for that neuron.
+        Every active column of the design contributes a coefficient here.
+        ``PopulationGLM`` overrides this: a masked-out feature is not estimated for that
+        neuron.
         """
-        return X.shape[1]
+        return jnp.sum(active_cols)
 
-    def _design_rank(self, X: jnp.ndarray) -> jnp.ndarray:
-        """Rank of the design, as a scalar or one per neuron.
+    def _design_rank(self, X: jnp.ndarray, active_cols: jnp.ndarray) -> jnp.ndarray:
+        """Rank of the design the model estimates over, as a scalar or one per neuron.
 
         The rank, rather than the column count, is what an unpenalized fit consumes:
-        collinear columns share degrees of freedom. ``PopulationGLM`` overrides this to
-        take the rank per neuron, since the mask gives each neuron its own design.
+        collinear columns share degrees of freedom. Frozen columns are dropped rather
+        than zeroed: a rank is an SVD away and the smaller matrix is the better
+        conditioned one. ``PopulationGLM`` overrides this to take the rank per neuron,
+        since the mask gives each neuron its own design.
         """
+        X = X[:, active_cols]
+        # every coefficient frozen leaves no design to take the rank of
+        if X.shape[1] == 0:
+            return jnp.asarray(0)
         return jnp.linalg.matrix_rank(X)
 
     def _initialize_optimizer_and_state(
         self,
-        init_params: GLMParams,
+        init_params: GLMParams[jnp.ndarray],
         X: dict[str, jnp.ndarray] | jnp.ndarray,
         y: jnp.ndarray,
-        frozen_params: GLMParams = None,
+        frozen_params: GLMParams[jnp.ndarray | None] = None,
     ) -> SolverState:
         """Initialize the solver by instantiating its init_state, update and, run methods.
 
@@ -1535,7 +1621,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
     @cast_to_jax
     def update(
         self,
-        params: GLMUserParams,
+        params: GLMUserParams[jnp.ndarray | NDArray],
         opt_state: SolverState,
         X: DESIGN_INPUT_TYPE,
         y: jnp.ndarray,
@@ -1682,6 +1768,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         >>> for key, value in model.get_params().items():
         ...     print(f"{key}: {value}")
         fit_intercept: True
+        fix_params: (None, None)
         inverse_link_function: <function one_over_x at ...>
         observation_model: GammaObservations()
         regularizer: Ridge()
@@ -1696,6 +1783,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         >>> for key, value in model.get_params().items():  # doctest: +ELLIPSIS
         ...     print(f"{key}: {value}")
         fit_intercept: True
+        fix_params: (None, None)
         inverse_link_function: <function one_over_x at ...>
         observation_model: GammaObservations()
         regularizer: Ridge()
@@ -1718,6 +1806,7 @@ class GLM(BaseRegressor[GLMUserParams, GLMParams, GLMValidator]):
         >>> for key, value in loaded_model.get_params().items():
         ...     print(f"{key}: {value}")
         fit_intercept: True
+        fix_params: (None, None)
         inverse_link_function: <function <lambda> at ...>
         observation_model: PoissonObservations()
         regularizer: UnRegularized()
@@ -1847,6 +1936,14 @@ class PopulationGLM(GLM):
         parameter structure to regularize parameters differentially.
     fit_intercept :
         When True (default), an intercept term is fit. When False, only the coefficients are fit.
+        An intercept pinned through ``fix_params`` takes precedence over this flag.
+    fix_params :
+        Parameters to hold fixed during fitting, as a ``(coef, intercept)`` tuple with
+        ``coef`` of shape ``(n_features, n_neurons)`` and ``intercept`` of shape
+        ``(n_neurons,)``. An array pins that parameter at the value provided, ``None``
+        leaves it to be learned. When ``X`` is a pytree, ``coef`` mirrors its structure,
+        its leaves have shape ``(n_features_in_leaf, n_neurons)``, and each leaf is
+        pinned or learned on its own. Defaults to ``None``, which learns every parameter.
     solver_name :
         Solver to use for model optimization. Defines the optimization scheme and related parameters.
         The solver must be an appropriate match for the chosen regularizer.
@@ -1979,10 +2076,10 @@ class PopulationGLM(GLM):
         regularizer: Union[str, Regularizer] = "UnRegularized",
         regularizer_strength: Any = None,
         fit_intercept: bool = True,
+        fix_params: Optional[GLMUserParams[jnp.ndarray | NDArray | None]] = None,
         solver_name: str = None,
         solver_kwargs: dict = None,
         feature_mask: Optional[jnp.ndarray] = None,
-        **kwargs,
     ):
         super().__init__(
             observation_model=observation_model,
@@ -1990,9 +2087,9 @@ class PopulationGLM(GLM):
             regularizer_strength=regularizer_strength,
             regularizer=regularizer,
             fit_intercept=fit_intercept,
+            fix_params=fix_params,
             solver_name=solver_name,
             solver_kwargs=solver_kwargs,
-            **kwargs,
         )
         self._metadata = None
         self.feature_mask = feature_mask
@@ -2048,7 +2145,7 @@ class PopulationGLM(GLM):
         self,
         X: Union[DESIGN_INPUT_TYPE, ArrayLike],
         y: ArrayLike,
-        init_params: Optional[GLMUserParams] = None,
+        init_params: Optional[GLMUserParams[jnp.ndarray | NDArray]] = None,
     ):
         """Fit GLM to the activity of a population of neurons.
 
@@ -2127,7 +2224,7 @@ class PopulationGLM(GLM):
         return super().fit(X, y, init_params)
 
     def _predict(
-        self, params: GLMParams, X: jnp.ndarray, feature_mask: Any = None
+        self, params: GLMParams[jnp.ndarray], X: jnp.ndarray, feature_mask: Any = None
     ) -> jnp.ndarray:
         """
         Predicts firing rates based on given parameters and design matrix.
@@ -2171,26 +2268,33 @@ class PopulationGLM(GLM):
             + params.intercept
         )
 
-    def _n_estimated_features(self, X: jnp.ndarray) -> jnp.ndarray:
+    def _n_estimated_features(self, active_cols: jnp.ndarray) -> jnp.ndarray:
         """Count the features the mask lets through, per neuron.
 
         A masked-out coefficient contributes nothing to the rate and is never estimated,
-        so it must not be charged against the residual degrees of freedom.
+        so it must not be charged against the residual degrees of freedom. A frozen one
+        is dropped the same way, through ``active_cols``.
         """
         if self._feature_mask is None:
-            return super()._n_estimated_features(X)
+            return super()._n_estimated_features(active_cols)
         mask = jnp.concatenate(jax.tree_util.tree_leaves(self._feature_mask), axis=0)
-        return jnp.sum(mask, axis=0)
+        return jnp.sum(mask[active_cols], axis=0)
 
-    def _design_rank(self, X: jnp.ndarray) -> jnp.ndarray:
+    def _design_rank(self, X: jnp.ndarray, active_cols: jnp.ndarray) -> jnp.ndarray:
         """Rank of each neuron's own design, after its masked columns are dropped.
 
         Zeroing the masked columns leaves the rank unchanged relative to deleting them,
-        so this stays a plain array op rather than a boolean index.
+        so the per-neuron mask stays a plain array op rather than a boolean index. The
+        frozen columns are the same for every neuron, so those are sliced away once,
+        before the vmap: every rank is then read off a smaller matrix.
         """
         if self._feature_mask is None:
-            return super()._design_rank(X)
+            return super()._design_rank(X, active_cols)
         mask = jnp.concatenate(jax.tree_util.tree_leaves(self._feature_mask), axis=0)
+        X, mask = X[:, active_cols], mask[active_cols]
+        # every coefficient frozen leaves no design to take the rank of
+        if X.shape[1] == 0:
+            return jnp.zeros(mask.shape[1], dtype=int)
         return jax.vmap(lambda m: jnp.linalg.matrix_rank(X * m), in_axes=1, out_axes=0)(
             mask
         )

--- a/src/nemos/glm/initialize_parameters.py
+++ b/src/nemos/glm/initialize_parameters.py
@@ -116,8 +116,34 @@ def scalar_root_find_elementwise(
     return jnp.array([opt.root for opt in opts])
 
 
+def compute_frozen_linear_predictor(X, frozen_coef, frozen_intercept):
+    """Linear predictor from the frozen parameters.
+
+    A frozen coefficient leaf contributes its ``X @ coef`` term; a free (``None``) leaf
+    contributes a broadcastable ``[0.]``. ``frozen_intercept`` is added when present.
+    """
+    intercept = 0.0 if frozen_intercept is None else frozen_intercept
+    return (
+        jax.tree.reduce(
+            jnp.add,
+            jax.tree.map(
+                lambda x1, x2: (
+                    jnp.matmul(x1, x2) if x2 is not None else jnp.array([0.0])
+                ),
+                X,
+                frozen_coef,
+            ),
+        )
+        + intercept
+    )
+
+
 def initialize_intercept_matching_mean_rate(
-    inverse_link_function: Callable, y: jnp.ndarray
+    inverse_link_function: Callable,
+    X: Union[Pytree, jnp.ndarray],
+    y: jnp.ndarray,
+    frozen_coef: Optional[Union[Pytree, jnp.ndarray]] = None,
+    frozen_intercept: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """
     Compute the initial intercept term for a regression models.
@@ -131,9 +157,13 @@ def initialize_intercept_matching_mean_rate(
     inverse_link_function:
         The inverse link function of the model, linking the mean to the linear combination of the covariates in
         a GLM.
+    X:
+        The predictors.
     y:
         The neural activity, shape either (num_sample,) for single variable regressors as `GLM`
          or (n_sample, n_neurons) for multi-variable regressors, such as `PopulaitonGLM`.
+    frozen_coef:
+        The frozen parameters.
 
     Returns
     -------
@@ -142,12 +172,20 @@ def initialize_intercept_matching_mean_rate(
 
     """
     y = jnp.asarray(y, float)
+    # expand tree to match structure
+    if frozen_coef is None:
+        frozen_coef = jax.tree_util.tree_map(lambda x: None, X)
+
     # return inverse if analytical solution is available
     analytical_inv = get_inverse_function(inverse_link_function)
 
+    # compute the linear predictor from the frozen tree
+    frozen_lin_pred = compute_frozen_linear_predictor(X, frozen_coef, frozen_intercept)
+    mean_frozen = jnp.nanmean(frozen_lin_pred, axis=0)
+
     means = jnp.atleast_1d(jnp.nanmean(y, axis=0))
     if analytical_inv:
-        out = analytical_inv(means)
+        out = analytical_inv(means) - mean_frozen
         if jnp.any(jnp.isnan(out)):
             raise ValueError(
                 "Failed to initialize the model intercept as the inverse of the firing rate for "
@@ -162,7 +200,7 @@ def initialize_intercept_matching_mean_rate(
         return inverse_link_function(x) - mean_x
 
     try:
-        out = scalar_root_find_elementwise(func, means, means)
+        out = scalar_root_find_elementwise(func, means, means) - mean_frozen
     except ValueError:
         raise ValueError(
             "Failed to initialize the model intercept as the inverse of the firing rate for the"
@@ -180,6 +218,8 @@ def initialize_constant_coef_matching_mean_rate(
     X: Union[Pytree, jnp.ndarray],
     y: jnp.ndarray,
     empty_coef: Union[Pytree, jnp.ndarray],
+    frozen_coef: Optional[Union[Pytree, jnp.ndarray]] = None,
+    frozen_intercept: Optional[jnp.ndarray] = None,
     eps: Optional[float] = None,
 ) -> Union[Pytree, jnp.ndarray]:
     r"""
@@ -218,6 +258,8 @@ def initialize_constant_coef_matching_mean_rate(
     empty_coef :
         A pytree matching the target coefficient structure and shapes (e.g. as returned
         by the validator's ``get_empty_params``). Used only for its leaf shapes.
+    frozen_coef :
+        Pytree including the fixed valued model coefficients.
     eps :
         Stabilization added to both numerator and denominator. Defaults to the machine
         epsilon of the row-sum dtype, which only intervenes when the design row-sums are
@@ -242,17 +284,42 @@ def initialize_constant_coef_matching_mean_rate(
     :math:`\varepsilon` terms added for numerical stability). The problem is degenerate
     only when :math:`s \equiv 0`, in which case no constant coefficient can inject an
     offset and the :math:`\varepsilon` stabilization keeps :math:`c` finite.
+
+    When some coefficients are frozen, their contribution is subtracted from the target
+    per sample (:math:`\eta^\star_t = \eta^\star - \sum_j X_{tj}\,\beta^{\text{frozen}}_j`)
+    and the frozen features are excluded from :math:`s_t`; for multi-output models the
+    projection is computed independently for each output.
     """
-    # the linear-predictor target a free intercept would supply, shape (n_out,)
-    eta_target = initialize_intercept_matching_mean_rate(inverse_link_function, y)
+    if frozen_coef is None:
+        frozen_coef = jax.tree_util.tree_map(lambda x: None, X)
+    # the linear-predictor target a free intercept would supply, shape (*out,)
+    eta_target = initialize_intercept_matching_mean_rate(inverse_link_function, X, y)
 
-    # row-sum of the design across all features of all leaves, shape (n_samples,)
-    row_sum = sum(jnp.nansum(leaf, axis=1) for leaf in jax.tree_util.tree_leaves(X))
+    # coef is (n_features, *out): out is () for GLM, (n_out,) for population/classifier
+    # GLM, (n_neurons, n_classes) for the population classifier. The frozen predictor is
+    # therefore (n_samples, *out), or *out alone for a frozen intercept. The GLM matmul
+    # drops its trailing size-1 output axis, so restore it before subtracting eta_target.
+    frozen_lin_pred = compute_frozen_linear_predictor(X, frozen_coef, frozen_intercept)
+    if eta_target.shape == (1,) and frozen_lin_pred.ndim == 1:
+        frozen_lin_pred = frozen_lin_pred[:, None]
+    residual = eta_target[None, ...] - frozen_lin_pred
 
+    # row-sum of the design across all active features of all leaves, shape (n_samples,)
+    row_sum = jax.tree.map(
+        lambda x1, x2: jnp.nansum(x1, axis=1) if x2 is None else jnp.array(0.0),
+        X,
+        frozen_coef,
+    )
+    row_sum = jax.tree.reduce(jnp.add, row_sum)
     if eps is None:
         eps = jnp.finfo(row_sum.dtype).eps
-
-    scale = (jnp.sum(row_sum) + eps) / (jnp.sum(row_sum**2) + eps)
-    const = eta_target * scale  # (n_out,)
-
-    return jax.tree_util.tree_map(lambda leaf: jnp.full_like(leaf, const), empty_coef)
+    # per-output least-squares projection: weight each sample's residual by its row-sum
+    # (broadcast across the output axes) and sum over samples. Result shape ``*out``.
+    weight = row_sum.reshape(row_sum.shape + (1,) * eta_target.ndim)
+    const = (jnp.sum(weight * residual, axis=0) + eps) / (jnp.sum(row_sum**2) + eps)
+    return jax.tree_util.tree_map(
+        lambda leaf1, leaf2: jnp.full_like(leaf1, const) if leaf2 is None else leaf2,
+        empty_coef,
+        frozen_coef,
+        is_leaf=lambda x: x is None,
+    )

--- a/src/nemos/glm/params.py
+++ b/src/nemos/glm/params.py
@@ -1,24 +1,22 @@
 """GLM parameter definitions and type aliases."""
 
-from typing import Callable, Tuple, Union
+from typing import Callable
 
-import jax.numpy as jnp
-from numpy.typing import ArrayLike
+from jaxtyping import PyTree
 
 from ..params import ModelParams
-from ..typing import DESIGN_INPUT_TYPE
 
 
-class GLMParams(ModelParams):
+class GLMParams[LeafT](ModelParams[LeafT]):
     """Parameter container for GLM models."""
 
-    coef: jnp.ndarray | dict
-    intercept: jnp.ndarray
+    coef: PyTree[LeafT]
+    intercept: LeafT
 
     @staticmethod
-    def regularizable_subtrees() -> list[Callable[["GLMParams"], jnp.ndarray | dict]]:
+    def regularizable_subtrees() -> list[Callable[["GLMParams[LeafT]"], PyTree[LeafT]]]:
         """Filter regularizable subtrees."""
         return [lambda p: p.coef]
 
 
-GLMUserParams = Tuple[Union[DESIGN_INPUT_TYPE, ArrayLike], ArrayLike]
+type GLMUserParams[LeafT] = tuple[PyTree[LeafT], LeafT]

--- a/src/nemos/glm/validation.py
+++ b/src/nemos/glm/validation.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Literal, Optional, Tuple, Union
 import jax
 import jax.numpy as jnp
 from jax.typing import DTypeLike
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, NDArray
 
 from .. import validation
 from ..base_validator import RegressorValidator
@@ -16,12 +16,12 @@ from ..typing import DESIGN_INPUT_TYPE
 from .params import GLMParams, GLMUserParams
 
 
-def to_glm_params(user_params: GLMUserParams) -> GLMParams:
+def to_glm_params[LeafT](user_params: GLMUserParams[LeafT]) -> GLMParams[LeafT]:
     """Map from GLMUserParams to GLMParams."""
     return GLMParams(*user_params)
 
 
-def from_glm_params(params: GLMParams) -> GLMUserParams:
+def from_glm_params[LeafT](params: GLMParams[LeafT]) -> GLMUserParams[LeafT]:
     """Map from GLMParams to GLMUserParams."""
     return params.coef, params.intercept
 
@@ -69,7 +69,9 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
         ("validate_intercept_shape", None),
     )
 
-    def validate_intercept_shape(self, params: GLMParams, **kwargs):
+    def validate_intercept_shape(
+        self, params: GLMParams[jnp.ndarray | NDArray], **kwargs
+    ):
         """
         Perform GLM-specific parameter validation.
 
@@ -99,12 +101,24 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
             )
         return params
 
+    def additional_validation_param_specs(
+        self, params: GLMParams[jnp.ndarray | NDArray], **kwargs
+    ) -> GLMParams[jnp.ndarray | NDArray]:
+        """Add the GLM intercept-shape check to a partial parameter specification.
+
+        The intercept is optional in a spec (``None`` when left learnable), so the
+        shape check only runs when an intercept is actually fixed.
+        """
+        if params.intercept is not None:
+            self.validate_intercept_shape(params)
+        return params
+
     def check_array_dimensions(
         self,
-        params: GLMUserParams,
+        params: GLMUserParams[jnp.ndarray | NDArray],
         err_msg: Optional[str] = None,
         err_message_format: str = None,
-    ) -> GLMUserParams:
+    ) -> GLMUserParams[jnp.ndarray | NDArray]:
         """
         Check array dimensions with custom error formatting for GLM parameters.
 
@@ -165,7 +179,7 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
 
     def validate_consistency(
         self,
-        params: GLMParams,
+        params: GLMParams[jnp.ndarray | NDArray],
         X: Optional[DESIGN_INPUT_TYPE] = None,
         y: Optional[jnp.ndarray] = None,
     ):
@@ -261,7 +275,7 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
     def feature_mask_consistency(
         self,
         feature_mask: Union[dict[str, jnp.ndarray], jnp.ndarray] | None,
-        params: GLMParams,
+        params: GLMParams[jnp.ndarray | NDArray],
     ):
         """Check that feature_mask mirrors the structure and the shape of ``params.coef``."""
         if feature_mask is None:
@@ -300,7 +314,7 @@ class GLMValidator(RegressorValidator[GLMUserParams, GLMParams]):
         """
         return coef.shape
 
-    def get_empty_params(self, X, y) -> GLMParams:
+    def get_empty_params(self, X, y) -> GLMParams[jnp.ndarray]:
         """Return the param shape given the input data."""
         empty_coef = jax.tree_util.tree_map(lambda x: jnp.empty((x.shape[1],)), X)
         empty_intercept = jnp.empty((1,))
@@ -346,7 +360,7 @@ class PopulationGLMValidator(GLMValidator):
 
     def validate_consistency(
         self,
-        params: GLMParams,
+        params: GLMParams[jnp.ndarray | NDArray],
         X: Optional[DESIGN_INPUT_TYPE] = None,
         y: Optional[jnp.ndarray] = None,
     ):
@@ -371,7 +385,18 @@ class PopulationGLMValidator(GLMValidator):
                 f"y has {jax.tree_util.tree_map(lambda x: x.shape[1], y)} neurons instead!",
             )
 
-    def get_empty_params(self, X, y) -> GLMParams:
+    def additional_validation_param_specs(
+        self, params: GLMParams[jnp.ndarray | NDArray], **kwargs
+    ) -> GLMParams[jnp.ndarray | NDArray]:
+        """No setter-time intercept-shape check for population GLM.
+
+        The intercept has shape ``(n_neurons,)`` and ``n_neurons`` is only known once
+        ``y`` is available, so the exact shape is validated by ``validate_consistency``
+        at fit time. ``check_array_dimensions`` still enforces the intercept ndim.
+        """
+        return params
+
+    def get_empty_params(self, X, y) -> GLMParams[jnp.ndarray]:
         """Return the param shape given the input data."""
         n_neurons = y.shape[1]
         empty_coef = jax.tree_util.tree_map(
@@ -434,10 +459,10 @@ class ClassifierGLMValidator(GLMValidator):
 
     def validate_n_classes_shape(
         self,
-        params: GLMUserParams,
+        params: GLMUserParams[jnp.ndarray | NDArray],
         intercept_err_format: str = None,
         **kwargs,
-    ) -> GLMUserParams:
+    ) -> GLMUserParams[jnp.ndarray | NDArray]:
         """
         Validate that coef and intercept last dimensions match n_classes.
 
@@ -475,9 +500,28 @@ class ClassifierGLMValidator(GLMValidator):
 
         return params
 
+    def additional_validation_param_specs(
+        self, params: GLMParams[jnp.ndarray | NDArray], **kwargs
+    ) -> GLMParams[jnp.ndarray | NDArray]:
+        """Check that a fixed intercept's class dimension matches ``n_classes``.
+
+        The last axis of the intercept is ``n_classes`` (known from ``extra_params``),
+        so it can be checked at setter time. For the population classifier the neuron
+        axis is left to ``validate_consistency`` at fit time. ``check_array_dimensions``
+        already enforces the intercept ndim.
+        """
+        if params.intercept is not None:
+            n_classes = self.extra_params["n_classes"]
+            if params.intercept.shape[-1] != n_classes:
+                raise ValueError(
+                    f"intercept last dimension must be n_classes = {n_classes}. "
+                    f"Got intercept with shape {params.intercept.shape}."
+                )
+        return params
+
     def validate_consistency(
         self,
-        params: GLMParams,
+        params: GLMParams[jnp.ndarray | NDArray],
         X: Optional[DESIGN_INPUT_TYPE] = None,
         y: Optional[jnp.ndarray] = None,
     ):
@@ -538,7 +582,7 @@ class ClassifierGLMValidator(GLMValidator):
             y_int = y
         return y_int
 
-    def get_empty_params(self, X, y) -> GLMParams:
+    def get_empty_params(self, X, y) -> GLMParams[jnp.ndarray]:
         """Return the param shape given the input data."""
         n_classes = self.extra_params["n_classes"]
         empty_coef = jax.tree_util.tree_map(
@@ -588,7 +632,7 @@ class PopulationClassifierGLMValidator(ClassifierGLMValidator):
 
     def validate_consistency(
         self,
-        params: GLMParams,
+        params: GLMParams[jnp.ndarray | NDArray],
         X: Optional[DESIGN_INPUT_TYPE] = None,
         y: Optional[jnp.ndarray] = None,
     ):
@@ -614,7 +658,7 @@ class PopulationClassifierGLMValidator(ClassifierGLMValidator):
                 f"y has {jax.tree_util.tree_map(lambda x: x.shape[1], y)} neurons instead!",
             )
 
-    def get_empty_params(self, X, y) -> GLMParams:
+    def get_empty_params(self, X, y) -> GLMParams[jnp.ndarray]:
         """Return the param shape given the input data."""
         n_neurons = y.shape[1]
         n_classes = self.extra_params["n_classes"]

--- a/src/nemos/glm_hmm/algorithm_configs.py
+++ b/src/nemos/glm_hmm/algorithm_configs.py
@@ -88,7 +88,7 @@ def _posterior_weighted_objective_impl(
     jax.jit, static_argnames=["inverse_link_function", "negative_log_likelihood_func"]
 )
 def posterior_weighted_glm_negative_log_likelihood(
-    glm_params: GLMParams,
+    glm_params: GLMParams[jnp.ndarray],
     X: Array,
     y: Array,
     posteriors: Array,

--- a/src/nemos/glm_hmm/initialize_parameters.py
+++ b/src/nemos/glm_hmm/initialize_parameters.py
@@ -105,7 +105,7 @@ def random_glm_params_init(
         X,
     )
     # mean-rate
-    intercept = initialize_intercept_matching_mean_rate(inverse_link_function, y)
+    intercept = initialize_intercept_matching_mean_rate(inverse_link_function, X, y)
     intercept = jnp.tile(intercept[:, jnp.newaxis], (1, n_states))
     if is_one_dim:
         coef = jax.tree_util.tree_map(lambda x: jnp.squeeze(x, axis=1), coef)

--- a/src/nemos/glm_hmm/utils.py
+++ b/src/nemos/glm_hmm/utils.py
@@ -11,7 +11,7 @@ from ..tree_utils import pytree_map_and_reduce
 
 
 def compute_rate_per_state(
-    X: Any, glm_params: GLMParams, inverse_link_function: Callable
+    X: Any, glm_params: GLMParams[jnp.ndarray], inverse_link_function: Callable
 ) -> Array:
     """
     Compute GLM predicted rates for all latent states.

--- a/src/nemos/io/io.py
+++ b/src/nemos/io/io.py
@@ -11,12 +11,14 @@ import numpy as np
 if TYPE_CHECKING:
     from ..base_regressor import BaseRegressor
     from ..observation_models import Observations
+    from ..params import ModelParams
     from ..regularizer import Regularizer
 
 from .._observation_model_builder import (
     AVAILABLE_OBSERVATION_MODELS,
     instantiate_observation_model,
 )
+from .._params_builder import AVAILABLE_PARAM_CONTAINERS, instantiate_param_container
 from .._regularizer_builder import AVAILABLE_REGULARIZERS, instantiate_regularizer
 from ..glm import GLM, ClassifierGLM, ClassifierPopulationGLM, PopulationGLM
 from ..glm_hmm import GLMHMM
@@ -194,7 +196,7 @@ def _is_param(par):
 
 def _safe_instantiate(
     param_name: str, class_name: str, **kwargs
-) -> "Regularizer | Observations":
+) -> "Regularizer | Observations | ModelParams":
     if not isinstance(class_name, str):
         # this should not be hit, if it does the saved params had been modified.
         raise ValueError(
@@ -205,6 +207,8 @@ def _safe_instantiate(
     class_basename = class_name.split(".")[-1]
     if class_basename in AVAILABLE_REGULARIZERS:
         return instantiate_regularizer(class_name, **kwargs)
+    elif class_basename in AVAILABLE_PARAM_CONTAINERS:
+        return instantiate_param_container(class_name, **kwargs)
     elif any(class_basename.startswith(obs) for obs in AVAILABLE_OBSERVATION_MODELS):
         return instantiate_observation_model(class_name, **kwargs)
     else:

--- a/src/nemos/io/io.py
+++ b/src/nemos/io/io.py
@@ -77,6 +77,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     >>> for key, value in model.get_params().items():
     ...     print(f"{key}: {value}")
     fit_intercept: True
+    fix_params: (None, None)
     inverse_link_function: <function one_over_x at ...>
     observation_model: GammaObservations()
     regularizer: Ridge()
@@ -91,6 +92,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     >>> for key, value in model.get_params().items():  # doctest: +ELLIPSIS
     ...     print(f"{key}: {value}")
     fit_intercept: True
+    fix_params: (None, None)
     inverse_link_function: <function one_over_x at ...>
     observation_model: GammaObservations()
     regularizer: Ridge()
@@ -110,6 +112,7 @@ def load_model(filename: Union[str, Path], mapping_dict: dict = None):
     >>> for key, value in loaded_model.get_params().items():
     ...     print(f"{key}: {value}")
     fit_intercept: True
+    fix_params: (None, None)
     inverse_link_function: <function <lambda> at ...>
     observation_model: PoissonObservations()
     regularizer: UnRegularized()

--- a/src/nemos/params.py
+++ b/src/nemos/params.py
@@ -1,16 +1,16 @@
-"""GLM parameter definitions and type aliases."""
+"""Model parameter definitions and type aliases."""
 
 from typing import Callable
 
 import equinox as eqx
-import jax.numpy as jnp
+from jaxtyping import PyTree
 
 
-class ModelParams(eqx.Module):
+class ModelParams[LeafT](eqx.Module):
     """Shared methods for model parameter containers."""
 
     @staticmethod
-    def regularizable_subtrees() -> list[Callable[["ModelParams"], jnp.ndarray | dict]]:
+    def regularizable_subtrees() -> list[Callable[["ModelParams"], PyTree]]:
         """
         Filter regularizable subtrees.
 

--- a/src/nemos/solvers/_no_op.py
+++ b/src/nemos/solvers/_no_op.py
@@ -2,7 +2,11 @@
 
 from typing import Any, NamedTuple
 
+import jax.numpy as jnp
+
 from ..typing import Params, StepResult
+from ._abstract_solver import AbstractSolver, OptimizationInfo
+from ._stochastic_mixins import StochasticSolverMixin
 
 
 class NoOpState(NamedTuple):
@@ -14,18 +18,33 @@ class NoOpState(NamedTuple):
     converged: bool = True
 
 
-class NoOpSolver:
+class NoOpSolver(StochasticSolverMixin, AbstractSolver[NoOpState]):
     """Identity solver for an empty active parameter tree.
 
     When every parameter is fixed there is nothing left to optimize: the pinned values
     already are the solution. The real solvers cannot be initialized on an empty pytree
-    (optax's line search indexes into its leaves), so this takes their place and lets
+    (optax's line search indexes into its leaves), so this stands in for them and lets
     the model entry points keep their shape — partition, run, recombine the frozen
-    values. It is internal: not registered, so it cannot be selected by name.
+    values.
+
+    It implements the full solver interface, including the stochastic one, so that it can
+    replace any solver the model was configured with. It is internal: not registered, so
+    it cannot be selected by name.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Accept and ignore whatever the real solver would have been given."""
         pass
+
+    @property
+    def acceleration_turned_on(self) -> bool:
+        """Nothing to accelerate."""
+        return False
+
+    @property
+    def linesearch_turned_on(self) -> bool:
+        """Nothing to search along."""
+        return False
 
     def init_state(self, init_params: Params, *args: Any) -> NoOpState:
         """Return the state of a solver that will not step."""
@@ -38,6 +57,36 @@ class NoOpSolver:
     def run(self, init_params: Params, *args: Any) -> StepResult:
         """Return ``init_params`` unchanged."""
         return init_params, NoOpState(), None
+
+    def _stochastic_run_impl(
+        self,
+        init_params: Params,
+        data_loader,
+        n_passes: int,
+        callback,
+        ctx,
+    ) -> StepResult:
+        """Bracket the run with the train callbacks, without touching the data.
+
+        Overrides the inherited loop rather than stepping through it: no batch can move a
+        fully fixed parameter tree, and iterating a data loader built for out-of-memory
+        data would read it in full to change nothing. The per-pass and per-batch hooks
+        are not called because no pass or batch is run.
+        """
+        state = self.init_state(init_params)
+        ctx.params, ctx.state = init_params, state
+        callback.on_train_begin(ctx)
+        callback.on_train_end(ctx)
+        return init_params, state, None
+
+    def _get_optim_info(self, state: NoOpState, **kwargs) -> OptimizationInfo:
+        """Report a converged run of zero steps."""
+        return OptimizationInfo(
+            function_val=None,
+            num_steps=jnp.asarray(0),
+            converged=jnp.asarray(True),
+            reached_max_steps=jnp.asarray(False),
+        )
 
     @classmethod
     def get_accepted_arguments(cls) -> set[str]:

--- a/src/nemos/solvers/_no_op.py
+++ b/src/nemos/solvers/_no_op.py
@@ -1,0 +1,45 @@
+"""Solver stand-in for models whose every parameter is fixed."""
+
+from typing import Any, NamedTuple
+
+from ..typing import Params, StepResult
+
+
+class NoOpState(NamedTuple):
+    """State of a solver with nothing to optimize.
+
+    ``converged`` is what the fit entry points inspect to decide whether to warn.
+    """
+
+    converged: bool = True
+
+
+class NoOpSolver:
+    """Identity solver for an empty active parameter tree.
+
+    When every parameter is fixed there is nothing left to optimize: the pinned values
+    already are the solution. The real solvers cannot be initialized on an empty pytree
+    (optax's line search indexes into its leaves), so this takes their place and lets
+    the model entry points keep their shape — partition, run, recombine the frozen
+    values. It is internal: not registered, so it cannot be selected by name.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def init_state(self, init_params: Params, *args: Any) -> NoOpState:
+        """Return the state of a solver that will not step."""
+        return NoOpState()
+
+    def update(self, params: Params, state: NoOpState, *args: Any) -> StepResult:
+        """Return ``params`` unchanged."""
+        return params, state, None
+
+    def run(self, init_params: Params, *args: Any) -> StepResult:
+        """Return ``init_params`` unchanged."""
+        return init_params, NoOpState(), None
+
+    @classmethod
+    def get_accepted_arguments(cls) -> set[str]:
+        """No configuration is accepted."""
+        return set()

--- a/src/nemos/solvers/_optimistix_adapter.py
+++ b/src/nemos/solvers/_optimistix_adapter.py
@@ -127,12 +127,15 @@ class OptimistixAdapter(SolverAdapter[OptimistixAdapterState]):
 
         self.config = OptimistixConfig(maxiter=maxiter, **user_args)
 
+        # ``fun_with_aux`` is packed because optimistix requires ``fn(y, args)``; ``fun``
+        # is the model-facing loss and stays ``fun(params, *args)``, as in every other
+        # adapter. Only ``fun_with_aux`` is handed to optimistix.
         if has_aux:
             self.fun_with_aux = pack_args(loss_fn)
-            self.fun = drop_aux(self.fun_with_aux)
+            self.fun = drop_aux(loss_fn)
         else:
-            self.fun = pack_args(loss_fn)
-            self.fun_with_aux = wrap_aux(self.fun)
+            self.fun = loss_fn
+            self.fun_with_aux = wrap_aux(pack_args(loss_fn))
 
         # make custom adjustments such as adding a derived "while_loop_kind" parameter for FISTA
         solver_init_kwargs = self.adjust_solver_init_kwargs(solver_init_kwargs)

--- a/src/nemos/tree_utils.py
+++ b/src/nemos/tree_utils.py
@@ -259,8 +259,8 @@ def tree_broadcast_prefix(prefix: Any, full: Any) -> Any:
     Examples
     --------
     >>> from nemos.tree_utils import tree_broadcast_prefix
-    >>> tree_broadcast_prefix({"a": 1, "b": 0}, {"a": {"x": True, "y": True}, "b": True})
-    {'a': {'x': 1, 'y': 1}, 'b': 0}
+    >>> tree_broadcast_prefix({"a": 1, "b": 0}, {"a": {"x": None, "y": None}, "b": None})
+    {'a': {'x': None, 'y': None}, 'b': None}
     """
     treedef = jax.tree_util.tree_structure(prefix)
     return jax.tree_util.tree_unflatten(

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import os
 import warnings
@@ -14,6 +15,7 @@ import jax.numpy as jnp
 import numpy as np
 from numpy.typing import NDArray
 
+from .params import ModelParams
 from .tree_utils import pytree_map_and_reduce
 from .type_casting import support_pynapple
 from .typing import Pytree
@@ -831,6 +833,16 @@ def _unpack_params(params_dict: dict, string_attrs: list = None) -> dict:
             cls_name = _get_name(value)
             params = _unpack_params(value.get_params(deep=False), string_attrs)
             out[key] = {"class": cls_name, "params": params}
+        elif isinstance(value, ModelParams):
+            # parameter containers are equinox modules and have no ``get_params``, so
+            # unpack them field by field through the same class/params convention.
+            # Without this they reach ``_flatten_dict`` whole and are stored as pickled
+            # object arrays, which ``load_model`` cannot read back.
+            fields = {f.name: getattr(value, f.name) for f in dataclasses.fields(value)}
+            out[key] = {
+                "class": _get_name(value),
+                "params": _unpack_params(fields, string_attrs),
+            }
         elif isinstance(value, dict):
             # serialize callable/class leaves inside plain dicts by their name,
             # so npz can store them as strings instead of pickled object arrays.

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -492,8 +492,15 @@ def format_repr(
     all_params = obj.get_params(deep=False)
     label = all_params.pop("label", None)
     for k, v in all_params.items():
+        # a pytree of only None leaves (e.g. the default fix_params spec) is "unset"
+        all_none = pytree_map_and_reduce(
+            lambda x: x is None, all, v, is_leaf=lambda x: x is None
+        )
         repr_param = (
-            k not in exclude_keys and not hasattr(v, "shape") and (v or v in (0, False))
+            k not in exclude_keys
+            and not hasattr(v, "shape")
+            and not all_none
+            and (v or v in (0, False))
         )
         if repr_param:
             if k in use_name_keys:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1100,21 +1100,6 @@ def example_data_prox_operator_multineuron():
 
 
 @pytest.fixture
-def poisson_observation_model():
-    return nmo.observation_models.PoissonObservations(jnp.exp)
-
-
-@pytest.fixture
-def ridge_regularizer():
-    return nmo.regularizer.Ridge()
-
-
-@pytest.fixture
-def lasso_regularizer():
-    return nmo.regularizer.Lasso()
-
-
-@pytest.fixture
 def group_lasso_2groups_5features_regularizer():
     mask = np.zeros((2, 5))
     mask[0, :2] = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1100,14 +1100,6 @@ def example_data_prox_operator_multineuron():
 
 
 @pytest.fixture
-def group_lasso_2groups_5features_regularizer():
-    mask = np.zeros((2, 5))
-    mask[0, :2] = 1
-    mask[1, 2:] = 1
-    return nmo.regularizer.GroupLasso(mask=mask)
-
-
-@pytest.fixture
 def mock_data():
     return jnp.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]), jnp.array([[1, 2], [3, 4]])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1111,7 +1111,7 @@ def ridge_regularizer():
 
 @pytest.fixture
 def lasso_regularizer():
-    return nmo.regularizer.Lasso(solver_name="ProximalGradient")
+    return nmo.regularizer.Lasso()
 
 
 @pytest.fixture
@@ -1119,7 +1119,7 @@ def group_lasso_2groups_5features_regularizer():
     mask = np.zeros((2, 5))
     mask[0, :2] = 1
     mask[1, 2:] = 1
-    return nmo.regularizer.GroupLasso(solver_name="ProximalGradient", mask=mask)
+    return nmo.regularizer.GroupLasso(mask=mask)
 
 
 @pytest.fixture

--- a/tests/test_base_regressor_subclasses.py
+++ b/tests/test_base_regressor_subclasses.py
@@ -64,6 +64,7 @@ DEFAULT_OBS_SHAPE = {
 HARD_CODED_GET_PARAMS_KEYS = {
     "GLM": {
         "fit_intercept",
+        "fix_params",
         "inverse_link_function",
         "observation_model",
         "regularizer",
@@ -73,6 +74,7 @@ HARD_CODED_GET_PARAMS_KEYS = {
     },
     "ClassifierGLM": {
         "fit_intercept",
+        "fix_params",
         "inverse_link_function",
         "n_classes",
         "regularizer",
@@ -81,7 +83,9 @@ HARD_CODED_GET_PARAMS_KEYS = {
         "solver_name",
     },
     "ClassifierPopulationGLM": {
+        "feature_mask",
         "fit_intercept",
+        "fix_params",
         "inverse_link_function",
         "n_classes",
         "regularizer",
@@ -90,14 +94,15 @@ HARD_CODED_GET_PARAMS_KEYS = {
         "solver_name",
     },
     "PopulationGLM": {
+        "feature_mask",
         "fit_intercept",
+        "fix_params",
         "inverse_link_function",
         "observation_model",
         "regularizer",
         "regularizer_strength",
         "solver_kwargs",
         "solver_name",
-        "feature_mask",
     },
     "GLMHMM": {
         "dirichlet_initial_proba",

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -3449,16 +3449,33 @@ def test_estimate_dof_resid_feature_mask(
         (nmo.regularizer.Ridge(), _DOF_MASK_COUNT),
     ],
 )
-@pytest.mark.parametrize("fit_intercept", [True, False])
+@pytest.mark.parametrize(
+    "fit_intercept, init_intercept, warn_match",
+    [
+        (True, "pinned_value", None),
+        # a frozen intercept handed the value it is pinned at discards nothing
+        (False, "pinned_value", None),
+        # handed anything else, the value is dropped and the user is told
+        (False, "other_value", "the provided intercept is ignored"),
+    ],
+)
 @pytest.mark.requires_x64
 def test_dof_resid_after_fit_feature_mask(
-    reg, dof_per_neuron, fit_intercept, request, patch_optimizer_run
+    reg,
+    dof_per_neuron,
+    fit_intercept,
+    init_intercept,
+    warn_match,
+    request,
+    patch_optimizer_run,
+    recwarn,
 ):
     """fit stores the per-neuron DOF of the masked model.
 
     The solver is a no-op returning ``init_params``, so the fitted coefficients are the
     injected ones and the DOF is fully determined. With ``fit_intercept=False`` the
-    intercept is frozen out of the partition and costs no DOF.
+    intercept is frozen out of the partition and costs no DOF, whatever intercept the
+    caller passed in.
     """
     _, _, model, _, _ = request.getfixturevalue(
         "population_poissonGLM_model_instantiation"
@@ -3474,18 +3491,18 @@ def test_dof_resid_after_fit_feature_mask(
 
     X = _set_masked_state(model, False, as_pytree=False)
     # hand the sparse state to fit as the starting point, leaving the model unfitted
-    init_params = (model.coef_, model.intercept_)
+    offset = 1.0 if init_intercept == "other_value" else 0.0
+    intercept = model.intercept_ + offset
+    init_params = (model.coef_, intercept)
     model.coef_, model.intercept_ = None, None
     y = np.ones((X.shape[0], _DOF_N_NEURONS))
 
-    # the injected init_params carry an intercept, which a frozen intercept discards
-    warns_ignored_intercept = (
-        does_not_raise()
-        if fit_intercept
-        else pytest.warns(UserWarning, match="the provided intercept is ignored")
-    )
-    with warns_ignored_intercept:
+    if warn_match is None:
         model.fit(X, y, init_params=init_params)
+        assert not [w for w in recwarn if issubclass(w.category, UserWarning)]
+    else:
+        with pytest.warns(UserWarning, match=warn_match):
+            model.fit(X, y, init_params=init_params)
 
     intercept_dof = 1 if fit_intercept else 0
     np.testing.assert_allclose(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -203,14 +203,14 @@ def get_param_shape(model, X, y):
     return jax.tree_util.tree_map(lambda x: x.shape, empty_par)
 
 
-def _group_lasso_model(mask):
+def _group_lasso_model(mask_kind):
     """GLM with a GroupLasso over 5 features split into 2 groups."""
     group_mask = np.zeros((2, 5))
     group_mask[0, :2] = 1
     group_mask[1, 2:] = 1
     mask = (
         GLMParams(coef=group_mask, intercept=None)
-        if mask == "structured"
+        if mask_kind == "structured"
         else group_mask
     )
     model = nmo.glm.GLM(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -25,6 +25,7 @@ import nemos as nmo
 from conftest import initialize_feature_mask_for_population_glm
 from nemos._observation_model_builder import instantiate_observation_model
 from nemos._regularizer_builder import instantiate_regularizer
+from nemos.glm.params import GLMParams
 from nemos.inverse_link_function_utils import identity, log_softmax
 from nemos.tree_utils import (
     pytree_map_and_reduce,
@@ -200,6 +201,53 @@ def test_get_fit_attrs(
 def get_param_shape(model, X, y):
     empty_par = model._validator.get_empty_params(X, y)
     return jax.tree_util.tree_map(lambda x: x.shape, empty_par)
+
+
+def _group_lasso_model(mask):
+    return nmo.glm.GLM(
+        regularizer=nmo.regularizer.GroupLasso(mask=mask),
+        regularizer_strength=0.1,
+        solver_name="ProximalGradient",
+    )
+
+
+@pytest.mark.parametrize("structured_mask", [False, True])
+def test_save_and_load_group_lasso_mask(
+    structured_mask, group_lasso_2groups_5features_regularizer, tmp_path
+):
+    """A GroupLasso mask round-trips whether it is a plain array or a GLMParams."""
+    array_mask = group_lasso_2groups_5features_regularizer.mask
+    mask = GLMParams(coef=array_mask, intercept=None) if structured_mask else array_mask
+
+    save_path = tmp_path / "group_lasso.npz"
+    _group_lasso_model(mask).save_params(save_path)
+    loaded_mask = nmo.load_model(save_path).regularizer.mask
+
+    assert type(loaded_mask) is type(mask)
+    if structured_mask:
+        np.testing.assert_allclose(loaded_mask.coef, mask.coef)
+        assert loaded_mask.intercept is None
+    else:
+        np.testing.assert_allclose(loaded_mask, mask)
+
+
+def test_structured_mask_saved_without_pickled_objects(
+    group_lasso_2groups_5features_regularizer, tmp_path
+):
+    """No entry is an object array, which ``load_model`` could never read back.
+
+    ``load_model`` opens the archive with ``allow_pickle=False``, so a parameter numpy
+    can only hold as an object array makes the whole file unloadable.
+    """
+    mask = GLMParams(
+        coef=group_lasso_2groups_5features_regularizer.mask, intercept=None
+    )
+    save_path = tmp_path / "no_objects.npz"
+    _group_lasso_model(mask).save_params(save_path)
+
+    with np.load(save_path, allow_pickle=True) as data:
+        pickled = [key for key in data.files if data[key].dtype == object]
+    assert pickled == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -204,46 +204,50 @@ def get_param_shape(model, X, y):
 
 
 def _group_lasso_model(mask):
-    return nmo.glm.GLM(
+    """GLM with a GroupLasso over 5 features split into 2 groups."""
+    group_mask = np.zeros((2, 5))
+    group_mask[0, :2] = 1
+    group_mask[1, 2:] = 1
+    mask = (
+        GLMParams(coef=group_mask, intercept=None)
+        if mask == "structured"
+        else group_mask
+    )
+    model = nmo.glm.GLM(
         regularizer=nmo.regularizer.GroupLasso(mask=mask),
         regularizer_strength=0.1,
         solver_name="ProximalGradient",
     )
+    return model, mask
 
 
-@pytest.mark.parametrize("structured_mask", [False, True])
-def test_save_and_load_group_lasso_mask(
-    structured_mask, group_lasso_2groups_5features_regularizer, tmp_path
-):
+@pytest.mark.parametrize("mask_kind", ["array", "structured"])
+def test_save_and_load_group_lasso_mask(mask_kind, tmp_path):
     """A GroupLasso mask round-trips whether it is a plain array or a GLMParams."""
-    array_mask = group_lasso_2groups_5features_regularizer.mask
-    mask = GLMParams(coef=array_mask, intercept=None) if structured_mask else array_mask
+    model, mask = _group_lasso_model(mask_kind)
 
     save_path = tmp_path / "group_lasso.npz"
-    _group_lasso_model(mask).save_params(save_path)
+    model.save_params(save_path)
     loaded_mask = nmo.load_model(save_path).regularizer.mask
 
-    assert type(loaded_mask) is type(mask)
-    if structured_mask:
+    if mask_kind == "structured":
+        assert isinstance(loaded_mask, GLMParams)
         np.testing.assert_allclose(loaded_mask.coef, mask.coef)
         assert loaded_mask.intercept is None
     else:
+        assert not isinstance(loaded_mask, GLMParams)
         np.testing.assert_allclose(loaded_mask, mask)
 
 
-def test_structured_mask_saved_without_pickled_objects(
-    group_lasso_2groups_5features_regularizer, tmp_path
-):
+def test_structured_mask_saved_without_pickled_objects(tmp_path):
     """No entry is an object array, which ``load_model`` could never read back.
 
     ``load_model`` opens the archive with ``allow_pickle=False``, so a parameter numpy
     can only hold as an object array makes the whole file unloadable.
     """
-    mask = GLMParams(
-        coef=group_lasso_2groups_5features_regularizer.mask, intercept=None
-    )
+    model, _ = _group_lasso_model("structured")
     save_path = tmp_path / "no_objects.npz"
-    _group_lasso_model(mask).save_params(save_path)
+    model.save_params(save_path)
 
     with np.load(save_path, allow_pickle=True) as data:
         pickled = [key for key in data.files if data[key].dtype == object]

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1108,7 +1108,7 @@ class TestGLM:
         ],
     )
     @pytest.mark.parametrize(
-        "model_class, fit_state_attrs",
+        "model_class, fit_state_attrs, fix_params",
         [
             (
                 nmo.glm.GLM,
@@ -1121,6 +1121,9 @@ class TestGLM:
                     "dof_resid_": 3,
                     "aux_": None,
                 },
+                # coef pinned, intercept left learnable: a spec with both an array and a
+                # ``None`` leaf, the latter being the fragile half of the round-trip
+                (jnp.ones((3,)), None),
             ),
             (
                 nmo.glm.PopulationGLM,
@@ -1131,6 +1134,7 @@ class TestGLM:
                     "dof_resid_": 3,
                     "aux_": None,
                 },
+                (jnp.ones((3, 1)), None),
             ),
             (
                 nmo.glm.ClassifierGLM,
@@ -1142,6 +1146,7 @@ class TestGLM:
                     "aux_": None,
                     "classes_": np.array([2, 3]),
                 },
+                (jnp.ones((3, 2)), None),
             ),
             (
                 nmo.glm.ClassifierPopulationGLM,
@@ -1153,6 +1158,7 @@ class TestGLM:
                     "aux_": None,
                     "classes_": np.array([2, 3]),
                 },
+                (jnp.ones((3, 1, 2)), None),
             ),
         ],
     )
@@ -1161,6 +1167,7 @@ class TestGLM:
         regularizer,
         obs_model,
         solver_name,
+        fix_params,
         tmp_path,
         glm_class_type,
         fit_state_attrs,
@@ -1186,6 +1193,7 @@ class TestGLM:
             regularizer=regularizer,
             regularizer_strength=2.0,
             solver_kwargs={"tol": 10**-6},
+            fix_params=fix_params,
         )
         clean_kwargs = dict(
             (k, p) for k, p in kwargs.items() if k in model_class._get_param_names()
@@ -1231,6 +1239,20 @@ class TestGLM:
                 assert np.allclose(
                     np.array(init_val), np.array(load_val)
                 ), f"{key} array mismatch"
+            elif isinstance(init_val, tuple):
+                # e.g. ``fix_params``: compare leafwise, keeping ``None`` a leaf so a
+                # dropped one cannot pass as an empty pytree node
+                is_none = lambda leaf: leaf is None
+                init_leaves = jax.tree_util.tree_leaves(init_val, is_leaf=is_none)
+                load_leaves = jax.tree_util.tree_leaves(load_val, is_leaf=is_none)
+                assert len(init_leaves) == len(
+                    load_leaves
+                ), f"{key} structure mismatch: {init_val} != {load_val}"
+                for init_leaf, load_leaf in zip(init_leaves, load_leaves):
+                    if init_leaf is None:
+                        assert load_leaf is None, f"{key} lost a None leaf"
+                    else:
+                        np.testing.assert_allclose(load_leaf, init_leaf)
             elif isinstance(init_val, Callable):
                 assert _get_name(init_val) == _get_name(
                     load_val

--- a/tests/test_glm_initialization.py
+++ b/tests/test_glm_initialization.py
@@ -35,7 +35,9 @@ from nemos.inverse_link_function_utils import exp as nmo_exp
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_invert_non_linearity(non_linearity, output_y):
     inv_y = initialize_intercept_matching_mean_rate(
-        inverse_link_function=non_linearity, y=output_y
+        inverse_link_function=non_linearity,
+        X=np.zeros((output_y.shape[0], 1)),
+        y=output_y,
     )
     assert jnp.allclose(non_linearity(inv_y), jnp.mean(output_y, axis=0), rtol=10**-5)
 
@@ -81,7 +83,9 @@ def test_initialization_error_nan_input(non_linearity, expectation):
     output_y = np.full((10, 2), np.nan)
     with expectation:
         initialize_intercept_matching_mean_rate(
-            inverse_link_function=non_linearity, y=output_y
+            inverse_link_function=non_linearity,
+            X=np.zeros((output_y.shape[0], 1)),
+            y=output_y,
         )
 
 
@@ -98,7 +102,9 @@ def test_initialization_error_non_invertible():
                 "ignore", category=RuntimeWarning, message="Tolerance of"
             )
             initialize_intercept_matching_mean_rate(
-                inverse_link_function=inv_link, y=output_y
+                inverse_link_function=inv_link,
+                X=np.zeros((output_y.shape[0], 1)),
+                y=output_y,
             )
 
 
@@ -106,7 +112,9 @@ def test_initialization_error_logistic_all_one_output():
     output_y = np.ones(10)
     with pytest.raises(ValueError, match="has non-finite values"):
         initialize_intercept_matching_mean_rate(
-            inverse_link_function=jax.lax.logistic, y=output_y
+            inverse_link_function=jax.lax.logistic,
+            X=np.zeros((output_y.shape[0], 1)),
+            y=output_y,
         )
 
 
@@ -173,6 +181,7 @@ def _make_y(n=4000, n_neurons=None, seed=1):
 )
 @pytest.mark.parametrize("as_dict", [False, True])
 @pytest.mark.parametrize("n_neurons", [None, 2])
+@pytest.mark.requires_x64
 def test_constant_coef_satisfies_normal_equation(design, as_dict, n_neurons):
     """The constant is the least-squares minimizer, i.e. it satisfies the
     (eps-regularized) normal equation ``c (Σs² + eps) = η* (Σs + eps)``."""
@@ -210,7 +219,7 @@ def test_constant_coef_satisfies_normal_equation(design, as_dict, n_neurons):
         assert jnp.allclose(c, jnp.broadcast_to(const, c.shape), rtol=1e-5)
 
     # normal-equation identity, verified independently of the closed-form impl
-    eta = initialize_intercept_matching_mean_rate(nmo_exp, y)  # (n_out,)
+    eta = initialize_intercept_matching_mean_rate(nmo_exp, X, y)  # (n_out,)
     s = _row_sum(X)
     eps = jnp.finfo(s.dtype).eps
     lhs = jnp.atleast_1d(const) * (jnp.sum(s**2) + eps)
@@ -221,14 +230,12 @@ def test_constant_coef_satisfies_normal_equation(design, as_dict, n_neurons):
 @pytest.mark.parametrize("design", ["all_zero"], indirect=True)
 def test_constant_coef_all_zero_design_equals_target(design):
     """With an all-zero design no constant can inject an offset; the eps
-    stabilization returns c = η* and stays finite (no NaN)."""
+    stabilization returns c = 1 and stays finite (no NaN)."""
     y = _make_y()
     coef = initialize_constant_coef_matching_mean_rate(
         nmo_exp, design, y, jnp.empty((3,))
     )
-    eta = initialize_intercept_matching_mean_rate(nmo_exp, y)
-    assert jnp.all(jnp.isfinite(coef))
-    assert jnp.allclose(coef, eta)
+    assert jnp.allclose(coef, 1)
 
 
 @pytest.mark.parametrize("design", ["centered"], indirect=True)

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -214,20 +214,20 @@ def test_newton_glm_instantiate_solver(regularizer_name, glm_class):
 
 
 def _freeze_first_coef_leaf(model, params):
-    """Build a ``_fix_params`` spec pinning the first ``coef`` leaf to its true value.
+    """Build a ``fix_params`` spec pinning the first ``coef`` leaf to its true value.
 
     Freezing a coefficient leaf rather than the intercept is what exercises the
     ``coef`` block of the Hessian: the intercept is a single row, so dropping it
     leaves the interesting block untouched.
     """
     leaves, treedef = jax.tree_util.tree_flatten(params.coef)
-    # cast the pinned leaf: ``fit`` casts its inputs, so an un-cast spec would be
-    # compared against a fitted leaf of a different dtype
     spec = jax.tree_util.tree_unflatten(
-        treedef, [jnp.asarray(leaves[0])] + [None] * (len(leaves) - 1)
+        treedef, [leaves[0]] + [None] * (len(leaves) - 1)
     )
-    model._fix_params = GLMParams(spec, None)
-    return spec
+    model.fix_params = (spec, None)
+    # read the spec back: the setter validates and casts it, so this is the value
+    # the frozen leaf is actually pinned to
+    return model.fix_params[0]
 
 
 @pytest.mark.requires_x64
@@ -295,16 +295,7 @@ def test_newton_leaves_frozen_params_untouched(
         )
     else:
         pinned = _freeze_first_coef_leaf(frozen_model, true_params)
-        # the spec decides which leaves the solver skips, not what they are worth: a
-        # frozen leaf is held at whatever the initialization put there. The intercept
-        # is filled from the spec at init time, a coef leaf is not, so the pinned value
-        # is handed in through ``init_params`` for the fitted leaf to be comparable.
-        zeros = jax.tree_util.tree_map(jnp.zeros_like, true_params.coef)
-        init_params = (
-            eqx.combine(pinned, zeros),
-            jnp.zeros_like(true_params.intercept),
-        )
-        frozen_model.fit(X, y, init_params=init_params)
+        frozen_model.fit(X, y)
         fitted = jax.tree_util.tree_leaves(frozen_model.coef_)[0]
         np.testing.assert_array_equal(fitted, jax.tree_util.tree_leaves(pinned)[0])
 
@@ -387,7 +378,7 @@ def test_population_glm_hess_fn_drops_frozen_leaves(freeze, request):
         assert hess.intercept is None
         assert all(row.intercept is None for row in hess.coef.values())
     else:
-        pinned = sorted(model._fix_params.coef)[0]
+        pinned = sorted(model.fix_params[0])[0]
         assert active.coef[pinned] is None
         assert hess.coef[pinned] is None
         # the frozen leaf is dropped as a column too, not just as a row

--- a/tests/test_observation_models.py
+++ b/tests/test_observation_models.py
@@ -346,7 +346,9 @@ class TestPoissonObservations:
         # Validate custom link function
         expected_output = jnp.sqrt(test_value)
         result = initialize_intercept_matching_mean_rate(
-            model.observation_model.inverse_link_function, test_value
+            model.observation_model.inverse_link_function,
+            jnp.zeros((test_value.shape[0], 1)),
+            test_value,
         )
 
         assert np.allclose(

--- a/tests/test_partial_param_spec.py
+++ b/tests/test_partial_param_spec.py
@@ -5,10 +5,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-
-import nemos as nmo
 from sklearn.base import clone
 
+import nemos as nmo
 from nemos.batching import ArrayDataLoader
 from nemos.callbacks import Callback
 from nemos.glm.params import GLMParams

--- a/tests/test_partial_param_spec.py
+++ b/tests/test_partial_param_spec.py
@@ -1,7 +1,4 @@
-"""Tests for the partial parameter specification (``fix_params``) machinery.
-
-Tree algebra only: no optimization runs here.
-"""
+"""Tests for the partial parameter specification (``fix_params``) machinery."""
 
 import equinox as eqx
 import jax
@@ -10,8 +7,37 @@ import numpy as np
 import pytest
 
 import nemos as nmo
+from nemos.batching import ArrayDataLoader
+from nemos.callbacks import Callback
+from nemos.solvers._abstract_solver import AbstractSolver
 from nemos.solvers._no_op import NoOpSolver
 from nemos.tree_utils import tree_broadcast_prefix
+
+
+class _RecordingCallback(Callback):
+    """Records which hooks the solver invoked, in order."""
+
+    def __init__(self):
+        self.calls = []
+
+    def on_train_begin(self, ctx):
+        self.calls.append("on_train_begin")
+
+    def on_train_end(self, ctx):
+        self.calls.append("on_train_end")
+
+    def on_pass_begin(self, ctx):
+        self.calls.append("on_pass_begin")
+
+    def on_pass_end(self, ctx):
+        self.calls.append("on_pass_end")
+
+    def on_batch_begin(self, ctx):
+        self.calls.append("on_batch_begin")
+
+    def on_batch_end(self, ctx):
+        self.calls.append("on_batch_end")
+
 
 # conftest fixtures, picked to vary the coef pytree structure and the intercept shape
 MODEL_FIXTURES = [
@@ -219,45 +245,24 @@ class CoefModule(eqx.Module):
     b: object
 
 
-def _custom_node_model(poissonGLM_model_instantiation, tmp_path):
-    """Save a model whose ``fix_params`` coef is a custom pytree node."""
+def test_user_defined_node_spec_cannot_be_loaded(
+    poissonGLM_model_instantiation, tmp_path
+):
+    """A spec built on a user-defined pytree node saves, then fails to load.
+
+    Only nemos-native containers are rebuilt at load time, so a foreign node reaches the
+    archive as an object array. Saving still succeeds: unserializable pieces are meant to
+    be supplied back through ``mapping_dict``, which accepts callables and classes only
+    and so cannot carry a parameter spec.
+    """
     X, y, model = poissonGLM_model_instantiation[:3]
-    spec = CoefModule(jnp.ones((3,)), None)
-    model.fix_params = (spec, None)
+    model.fix_params = (CoefModule(jnp.ones((3,)), None), None)
 
     path = tmp_path / "model.npz"
     model.save_params(path)
-    return path, spec
-
-
-def test_custom_node_spec_saves_but_needs_a_mapping(
-    poissonGLM_model_instantiation, tmp_path
-):
-    """Saving a custom-node spec succeeds; a bare load cannot read it back."""
-    path, _ = _custom_node_model(poissonGLM_model_instantiation, tmp_path)
 
     with pytest.raises(ValueError, match="allow_pickle=False"):
         nmo.load_model(path)
-
-
-@pytest.mark.xfail(
-    reason="load_model unflattens every key before applying mapping_dict, so the "
-    "mapping cannot rescue a fix_params spec holding a custom pytree node",
-    raises=ValueError,
-    strict=True,
-)
-def test_custom_node_spec_recoverable_through_mapping(
-    poissonGLM_model_instantiation, tmp_path
-):
-    """``mapping_dict`` should supply back a spec that could not be serialized."""
-    path, spec = _custom_node_model(poissonGLM_model_instantiation, tmp_path)
-
-    loaded = nmo.load_model(path, mapping_dict={"fix_params": (spec, None)})
-
-    coef_spec = loaded.fix_params[0]
-    assert isinstance(coef_spec, CoefModule)
-    np.testing.assert_array_equal(coef_spec.a, spec.a)
-    assert coef_spec.b is None
 
 
 def _pin_everything(model, X, y):
@@ -338,3 +343,87 @@ class TestEveryParameterFixed:
         assert [
             w for w in recwarn if "Every parameter is fixed" in str(w.message)
         ] == []
+
+    @pytest.mark.parametrize("solver_name", ["LBFGS", "Newton"])
+    def test_fit_pins_values_for_hessian_and_gradient_solvers(
+        self, poissonGLM_model_instantiation, solver_name
+    ):
+        """Newton needs a Hessian the stand-in never supplies, and still short-circuits.
+
+        ``setup_hessian`` is only reached while instantiating a real solver, which the
+        empty-tree case skips, so no Newton-specific hook is required of the stand-in.
+        """
+        X, y, model = poissonGLM_model_instantiation[:3]
+        coef, intercept = _pin_everything(model, X, y)
+        model.set_params(fix_params=(coef, intercept), solver_name=solver_name)
+
+        with pytest.warns(UserWarning, match="Every parameter is fixed"):
+            model.fit(X, y)
+
+        np.testing.assert_array_equal(model.coef_, coef)
+        np.testing.assert_array_equal(model.intercept_, intercept)
+        assert isinstance(model.solver, NoOpSolver)
+
+    def test_stochastic_fit_returns_the_pinned_values(
+        self, poissonGLM_model_instantiation
+    ):
+        """``stochastic_fit`` reaches the solver directly, so it needs its own coverage."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        coef, intercept = _pin_everything(model, X, y)
+        model.set_params(fix_params=(coef, intercept), solver_name="SVRG")
+
+        with pytest.warns(UserWarning, match="Every parameter is fixed"):
+            model.stochastic_fit(ArrayDataLoader(X, y, batch_size=32), n_passes=2)
+
+        np.testing.assert_array_equal(model.coef_, coef)
+        np.testing.assert_array_equal(model.intercept_, intercept)
+
+    def test_stochastic_fit_pins_a_frozen_leaf_exactly(
+        self, poissonGLM_model_instantiation, recwarn
+    ):
+        """With coef free, the real stochastic solver runs and never moves the intercept."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        _, intercept = _pin_everything(model, X, y)
+        model.set_params(fix_params=(None, intercept), solver_name="SVRG")
+
+        model.stochastic_fit(ArrayDataLoader(X, y, batch_size=32), n_passes=2)
+
+        np.testing.assert_array_equal(model.intercept_, intercept)
+        assert not isinstance(model.solver, NoOpSolver)
+        assert [
+            w for w in recwarn if "Every parameter is fixed" in str(w.message)
+        ] == []
+
+    def test_stochastic_fit_skips_the_data_passes(self, poissonGLM_model_instantiation):
+        """No pass or batch runs, so only the train-level callbacks fire.
+
+        Iterating the loader could not change a fully fixed tree, and for out-of-memory
+        data it would read everything to no effect.
+        """
+        X, y, model = poissonGLM_model_instantiation[:3]
+        model.set_params(fix_params=_pin_everything(model, X, y), solver_name="SVRG")
+        callback = _RecordingCallback()
+
+        with pytest.warns(UserWarning, match="Every parameter is fixed"):
+            model.stochastic_fit(
+                ArrayDataLoader(X, y, batch_size=32), n_passes=3, callbacks=callback
+            )
+
+        assert callback.calls == ["on_train_begin", "on_train_end"]
+
+
+def test_no_op_solver_covers_the_solver_interface():
+    """``NoOpSolver`` replaces any configured solver, so it must implement all of it.
+
+    The model reaches for solver methods after initialization — ``stochastic_run`` is one
+    — and a missing one only shows up as an ``AttributeError`` mid-fit. Comparing the
+    public surface catches that when the interface grows, e.g. a Hessian mixin.
+    """
+    expected = {
+        name
+        for name in dir(AbstractSolver)
+        if not name.startswith("_") and callable(getattr(AbstractSolver, name, None))
+    }
+
+    missing = sorted(name for name in expected if not hasattr(NoOpSolver, name))
+    assert missing == []

--- a/tests/test_partial_param_spec.py
+++ b/tests/test_partial_param_spec.py
@@ -1,0 +1,340 @@
+"""Tests for the partial parameter specification (``fix_params``) machinery.
+
+Tree algebra only: no optimization runs here.
+"""
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import nemos as nmo
+from nemos.solvers._no_op import NoOpSolver
+from nemos.tree_utils import tree_broadcast_prefix
+
+# conftest fixtures, picked to vary the coef pytree structure and the intercept shape
+MODEL_FIXTURES = [
+    "poissonGLM_model_instantiation",  # coef: one array
+    "poissonGLM_model_instantiation_pytree",  # coef: dict of two arrays
+    "population_poissonGLM_model_instantiation",  # 2-D coef, (n_neurons,) intercept
+    "population_poissonGLM_model_instantiation_pytree",
+    "classifierGLM_model_instantiation",
+]
+
+COEF_MODES = ["learn_all", "pin_all", "pin_first"]
+
+
+def _coef_spec(model, X, y, mode):
+    """Coef spec mirroring ``X``: ``None`` learns a leaf, an array pins it."""
+    if mode == "learn_all":
+        return None
+
+    empty_coef = model._validator.get_empty_params(X, y).coef
+    if mode == "pin_all":
+        return jax.tree_util.tree_map(jnp.ones_like, empty_coef)
+
+    seen = []
+
+    def pin_first(leaf):
+        seen.append(None)
+        return jnp.ones_like(leaf) if len(seen) == 1 else None
+
+    return jax.tree_util.tree_map(pin_first, empty_coef)
+
+
+def _pinned_intercept(model, X, y):
+    """A pinned intercept of the shape this model expects."""
+    return jnp.full_like(model._validator.get_empty_params(X, y).intercept, 0.5)
+
+
+def _leaves(tree):
+    """Leaves of ``tree``, treating ``None`` as a leaf rather than an empty node."""
+    return jax.tree_util.tree_leaves(tree, is_leaf=lambda x: x is None)
+
+
+def _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept):
+    """Apply a spec through the public setters, returning the model."""
+    intercept = _pinned_intercept(model, X, y) if intercept_pinned else None
+    model.fix_params = (_coef_spec(model, X, y, coef_mode), intercept)
+    model.fit_intercept = fit_intercept
+    return model
+
+
+@pytest.mark.parametrize("model_fixture", MODEL_FIXTURES)
+@pytest.mark.parametrize("coef_mode", COEF_MODES)
+@pytest.mark.parametrize("intercept_pinned", [False, True])
+@pytest.mark.parametrize("fit_intercept", [True, False])
+class TestSpecAlgebra:
+    """``_active_filter_spec`` / ``_frozen_values`` / ``_partition_active``."""
+
+    def test_active_spec_matches_fix_params(
+        self, request, model_fixture, coef_mode, intercept_pinned, fit_intercept
+    ):
+        """A coef leaf is active iff the user left it ``None`` in the spec."""
+        X, y, model = request.getfixturevalue(model_fixture)[:3]
+        _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept)
+
+        active = model._active_filter_spec()
+        if coef_mode == "learn_all":
+            # a wholly-unset spec collapses to the single prefix value ``True``
+            assert all(bool(leaf) for leaf in _leaves(active.coef))
+        else:
+            expected = jax.tree_util.tree_map(
+                lambda spec: spec is None,
+                model.fix_params[0],
+                is_leaf=lambda x: x is None,
+            )
+            assert _leaves(active.coef) == _leaves(expected)
+
+    def test_intercept_active_only_when_free_and_unpinned(
+        self, request, model_fixture, coef_mode, intercept_pinned, fit_intercept
+    ):
+        """Either mechanism freezes the intercept; it is active only if neither fires."""
+        X, y, model = request.getfixturevalue(model_fixture)[:3]
+        _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept)
+
+        expected = fit_intercept and not intercept_pinned
+        assert bool(model._active_filter_spec().intercept) is expected
+
+    def test_filter_spec_and_frozen_values_are_complements(
+        self, request, model_fixture, coef_mode, intercept_pinned, fit_intercept
+    ):
+        """A leaf is inactive iff ``_frozen_values`` holds a concrete array for it."""
+        X, y, model = request.getfixturevalue(model_fixture)[:3]
+        _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept)
+
+        # expand against params, not frozen: None leaves would swallow the broadcast
+        params = model._validator.get_empty_params(X, y)
+        active = tree_broadcast_prefix(model._active_filter_spec(), params)
+        frozen = model._frozen_values(X, y)
+
+        for is_active, frozen_leaf in zip(_leaves(active), _leaves(frozen)):
+            assert bool(is_active) is (
+                frozen_leaf is None
+            ), f"active={is_active!r} but frozen={frozen_leaf!r}"
+
+    def test_partition_recombines_exactly(
+        self, request, model_fixture, coef_mode, intercept_pinned, fit_intercept
+    ):
+        """``_partition_active`` loses nothing: the halves recombine to the input."""
+        X, y, model = request.getfixturevalue(model_fixture)[:3]
+        _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept)
+
+        params = jax.tree_util.tree_map(
+            jnp.ones_like, model._validator.get_empty_params(X, y)
+        )
+        recombined = eqx.combine(*model._partition_active(params))
+
+        assert jax.tree_util.tree_structure(recombined) == jax.tree_util.tree_structure(
+            params
+        )
+        for got, want in zip(_leaves(recombined), _leaves(params)):
+            np.testing.assert_array_equal(got, want)
+
+
+class TestInterceptPrecedence:
+    """``fit_intercept=False`` and a pinned intercept are two paths to one frozen leaf."""
+
+    @pytest.mark.parametrize("fit_intercept", [True, False])
+    def test_pinned_intercept_wins_over_fit_intercept(
+        self, poissonGLM_model_instantiation, fit_intercept
+    ):
+        """A pinned intercept is honoured whatever ``fit_intercept`` says."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        pinned = _pinned_intercept(model, X, y)
+        model.fix_params = (None, pinned)
+        model.fit_intercept = fit_intercept
+
+        np.testing.assert_array_equal(model._frozen_values(X, y).intercept, pinned)
+
+    def test_fit_intercept_false_pins_zero_when_unpinned(
+        self, poissonGLM_model_instantiation
+    ):
+        """With nothing pinned, ``fit_intercept=False`` supplies the zero itself."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        model.fit_intercept = False
+
+        frozen = model._frozen_values(X, y)
+        np.testing.assert_array_equal(
+            frozen.intercept, jnp.zeros_like(frozen.intercept)
+        )
+        assert bool(model._active_filter_spec().intercept) is False
+
+    def test_default_freezes_nothing_and_warns_nothing(
+        self, poissonGLM_model_instantiation, recwarn
+    ):
+        """The default combination leaves the intercept free and warns about nothing."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+
+        assert model._frozen_values(X, y).intercept is None
+        assert bool(model._active_filter_spec().intercept) is True
+        assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+
+    def test_flipping_fit_intercept_changes_the_partition(
+        self, poissonGLM_model_instantiation
+    ):
+        """The two mechanisms stay consistent when the flag flips after construction."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        assert bool(model._active_filter_spec().intercept) is True
+
+        model.fit_intercept = False
+        frozen = model._frozen_values(X, y)
+        assert bool(model._active_filter_spec().intercept) is False
+        np.testing.assert_array_equal(
+            frozen.intercept, jnp.zeros_like(frozen.intercept)
+        )
+
+
+@pytest.mark.parametrize("model_fixture", MODEL_FIXTURES)
+@pytest.mark.parametrize("coef_mode", COEF_MODES)
+@pytest.mark.parametrize("intercept_pinned", [False, True])
+def test_fix_params_survives_save_load(
+    request, tmp_path, model_fixture, coef_mode, intercept_pinned
+):
+    """``fix_params`` round-trips through ``.npz``, ``None`` leaves included."""
+    X, y, model = request.getfixturevalue(model_fixture)[:3]
+    _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept=True)
+
+    path = tmp_path / "model.npz"
+    model.save_params(path)
+    loaded = nmo.load_model(path)
+
+    before, after = model.fix_params, loaded.fix_params
+    is_none = lambda x: x is None
+    assert jax.tree_util.tree_structure(
+        after, is_leaf=is_none
+    ) == jax.tree_util.tree_structure(before, is_leaf=is_none)
+    for got, want in zip(_leaves(after), _leaves(before)):
+        if want is None:
+            assert got is None
+        else:
+            np.testing.assert_array_equal(got, want)
+
+
+class CoefModule(eqx.Module):
+    """Custom pytree node, standing in for a user-defined coef container."""
+
+    a: jnp.ndarray
+    b: object
+
+
+def _custom_node_model(poissonGLM_model_instantiation, tmp_path):
+    """Save a model whose ``fix_params`` coef is a custom pytree node."""
+    X, y, model = poissonGLM_model_instantiation[:3]
+    spec = CoefModule(jnp.ones((3,)), None)
+    model.fix_params = (spec, None)
+
+    path = tmp_path / "model.npz"
+    model.save_params(path)
+    return path, spec
+
+
+def test_custom_node_spec_saves_but_needs_a_mapping(
+    poissonGLM_model_instantiation, tmp_path
+):
+    """Saving a custom-node spec succeeds; a bare load cannot read it back."""
+    path, _ = _custom_node_model(poissonGLM_model_instantiation, tmp_path)
+
+    with pytest.raises(ValueError, match="allow_pickle=False"):
+        nmo.load_model(path)
+
+
+@pytest.mark.xfail(
+    reason="load_model unflattens every key before applying mapping_dict, so the "
+    "mapping cannot rescue a fix_params spec holding a custom pytree node",
+    raises=ValueError,
+    strict=True,
+)
+def test_custom_node_spec_recoverable_through_mapping(
+    poissonGLM_model_instantiation, tmp_path
+):
+    """``mapping_dict`` should supply back a spec that could not be serialized."""
+    path, spec = _custom_node_model(poissonGLM_model_instantiation, tmp_path)
+
+    loaded = nmo.load_model(path, mapping_dict={"fix_params": (spec, None)})
+
+    coef_spec = loaded.fix_params[0]
+    assert isinstance(coef_spec, CoefModule)
+    np.testing.assert_array_equal(coef_spec.a, spec.a)
+    assert coef_spec.b is None
+
+
+def _pin_everything(model, X, y):
+    """A ``fix_params`` spec leaving nothing active."""
+    empty = model._validator.get_empty_params(X, y)
+    return (
+        jax.tree_util.tree_map(jnp.ones_like, empty.coef),
+        jnp.full_like(empty.intercept, 0.25),
+    )
+
+
+def _convergence_warnings(recwarn):
+    return [w for w in recwarn if "did not converge" in str(w.message)]
+
+
+class TestEveryParameterFixed:
+    """Entry points return the pinned values rather than driving an empty solver."""
+
+    @pytest.mark.parametrize("model_fixture", MODEL_FIXTURES)
+    def test_fit_returns_the_pinned_values(self, request, model_fixture):
+        """``fit`` skips the solver and reports the fixed values."""
+        X, y, model = request.getfixturevalue(model_fixture)[:3]
+        coef, intercept = _pin_everything(model, X, y)
+        model.fix_params = (coef, intercept)
+
+        with pytest.warns(UserWarning, match="Every parameter is fixed"):
+            model.fit(X, y)
+
+        for got, want in zip(_leaves(model.coef_), _leaves(coef)):
+            np.testing.assert_array_equal(got, want)
+        np.testing.assert_array_equal(model.intercept_, intercept)
+
+    def test_update_returns_the_pinned_values(self, poissonGLM_model_instantiation):
+        """A single ``update`` step is the identity when nothing is active."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        coef, intercept = _pin_everything(model, X, y)
+        model.fix_params = (coef, intercept)
+
+        with pytest.warns(UserWarning, match="Every parameter is fixed"):
+            state = model.initialize_optimizer_and_state((coef, intercept), X, y)
+            model.update((coef, intercept), state, X, y)
+
+        np.testing.assert_array_equal(model.coef_, coef)
+        np.testing.assert_array_equal(model.intercept_, intercept)
+
+    def test_fit_does_not_warn_about_convergence(
+        self, poissonGLM_model_instantiation, recwarn
+    ):
+        """The stand-in state reports convergence, so no second warning fires."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        model.fix_params = _pin_everything(model, X, y)
+
+        model.fit(X, y)
+
+        assert _convergence_warnings(recwarn) == []
+
+    def test_no_op_solver_is_installed(self, poissonGLM_model_instantiation):
+        """The empty-tree case is served by ``NoOpSolver``, not a real solver."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        model.fix_params = _pin_everything(model, X, y)
+
+        with pytest.warns(UserWarning, match="Every parameter is fixed"):
+            model.fit(X, y)
+
+        assert isinstance(model.solver, NoOpSolver)
+
+    def test_freeing_one_leaf_runs_the_real_solver(
+        self, poissonGLM_model_instantiation, recwarn
+    ):
+        """Leaving any leaf active restores the normal path, with no warning."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        _, intercept = _pin_everything(model, X, y)
+        model.fix_params = (None, intercept)
+
+        model.fit(X, y)
+
+        assert not isinstance(model.solver, NoOpSolver)
+        assert [
+            w for w in recwarn if "Every parameter is fixed" in str(w.message)
+        ] == []

--- a/tests/test_partial_param_spec.py
+++ b/tests/test_partial_param_spec.py
@@ -82,6 +82,22 @@ def _leaves(tree):
     return jax.tree_util.tree_leaves(tree, is_leaf=lambda x: x is None)
 
 
+def _assert_same_spec(got, want):
+    """Two specs agree in structure and values, ``None`` leaves included.
+
+    ``None`` is kept a leaf: as an empty pytree node a dropped one would compare equal.
+    """
+    is_none = lambda leaf: leaf is None
+    assert jax.tree_util.tree_structure(
+        got, is_leaf=is_none
+    ) == jax.tree_util.tree_structure(want, is_leaf=is_none)
+    for got_leaf, want_leaf in zip(_leaves(got), _leaves(want)):
+        if want_leaf is None:
+            assert got_leaf is None
+        else:
+            np.testing.assert_array_equal(got_leaf, want_leaf)
+
+
 def _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept):
     """Apply a spec through the public setters, returning the model."""
     intercept = _pinned_intercept(model, X, y) if intercept_pinned else None
@@ -229,16 +245,7 @@ def test_fix_params_survives_save_load(
     model.save_params(path)
     loaded = nmo.load_model(path)
 
-    before, after = model.fix_params, loaded.fix_params
-    is_none = lambda x: x is None
-    assert jax.tree_util.tree_structure(
-        after, is_leaf=is_none
-    ) == jax.tree_util.tree_structure(before, is_leaf=is_none)
-    for got, want in zip(_leaves(after), _leaves(before)):
-        if want is None:
-            assert got is None
-        else:
-            np.testing.assert_array_equal(got, want)
+    _assert_same_spec(loaded.fix_params, model.fix_params)
 
 
 class CoefModule(eqx.Module):
@@ -523,3 +530,62 @@ class TestFrozenValuesEnterTheObjective:
             )
             > 1e-2
         )
+
+
+@pytest.mark.parametrize("model_fixture", MODEL_FIXTURES)
+@pytest.mark.parametrize("coef_mode", COEF_MODES)
+@pytest.mark.parametrize("intercept_pinned", [False, True])
+class TestSpecSurvivesSklearnProtocol:
+    """``fix_params`` travels through ``get_params``/``set_params``/``clone``.
+
+    A spec that does not survive ``clone`` breaks every cross-validation and pipeline
+    silently: sklearn rebuilds the estimator from ``get_params`` before each fit, so the
+    freezing would just stop happening.
+    """
+
+    def test_clone_reproduces_the_spec(
+        self, request, model_fixture, coef_mode, intercept_pinned
+    ):
+        """``clone`` rebuilds from ``get_params`` and must carry the spec across."""
+        X, y, model = request.getfixturevalue(model_fixture)[:3]
+        _configure(model, X, y, coef_mode, intercept_pinned, fit_intercept=True)
+
+        _assert_same_spec(clone(model).fix_params, model.fix_params)
+
+    def test_set_params_applies_the_spec(
+        self, request, model_fixture, coef_mode, intercept_pinned
+    ):
+        """A spec handed to ``set_params`` reads back the same through ``get_params``."""
+        X, y, model = request.getfixturevalue(model_fixture)[:3]
+        spec = (
+            _coef_spec(model, X, y, coef_mode),
+            _pinned_intercept(model, X, y) if intercept_pinned else None,
+        )
+
+        model.set_params(fix_params=spec)
+
+        _assert_same_spec(model.get_params()["fix_params"], spec)
+
+
+def test_set_params_validates_the_spec(poissonGLM_model_instantiation):
+    """``set_params`` rejects what the constructor would reject."""
+    X, y, model = poissonGLM_model_instantiation[:3]
+
+    with pytest.raises(ValueError, match="Intercept term should be"):
+        model.set_params(fix_params=(None, jnp.zeros((5,))))
+
+
+def test_reassigning_the_spec_invalidates_the_solver(poissonGLM_model_instantiation):
+    """A new spec changes the partition, so the built solver is stale."""
+    X, y, model = poissonGLM_model_instantiation[:3]
+    params = model.initialize_params(X, y)
+    model.initialize_optimizer_and_state(params, X, y)
+    assert model._solver is not None
+
+    model.fix_params = (None, _pinned_intercept(model, X, y))
+
+    assert model._solver is None
+    assert model._solver_loss_fun is None
+    assert model._optimizer_init_state is None
+    assert model._optimizer_update is None
+    assert model._optimizer_run is None

--- a/tests/test_partial_param_spec.py
+++ b/tests/test_partial_param_spec.py
@@ -7,8 +7,11 @@ import numpy as np
 import pytest
 
 import nemos as nmo
+from sklearn.base import clone
+
 from nemos.batching import ArrayDataLoader
 from nemos.callbacks import Callback
+from nemos.glm.params import GLMParams
 from nemos.solvers._abstract_solver import AbstractSolver
 from nemos.solvers._no_op import NoOpSolver
 from nemos.tree_utils import tree_broadcast_prefix
@@ -427,3 +430,96 @@ def test_no_op_solver_covers_the_solver_interface():
 
     missing = sorted(name for name in expected if not hasattr(NoOpSolver, name))
     assert missing == []
+
+
+def _solver_grad_norm(model, active, X, y):
+    """Norm of the gradient of the loss the solver minimized, evaluated at ``active``.
+
+    ``_solver_loss_fun`` is the penalized loss closed over the frozen leaves and taking
+    the active subtree alone. The unpenalized model loss is the wrong object: its
+    gradient keeps a residual equal to the penalty gradient, no matter the tolerance.
+    """
+    grad = jax.grad(model._solver_loss_fun)(active, X, y)
+    return float(
+        jnp.sqrt(
+            sum(jnp.sum(jnp.square(leaf)) for leaf in jax.tree_util.tree_leaves(grad))
+        )
+    )
+
+
+def _grad_norm_under_other_spec(model, active, X, y, fix_params, full_params):
+    """``_solver_grad_norm`` at ``active``, but with different values frozen.
+
+    The frozen values are closed over when the solver is built, so the contrast needs a
+    second model carrying the alternative spec.
+    """
+    other = clone(model)
+    other.set_params(fix_params=fix_params)
+    other.initialize_optimizer_and_state(full_params, X, y)
+    return _solver_grad_norm(other, active, X, y)
+
+
+@pytest.mark.requires_x64
+class TestFrozenValuesEnterTheObjective:
+    """Pinned values take part in the objective, not reattached to the result.
+
+    Preservation alone cannot detect a frozen leaf dropped from the linear predictor: the
+    returned parameters look identical either way. The active gradient of the solver's own
+    loss vanishes at the fitted point only if the pinned value was in the objective, so
+    freezing a different value there must spoil stationarity.
+    """
+
+    def test_pinned_intercept_is_used_by_the_loss(self, poissonGLM_model_instantiation):
+        """coef converges to the optimum *given* the pinned intercept."""
+        X, y, model = poissonGLM_model_instantiation[:3]
+        pinned = _pinned_intercept(model, X, y)
+        model.set_params(fix_params=(None, pinned), solver_kwargs={"tol": 1e-12})
+
+        model.fit(X, y)
+
+        np.testing.assert_allclose(model.intercept_, pinned)
+        active, _ = model._partition_active(GLMParams(model.coef_, model.intercept_))
+        zeros = jnp.zeros_like(pinned)
+        # float64 with tol=1e-12 lands at ~1e-13; three orders of margin, no more
+        assert _solver_grad_norm(model, active, X, y) < 1e-10
+        assert (
+            _grad_norm_under_other_spec(
+                model, active, X, y, (None, zeros), (model.coef_, zeros)
+            )
+            > 1e-2
+        )
+
+    def test_pinned_coef_leaf_is_used_by_the_loss(
+        self, poissonGLM_model_instantiation_pytree
+    ):
+        """The free coef leaves converge to the optimum *given* the pinned leaf."""
+        X, y, model = poissonGLM_model_instantiation_pytree[:3]
+        spec = _coef_spec(model, X, y, "pin_first")
+        model.set_params(fix_params=(spec, None), solver_kwargs={"tol": 1e-12})
+
+        model.fit(X, y)
+
+        pinned_key = next(key for key, val in spec.items() if val is not None)
+        np.testing.assert_allclose(model.coef_[pinned_key], spec[pinned_key])
+        active, _ = model._partition_active(GLMParams(model.coef_, model.intercept_))
+        zeroed_spec = {
+            key: jnp.zeros_like(val) if key == pinned_key else val
+            for key, val in spec.items()
+        }
+        zeroed_coef = {
+            key: jnp.zeros_like(leaf) if key == pinned_key else leaf
+            for key, leaf in model.coef_.items()
+        }
+        # float64 with tol=1e-12 lands at ~1e-13; three orders of margin, no more
+        assert _solver_grad_norm(model, active, X, y) < 1e-10
+        assert (
+            _grad_norm_under_other_spec(
+                model,
+                active,
+                X,
+                y,
+                (zeroed_spec, None),
+                (zeroed_coef, model.intercept_),
+            )
+            > 1e-2
+        )

--- a/tests/test_partial_param_spec.py
+++ b/tests/test_partial_param_spec.py
@@ -589,3 +589,24 @@ def test_reassigning_the_spec_invalidates_the_solver(poissonGLM_model_instantiat
     assert model._optimizer_init_state is None
     assert model._optimizer_update is None
     assert model._optimizer_run is None
+
+
+def test_all_fixed_spec_still_short_circuits_after_reload(
+    poissonGLM_model_instantiation, tmp_path
+):
+    """A reloaded all-fixed model round-trips and keeps skipping the solver."""
+    X, y, model = poissonGLM_model_instantiation[:3]
+    coef, intercept = _pin_everything(model, X, y)
+    model.fix_params = (coef, intercept)
+
+    path = tmp_path / "all_fixed.npz"
+    model.save_params(path)
+    loaded = nmo.load_model(path)
+
+    _assert_same_spec(loaded.fix_params, model.fix_params)
+    with pytest.warns(UserWarning, match="Every parameter is fixed"):
+        loaded.fit(X, y)
+
+    np.testing.assert_array_equal(loaded.coef_, coef)
+    np.testing.assert_array_equal(loaded.intercept_, intercept)
+    assert isinstance(loaded.solver, NoOpSolver)

--- a/tests/test_partial_param_spec.py
+++ b/tests/test_partial_param_spec.py
@@ -11,7 +11,6 @@ import nemos as nmo
 from nemos.batching import ArrayDataLoader
 from nemos.callbacks import Callback
 from nemos.glm.params import GLMParams
-from nemos.solvers._abstract_solver import AbstractSolver
 from nemos.solvers._no_op import NoOpSolver
 from nemos.tree_utils import tree_broadcast_prefix
 
@@ -419,23 +418,6 @@ class TestEveryParameterFixed:
             )
 
         assert callback.calls == ["on_train_begin", "on_train_end"]
-
-
-def test_no_op_solver_covers_the_solver_interface():
-    """``NoOpSolver`` replaces any configured solver, so it must implement all of it.
-
-    The model reaches for solver methods after initialization — ``stochastic_run`` is one
-    — and a missing one only shows up as an ``AttributeError`` mid-fit. Comparing the
-    public surface catches that when the interface grows, e.g. a Hessian mixin.
-    """
-    expected = {
-        name
-        for name in dir(AbstractSolver)
-        if not name.startswith("_") and callable(getattr(AbstractSolver, name, None))
-    }
-
-    missing = sorted(name for name in expected if not hasattr(NoOpSolver, name))
-    assert missing == []
 
 
 def _solver_grad_norm(model, active, X, y):

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -9,6 +9,8 @@ import pytest
 import nemos as nmo
 from nemos.glm.params import GLMParams
 from nemos.proximal_operator import prox_lasso, prox_none, prox_ridge
+from nemos.solvers._abstract_solver import AbstractSolver
+from nemos.solvers._no_op import NoOpSolver
 from nemos.solvers._svrg import SVRG, ProxSVRG, SVRGState
 from nemos.tree_utils import (
     pytree_map_and_reduce,
@@ -943,3 +945,20 @@ def test_jaxopt_adapter_rejects_none_stepsize(request, solver_name):
             has_aux=False,
             stepsize=None,
         )
+
+
+def test_no_op_solver_covers_the_solver_interface():
+    """``NoOpSolver`` replaces any configured solver, so it must implement all of it.
+
+    The model reaches for solver methods after initialization — ``stochastic_run`` is one
+    — and a missing one only shows up as an ``AttributeError`` mid-fit. Comparing the
+    public surface catches that when the interface grows, e.g. a Hessian mixin.
+    """
+    expected = {
+        name
+        for name in dir(AbstractSolver)
+        if not name.startswith("_") and callable(getattr(AbstractSolver, name, None))
+    }
+
+    missing = sorted(name for name in expected if not hasattr(NoOpSolver, name))
+    assert missing == []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -668,8 +668,7 @@ def test_inspect_npz(tmp_path, model_class, monkeypatch, capsys):
         lines.append("feature_mask           : None")
 
     lines.append("fit_intercept          : True")
-    if model_class is nmo.glm.GLM:
-        lines.append("fix_params             : (None, None)")
+    lines.append("fix_params             : (None, None)")
     lines += [
         "inverse_link_function  : jax.numpy.exp",
         "observation_model      : {'class': 'nemos.observation_models.PoissonObservations'}",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -667,8 +667,10 @@ def test_inspect_npz(tmp_path, model_class, monkeypatch, capsys):
     if hasattr(model_class, "feature_mask") or model_class == nmo.glm.PopulationGLM:
         lines.append("feature_mask           : None")
 
+    lines.append("fit_intercept          : True")
+    if model_class is nmo.glm.GLM:
+        lines.append("fix_params             : (None, None)")
     lines += [
-        "fit_intercept          : True",
         "inverse_link_function  : jax.numpy.exp",
         "observation_model      : {'class': 'nemos.observation_models.PoissonObservations'}",
         "regularizer            : {'class': 'nemos.regularizer.Ridge'}",


### PR DESCRIPTION
## Summary and Motivation
With this PR we add support for partial parameter specifications in GLMs. This feature has been requested by multiple users, including in this discussion #485. 

This PR addresses that. 

## Implementation 

### GLM

- **new** `fix_params` parameter. This is of type `UserGLMParams`, which is a `tuple[PyTree[NDArray | None] | None, NDArray|None]` coef and intercept. Any concrete array in the tree will be fixed, the None will be learned.
- Extended initialization logic to account for `fix_params`: similar to the `fit_intercept=False` initialization logic, when the intercept is frozen, either by flag or by `fix_params` the active coefficients are initialized to a constant minimizing $\Vert g(y) - X_\text{fix} \cdot b_\text{fix}- X_\text{active} \cdot \mathbf{1} b \Vert _2^2$.
- Resolution order for fixing the intercept: if it is provided by `fix_params`, the pinned value is used. Otherwise, the `fit_intercept` flag determines if the intercept is pinned to zero or not.
- DOF computation is now based on the active parameters only.
- If all params are fixed a NoOpSolver is defined matching the interface.

### Validator
- **validate_param_specs**: method of the base validator. This checks that the `fix_params` has the expected structure, and that its leaves are None or arrays.
- **additional_validation_param_specs**: hook to validate additional model specific structure.
- BaseValidator validation chain for fix parameter specifications.

### Solvers
- **new** convenience No-op solver, can be used for trivial model fits (no params)
- changed the interface of self.fun in optimistix adapter to match the nemos loss. This can be safely done because the function that optimistix minimise receives is self.fun_with_aux, which follows their interface (`fun(params, args=None)`).

### BaseRegressor
- convenience method for no-op optimizer setup.

### Parameters

- Typing of model parameters was generalized, allowing more precise `Params[LeafType]` specification. this is useful because we can annotate if a method requires the fully specified parameters `GLMParams[NDArray]` or if it can accept partial parameters specs: `GLMParams[NDArray | None]` .

### Repr

- `format_repr` now filters out tree with all None leaves from the repr. This is the default for `fix_params`.
