### PR TITLE
Fix module param io

### DIFF
--- a/src/nemos/_params_builder.py
+++ b/src/nemos/_params_builder.py
@@ -1,0 +1,60 @@
+"""Utility functions for creating parameter container objects."""
+
+from .glm.params import GLMParams
+from .glm_hmm.params import GLMHMMModelParams, GLMHMMParams
+from .hmm.params import HMMParams
+
+AVAILABLE_PARAM_CONTAINERS = [
+    "GLMParams",
+    "HMMParams",
+    "GLMHMMParams",
+    "GLMHMMModelParams",
+]
+
+# Mapping for O(1) lookup
+_PARAM_CONTAINER_MAP = {
+    "GLMParams": GLMParams,
+    "HMMParams": HMMParams,
+    "GLMHMMParams": GLMHMMParams,
+    "GLMHMMModelParams": GLMHMMModelParams,
+}
+
+
+def instantiate_param_container(name: str, **kwargs):
+    """
+    Create a parameter container from a given name.
+
+    Parameter containers are equinox modules holding a model's parameters, e.g.
+    ``GLMParams(coef, intercept)``. They reach saved files as the values of other
+    parameters — a structured ``GroupLasso`` mask, for instance — and are rebuilt from
+    their class name at load time. Only the containers listed in
+    ``AVAILABLE_PARAM_CONTAINERS`` can be built, so loading never calls an arbitrary
+    constructor.
+
+    Parameters
+    ----------
+    name :
+        The string name of the container to create, either bare or as a full module
+        path. Must name one of ``AVAILABLE_PARAM_CONTAINERS``.
+    **kwargs :
+        Additional keyword arguments are passed to the container constructor, one per
+        field of the container.
+
+    Returns
+    -------
+    :
+        The parameter container instance.
+
+    Raises
+    ------
+    ValueError
+        If the ``name`` provided does not match any available container.
+    """
+    basename = name.split(".")[-1]
+    if basename in _PARAM_CONTAINER_MAP:
+        return _PARAM_CONTAINER_MAP[basename](**kwargs)
+
+    raise ValueError(
+        f"Unknown parameter container: {name}. "
+        f"Container must be one of {AVAILABLE_PARAM_CONTAINERS} or their full module path."
+    )

--- a/src/nemos/io/io.py
+++ b/src/nemos/io/io.py
@@ -11,12 +11,14 @@ import numpy as np
 if TYPE_CHECKING:
     from ..base_regressor import BaseRegressor
     from ..observation_models import Observations
+    from ..params import ModelParams
     from ..regularizer import Regularizer
 
 from .._observation_model_builder import (
     AVAILABLE_OBSERVATION_MODELS,
     instantiate_observation_model,
 )
+from .._params_builder import AVAILABLE_PARAM_CONTAINERS, instantiate_param_container
 from .._regularizer_builder import AVAILABLE_REGULARIZERS, instantiate_regularizer
 from ..glm import GLM, ClassifierGLM, ClassifierPopulationGLM, PopulationGLM
 from ..glm_hmm import GLMHMM
