### PR TITLE
Benckmarking fix

### DIFF
--- a/scripts/benchmarking/benchmarking_glm.py
+++ b/scripts/benchmarking/benchmarking_glm.py
@@ -444,10 +444,7 @@ def _benchmark_nemos(config: dict, X: jnp.ndarray, y: jnp.ndarray, n_reps: int) 
         if not is_scipy:
             t2 = perf_counter()
             compiled = (
-                jax.jit(model._optimizer_run)
-                .trace(active_pars, X, y)
-                .lower()
-                .compile()
+                jax.jit(model._optimizer_run).trace(active_pars, X, y).lower().compile()
             )
             t3 = perf_counter()
             compilation_s.append(t3 - t2)

--- a/scripts/benchmarking/benchmarking_glm.py
+++ b/scripts/benchmarking/benchmarking_glm.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from time import perf_counter
 from typing import List, Literal, Optional, Tuple
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pandas as pd
@@ -404,6 +405,14 @@ def _benchmark_nemos(config: dict, X: jnp.ndarray, y: jnp.ndarray, n_reps: int) 
     model = model_from_config(config)
     pars = model.initialize_params(X, y)
     model_pars = model._validator.to_model_params(pars)
+    # Mirror what model.fit() does before touching the solver: split params into
+    # the active subtree the optimizer actually runs on and the (here, empty)
+    # frozen subtree, and thread frozen_params through init. Skipping this — as
+    # this function used to — breaks PopulationGLM's Newton solver: its
+    # per-neuron Hessian vmaps over `frozen`, and that vmap's in_axes spec
+    # assumes the partitioned GLMParams shape, not the bare `None` you get by
+    # calling _initialize_optimizer_and_state/_optimizer_run without it.
+    active_pars, frozen_pars = model._partition_active(model_pars)
 
     is_scipy = model.solver_spec.backend == "scipy"
 
@@ -426,14 +435,19 @@ def _benchmark_nemos(config: dict, X: jnp.ndarray, y: jnp.ndarray, n_reps: int) 
         model = model_from_config(config)
 
         t0 = perf_counter()
-        _ = model._initialize_optimizer_and_state(model_pars, X, y)
+        _ = model._initialize_optimizer_and_state(
+            active_pars, X, y, frozen_params=frozen_pars
+        )
         t1 = perf_counter()
         solver_init_s.append(t1 - t0)
 
         if not is_scipy:
             t2 = perf_counter()
             compiled = (
-                jax.jit(model._optimizer_run).trace(model_pars, X, y).lower().compile()
+                jax.jit(model._optimizer_run)
+                .trace(active_pars, X, y)
+                .lower()
+                .compile()
             )
             t3 = perf_counter()
             compilation_s.append(t3 - t2)
@@ -442,7 +456,8 @@ def _benchmark_nemos(config: dict, X: jnp.ndarray, y: jnp.ndarray, n_reps: int) 
             compilation_s.append(jnp.nan)
 
         t4 = perf_counter()
-        pars, state, _ = compiled(model_pars, X, y)
+        pars, state, _ = compiled(active_pars, X, y)
+        pars = eqx.combine(pars, frozen_pars)
         pars.coef.block_until_ready()
         t5 = perf_counter()
         fit_s.append(t5 - t4)

--- a/tests/test_benchmarking_glm.py
+++ b/tests/test_benchmarking_glm.py
@@ -4,6 +4,7 @@ These exercise the benchmarking harness itself (not just nemos), since the
 harness calls private solver internals directly and can drift out of sync
 with what model.fit() actually does.
 """
+
 import sys
 from pathlib import Path
 
@@ -13,7 +14,11 @@ import pytest
 sys.path.insert(
     0, str(Path(__file__).resolve().parents[1] / "scripts" / "benchmarking")
 )
-from benchmarking_glm import benchmark_fit, generate_data, model_from_config  # noqa: E402
+from benchmarking_glm import (  # noqa: E402
+    benchmark_fit,
+    generate_data,
+    model_from_config,
+)
 
 
 @pytest.mark.solver_related

--- a/tests/test_benchmarking_glm.py
+++ b/tests/test_benchmarking_glm.py
@@ -1,0 +1,49 @@
+"""Regression tests for scripts/benchmarking/benchmarking_glm.py.
+
+These exercise the benchmarking harness itself (not just nemos), since the
+harness calls private solver internals directly and can drift out of sync
+with what model.fit() actually does.
+"""
+import sys
+from pathlib import Path
+
+import jax
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "scripts" / "benchmarking")
+)
+from benchmarking_glm import benchmark_fit, generate_data, model_from_config  # noqa: E402
+
+
+@pytest.mark.solver_related
+def test_benchmark_newton_population_glm_synthetic():
+    """Newton[nemos] must benchmark successfully on a PopulationGLM (pop_size > 1).
+
+    _benchmark_nemos used to call the solver's private init/run methods on the
+    full parameter pytree instead of partitioning active/frozen params the way
+    model.fit() does. That's a no-op for a single-neuron GLM, but
+    PopulationGLM's Newton Hessian vmaps over the frozen params, so skipping
+    the partition raised a `vmap in_axes` pytree-structure ValueError for
+    every PopulationGLM fit -- including, unnoticed, every real-data (NWB)
+    fit, since those are always fit as a PopulationGLM.
+    """
+    jax.config.update("jax_enable_x64", True)
+    config = {
+        "package": "nemos",
+        "input_shapes": {"X": [50, 2], "y": [50, 3]},
+        "model_conf": {
+            "solver_name": "Newton[nemos]",
+            "solver_kwargs": {"maxiter": 100, "tol": 1e-6},
+            "regularizer": "Ridge",
+            "regularizer_strength": 0.001,
+        },
+        "device": "cpu",
+        "file_name": "cpu_test_newton_population.json",
+    }
+    model = model_from_config(config)
+    X, y = generate_data(model, config)
+
+    result = benchmark_fit(config, X, y, n_reps=1)
+
+    assert result["results"]["converged"][0]


### PR DESCRIPTION
Hotfixing benchmarks: benchmarks do not call fit directly to decompose the fit into pre-processing, compilation and fit. 

This split broke the hessian path. the pr fixes that