@@ -194,7 +196,7 @@ def _is_param(par):
 
 def _safe_instantiate(
     param_name: str, class_name: str, **kwargs
-) -> "Regularizer | Observations":
+) -> "Regularizer | Observations | ModelParams":
     if not isinstance(class_name, str):
         # this should not be hit, if it does the saved params had been modified.
         raise ValueError(
@@ -205,6 +207,8 @@ def _safe_instantiate(
     class_basename = class_name.split(".")[-1]
     if class_basename in AVAILABLE_REGULARIZERS:
         return instantiate_regularizer(class_name, **kwargs)
+    elif class_basename in AVAILABLE_PARAM_CONTAINERS:
+        return instantiate_param_container(class_name, **kwargs)
     elif any(class_basename.startswith(obs) for obs in AVAILABLE_OBSERVATION_MODELS):
         return instantiate_observation_model(class_name, **kwargs)
     else:

--- a/src/nemos/utils.py
+++ b/src/nemos/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import os
 import warnings
@@ -14,6 +15,7 @@ import jax.numpy as jnp
 import numpy as np
 from numpy.typing import NDArray
 
+from .params import ModelParams
 from .tree_utils import pytree_map_and_reduce
 from .type_casting import support_pynapple
 from .typing import Pytree
@@ -831,6 +833,16 @@ def _unpack_params(params_dict: dict, string_attrs: list = None) -> dict:
             cls_name = _get_name(value)
             params = _unpack_params(value.get_params(deep=False), string_attrs)
             out[key] = {"class": cls_name, "params": params}
+        elif isinstance(value, ModelParams):
+            # parameter containers are equinox modules and have no ``get_params``, so
+            # unpack them field by field through the same class/params convention.
+            # Without this they reach ``_flatten_dict`` whole and are stored as pickled
+            # object arrays, which ``load_model`` cannot read back.
+            fields = {f.name: getattr(value, f.name) for f in dataclasses.fields(value)}
+            out[key] = {
+                "class": _get_name(value),
+                "params": _unpack_params(fields, string_attrs),
+            }
         elif isinstance(value, dict):
             # serialize callable/class leaves inside plain dicts by their name,
             # so npz can store them as strings instead of pickled object arrays.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1100,21 +1100,6 @@ def example_data_prox_operator_multineuron():
 
 
 @pytest.fixture
-def poisson_observation_model():
-    return nmo.observation_models.PoissonObservations(jnp.exp)
-
-
-@pytest.fixture
-def ridge_regularizer():
-    return nmo.regularizer.Ridge()
-
-
-@pytest.fixture
-def lasso_regularizer():
-    return nmo.regularizer.Lasso()
-
-
-@pytest.fixture
 def group_lasso_2groups_5features_regularizer():
     mask = np.zeros((2, 5))
     mask[0, :2] = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1100,14 +1100,6 @@ def example_data_prox_operator_multineuron():
 
 
 @pytest.fixture
-def group_lasso_2groups_5features_regularizer():
-    mask = np.zeros((2, 5))
-    mask[0, :2] = 1
-    mask[1, 2:] = 1
-    return nmo.regularizer.GroupLasso(mask=mask)
-
-
-@pytest.fixture
 def mock_data():
     return jnp.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]), jnp.array([[1, 2], [3, 4]])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1111,7 +1111,7 @@ def ridge_regularizer():
 
 @pytest.fixture
 def lasso_regularizer():
-    return nmo.regularizer.Lasso(solver_name="ProximalGradient")
+    return nmo.regularizer.Lasso()
 
 
 @pytest.fixture
@@ -1119,7 +1119,7 @@ def group_lasso_2groups_5features_regularizer():
     mask = np.zeros((2, 5))
     mask[0, :2] = 1
     mask[1, 2:] = 1
-    return nmo.regularizer.GroupLasso(solver_name="ProximalGradient", mask=mask)
+    return nmo.regularizer.GroupLasso(mask=mask)
 
 
 @pytest.fixture

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -203,14 +203,14 @@ def get_param_shape(model, X, y):
     return jax.tree_util.tree_map(lambda x: x.shape, empty_par)
 
 
-def _group_lasso_model(mask):
+def _group_lasso_model(mask_kind):
     """GLM with a GroupLasso over 5 features split into 2 groups."""
     group_mask = np.zeros((2, 5))
     group_mask[0, :2] = 1
     group_mask[1, 2:] = 1
     mask = (
         GLMParams(coef=group_mask, intercept=None)
-        if mask == "structured"
+        if mask_kind == "structured"
         else group_mask
     )
     model = nmo.glm.GLM(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -25,6 +25,7 @@ import nemos as nmo
 from conftest import initialize_feature_mask_for_population_glm
 from nemos._observation_model_builder import instantiate_observation_model
 from nemos._regularizer_builder import instantiate_regularizer
+from nemos.glm.params import GLMParams
 from nemos.inverse_link_function_utils import identity, log_softmax
 from nemos.tree_utils import (
     pytree_map_and_reduce,
@@ -200,6 +201,53 @@ def test_get_fit_attrs(
 def get_param_shape(model, X, y):
     empty_par = model._validator.get_empty_params(X, y)
     return jax.tree_util.tree_map(lambda x: x.shape, empty_par)
+
+
+def _group_lasso_model(mask):
+    return nmo.glm.GLM(
+        regularizer=nmo.regularizer.GroupLasso(mask=mask),
+        regularizer_strength=0.1,
+        solver_name="ProximalGradient",
+    )
+
+
+@pytest.mark.parametrize("structured_mask", [False, True])
+def test_save_and_load_group_lasso_mask(
+    structured_mask, group_lasso_2groups_5features_regularizer, tmp_path
+):
+    """A GroupLasso mask round-trips whether it is a plain array or a GLMParams."""
+    array_mask = group_lasso_2groups_5features_regularizer.mask
+    mask = GLMParams(coef=array_mask, intercept=None) if structured_mask else array_mask
+
+    save_path = tmp_path / "group_lasso.npz"
+    _group_lasso_model(mask).save_params(save_path)
+    loaded_mask = nmo.load_model(save_path).regularizer.mask
+
+    assert type(loaded_mask) is type(mask)
+    if structured_mask:
+        np.testing.assert_allclose(loaded_mask.coef, mask.coef)
+        assert loaded_mask.intercept is None
+    else:
+        np.testing.assert_allclose(loaded_mask, mask)
+
+
+def test_structured_mask_saved_without_pickled_objects(
+    group_lasso_2groups_5features_regularizer, tmp_path
+):
+    """No entry is an object array, which ``load_model`` could never read back.
+
+    ``load_model`` opens the archive with ``allow_pickle=False``, so a parameter numpy
+    can only hold as an object array makes the whole file unloadable.
+    """
+    mask = GLMParams(
+        coef=group_lasso_2groups_5features_regularizer.mask, intercept=None
+    )
+    save_path = tmp_path / "no_objects.npz"
+    _group_lasso_model(mask).save_params(save_path)
+
+    with np.load(save_path, allow_pickle=True) as data:
+        pickled = [key for key in data.files if data[key].dtype == object]
+    assert pickled == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -204,46 +204,50 @@ def get_param_shape(model, X, y):
 
 
 def _group_lasso_model(mask):
-    return nmo.glm.GLM(
+    """GLM with a GroupLasso over 5 features split into 2 groups."""
+    group_mask = np.zeros((2, 5))
+    group_mask[0, :2] = 1
+    group_mask[1, 2:] = 1
+    mask = (
+        GLMParams(coef=group_mask, intercept=None)
+        if mask == "structured"
+        else group_mask
+    )
+    model = nmo.glm.GLM(
         regularizer=nmo.regularizer.GroupLasso(mask=mask),
         regularizer_strength=0.1,
         solver_name="ProximalGradient",
     )
+    return model, mask
 
 
-@pytest.mark.parametrize("structured_mask", [False, True])
-def test_save_and_load_group_lasso_mask(
-    structured_mask, group_lasso_2groups_5features_regularizer, tmp_path
-):
+@pytest.mark.parametrize("mask_kind", ["array", "structured"])
+def test_save_and_load_group_lasso_mask(mask_kind, tmp_path):
     """A GroupLasso mask round-trips whether it is a plain array or a GLMParams."""
-    array_mask = group_lasso_2groups_5features_regularizer.mask
-    mask = GLMParams(coef=array_mask, intercept=None) if structured_mask else array_mask
+    model, mask = _group_lasso_model(mask_kind)
 
     save_path = tmp_path / "group_lasso.npz"
-    _group_lasso_model(mask).save_params(save_path)
+    model.save_params(save_path)
     loaded_mask = nmo.load_model(save_path).regularizer.mask
 
-    assert type(loaded_mask) is type(mask)
-    if structured_mask:
+    if mask_kind == "structured":
+        assert isinstance(loaded_mask, GLMParams)
         np.testing.assert_allclose(loaded_mask.coef, mask.coef)
         assert loaded_mask.intercept is None
     else:
+        assert not isinstance(loaded_mask, GLMParams)
         np.testing.assert_allclose(loaded_mask, mask)
 
 
-def test_structured_mask_saved_without_pickled_objects(
-    group_lasso_2groups_5features_regularizer, tmp_path
-):
+def test_structured_mask_saved_without_pickled_objects(tmp_path):
     """No entry is an object array, which ``load_model`` could never read back.
 
     ``load_model`` opens the archive with ``allow_pickle=False``, so a parameter numpy
     can only hold as an object array makes the whole file unloadable.
     """
-    mask = GLMParams(
-        coef=group_lasso_2groups_5features_regularizer.mask, intercept=None
-    )
+    model, _ = _group_lasso_model("structured")
     save_path = tmp_path / "no_objects.npz"
-    _group_lasso_model(mask).save_params(save_path)
+    model.save_params(save_path)
 
     with np.load(save_path, allow_pickle=True) as data:
         pickled = [key for key in data.files if data[key].dtype == object]


### PR DESCRIPTION
Bugfix the io for model storing `ModelParams` as attributes. This happens when the `feature_mask` is defined and saved. The mask was an instance from an internal class but was not loaded.

The `_safe_instantiate` as extended to the loading of internal nemos parameter classes. In the meanwhile, some fixture cleanup (unused or used once) was also done. 

Added tests covering the structured `feature_mask`.