### PR TITLE
Auto discovery basis test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,11 @@ filterwarnings = [
 markers = [
   "solver_related: tests that interact with solvers",
   "requires_x64: mark test as requiring JAX float64 precision",
+  # Coverage guards: compare what the package registers/discovers against what the test
+  # parametrizations cover, so an uncovered component fails instead of passing silently.
+  # No fitting, so the whole set runs in about a second -- run it BEFORE writing tests
+  # (`pytest -m metatest -q`). Never exclude it from a run.
+  "metatest: coverage guard asserting the test suite covers every registered component",
 ]
 # -s: no capture from pytest (prints will show)
 addopts = ["-s", "--strict-markers"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -545,7 +545,15 @@ _ALL_BASIS_CLASSES = _discover_basis_classes()
 
 
 def is_composite_basis(basis_cls) -> bool:
-    """Whether a basis combines other bases rather than evaluating an input itself."""
+    """Whether a basis combines other bases rather than evaluating an input itself.
+
+    Note this is **not** the complement of ``AtomicBasisMixin``, tempting as that reading is.
+    The two agree on 19 of the 20 bases; ``CustomBasis`` carries neither mixin, since it is
+    not a ``Basis`` subclass. That one class is why the non-composite sets below have to be
+    defined by the absence of ``CompositeBasisMixin`` rather than the presence of
+    ``AtomicBasisMixin`` -- the latter would drop ``CustomBasis``, which is precisely the
+    class every call site used to append by hand.
+    """
     return issubclass(basis_cls, CompositeBasisMixin)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -502,11 +502,7 @@ def is_conv_basis(basis_cls) -> bool:
     return issubclass(basis_cls, ConvBasisMixin) or basis_cls.__name__.endswith("Conv")
 
 
-# A basis is instantiable exactly when it combines ``Basis`` with one of these behaviour
-# mixins. That is what separates a user-facing basis from a shared implementation base:
-# ``FourierEval`` is ``FourierBasis`` plus ``EvalBasisMixin``, and ``FourierBasis`` alone is
-# not meant to be instantiated. Filtering on the mixin therefore drops the intermediates
-# without naming them.
+# Instantiable means ``Basis`` plus a behaviour mixin, which drops bases like ``FourierBasis``.
 _BASIS_BEHAVIOUR_MIXINS = (EvalBasisMixin, ConvBasisMixin, CompositeBasisMixin)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -544,17 +544,39 @@ def _discover_basis_classes() -> list:
 _ALL_BASIS_CLASSES = _discover_basis_classes()
 
 
+def is_composite_basis(basis_cls) -> bool:
+    """Whether a basis combines other bases rather than evaluating an input itself."""
+    return issubclass(basis_cls, CompositeBasisMixin)
+
+
 # automatic define user accessible basis and check the methods
 def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
     """
     Return all the instantiable basis classes in nemos.basis, which is every concrete
     class combining ``Basis`` with an Eval/Conv/Composite mixin, plus ``CustomBasis``.
+
+    Parameters
+    ----------
+    filter_basis :
+        ``"all"`` for everything, ``"Eval"`` or ``"Conv"`` for the bases carrying that
+        behaviour, or ``"NonComposite"`` for everything that is not a composite.
+
+        ``"NonComposite"`` is the entry point for the tests that exercise single bases: it is
+        the set that used to be spelled ``list_all_basis_classes("Eval") +
+        list_all_basis_classes("Conv") + [CustomBasis]``. Defining it by the mixin a composite
+        *carries*, rather than by the absence of Eval and Conv, keeps it correct if a further
+        behaviour mixin is ever introduced -- such a basis would still be non-composite, and
+        the Eval/Conv partition guard is what would flag the new behaviour.
     """
     all_basis = list(_ALL_BASIS_CLASSES)
-    if filter_basis != "all":
-        cond_fn = is_eval_basis if filter_basis == "Eval" else is_conv_basis
-        all_basis = [a for a in all_basis if cond_fn(a)]
-    return all_basis
+    if filter_basis == "all":
+        return all_basis
+    cond_fn = {
+        "Eval": is_eval_basis,
+        "Conv": is_conv_basis,
+        "NonComposite": lambda cls: not is_composite_basis(cls),
+    }[filter_basis]
+    return [a for a in all_basis if cond_fn(a)]
 
 
 def implementation_superclass(basis_cls) -> Optional[type]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -618,7 +618,8 @@ def atomic_basis_superclass_pairs() -> list[tuple]:
     return [
         (cls, implementation_superclass(cls))
         for cls in list_all_basis_classes()
-        if issubclass(cls, AtomicBasisMixin) and implementation_superclass(cls) is not None
+        if issubclass(cls, AtomicBasisMixin)
+        and implementation_superclass(cls) is not None
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,6 +567,11 @@ def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
         *carries*, rather than by the absence of Eval and Conv, keeps it correct if a further
         behaviour mixin is ever introduced -- such a basis would still be non-composite, and
         the Eval/Conv partition guard is what would flag the new behaviour.
+
+        ``"EvalLike"`` is the non-composite bases that do not convolve, i.e. the former
+        ``list_all_basis_classes("Eval") + [CustomBasis]``. ``CustomBasis`` belongs there
+        because it evaluates a user-supplied callable, which is Eval behaviour without the
+        mixin.
     """
     all_basis = list(_ALL_BASIS_CLASSES)
     if filter_basis == "all":
@@ -575,6 +580,7 @@ def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
         "Eval": is_eval_basis,
         "Conv": is_conv_basis,
         "NonComposite": lambda cls: not is_composite_basis(cls),
+        "EvalLike": lambda cls: not is_composite_basis(cls) and not is_conv_basis(cls),
     }[filter_basis]
     return [a for a in all_basis if cond_fn(a)]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,10 @@ Note:
 """
 
 import abc
+import importlib
+import inspect
 import os
+import pkgutil
 import re
 from collections import defaultdict, namedtuple
 from copy import deepcopy
@@ -32,8 +35,12 @@ from nemos.base_regressor import BaseRegressor
 from nemos.base_validator import RegressorValidator
 from nemos.basis import AdditiveBasis, Category, CustomBasis, MultiplicativeBasis, Zero
 from nemos.basis._basis import Basis
-from nemos.basis._basis_mixin import BasisMixin
-from nemos.basis._transformer_basis import TransformerBasis
+from nemos.basis._basis_mixin import (
+    BasisMixin,
+    CompositeBasisMixin,
+    ConvBasisMixin,
+    EvalBasisMixin,
+)
 from nemos.glm.params import GLMParams
 from nemos.glm.validation import GLMValidator
 from nemos.glm_hmm.initialize_parameters import random_glm_params_init
@@ -479,36 +486,70 @@ class CombinedBasis(BasisFuncsTesting):
 
 
 def is_eval_basis(basis_cls) -> bool:
-    is_eval = "Eval" in basis_cls.__name__ or issubclass(
-        basis_cls, (basis.Zero, Category)
-    )
-    return is_eval
+    """Whether a basis maps its input through the basis functions.
+
+    The mixin is the criterion: it is what actually gives the class its ``Eval`` behaviour,
+    so it classifies correctly regardless of naming. The name suffix is kept as a fallback
+    for classes that implement the behaviour without the mixin, such as test doubles.
+    ``Zero`` and ``Category`` need no special case -- both carry ``EvalBasisMixin``.
+    """
+    return issubclass(basis_cls, EvalBasisMixin) or basis_cls.__name__.endswith("Eval")
 
 
 def is_conv_basis(basis_cls) -> bool:
-    is_eval = "Conv" in basis_cls.__name__
-    return is_eval
+    """Whether a basis convolves its input with the basis kernel. See ``is_eval_basis``."""
+    return issubclass(basis_cls, ConvBasisMixin) or basis_cls.__name__.endswith("Conv")
+
+
+# A basis is instantiable exactly when it combines ``Basis`` with one of these behaviour
+# mixins. That is what separates a user-facing basis from a shared implementation base:
+# ``FourierEval`` is ``FourierBasis`` plus ``EvalBasisMixin``, and ``FourierBasis`` alone is
+# not meant to be instantiated. Filtering on the mixin therefore drops the intermediates
+# without naming them.
+_BASIS_BEHAVIOUR_MIXINS = (EvalBasisMixin, ConvBasisMixin, CompositeBasisMixin)
+
+
+def _discover_basis_classes() -> list:
+    """Every instantiable basis in ``nemos.basis``, found by walking the whole package.
+
+    Walking the package rather than naming modules is what keeps this from going stale: a
+    basis added in a new private module (as ``Category`` was, in ``nemos.basis._category``)
+    is picked up without touching this helper.
+
+    ``CustomBasis`` is the one genuine exception, and for a substantive reason -- it is not a
+    ``Basis`` subclass, so no amount of discovery over ``Basis`` will find it.
+    """
+    found = set()
+    for _, modname, _ in pkgutil.walk_packages(
+        nmo.basis.__path__, prefix="nemos.basis."
+    ):
+        try:
+            module = importlib.import_module(modname)
+        except Exception:  # pragma: no cover - an unimportable private module
+            continue
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                issubclass(obj, Basis)
+                and issubclass(obj, _BASIS_BEHAVIOUR_MIXINS)
+                and not inspect_utils.is_abstract(obj)
+                and obj.__module__.startswith("nemos.basis")
+            ):
+                found.add(obj)
+    # sorted so parametrization ids and ordering are reproducible across runs
+    return sorted(found, key=lambda cls: cls.__name__) + [CustomBasis]
+
+
+# computed once: the walk imports every submodule, which should not run per call
+_ALL_BASIS_CLASSES = _discover_basis_classes()
 
 
 # automatic define user accessible basis and check the methods
 def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
     """
-    Return all the classes in nemos.basis which are a subclass of Basis,
-    which should be all concrete classes except TransformerBasis.
+    Return all the instantiable basis classes in nemos.basis, which is every concrete
+    class combining ``Basis`` with an Eval/Conv/Composite mixin, plus ``CustomBasis``.
     """
-    all_basis = (
-        [
-            class_obj
-            for _, class_obj in inspect_utils.get_non_abstract_classes(basis)
-            if issubclass(class_obj, Basis)
-        ]
-        + [
-            bas
-            for _, bas in inspect_utils.get_non_abstract_classes(nmo.basis._basis)
-            if bas != TransformerBasis
-        ]
-        + [CustomBasis, Category]
-    )
+    all_basis = list(_ALL_BASIS_CLASSES)
     if filter_basis != "all":
         cond_fn = is_eval_basis if filter_basis == "Eval" else is_conv_basis
         all_basis = [a for a in all_basis if cond_fn(a)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ from nemos.base_validator import RegressorValidator
 from nemos.basis import AdditiveBasis, Category, CustomBasis, MultiplicativeBasis, Zero
 from nemos.basis._basis import Basis
 from nemos.basis._basis_mixin import (
+    AtomicBasisMixin,
     BasisMixin,
     CompositeBasisMixin,
     ConvBasisMixin,
@@ -554,6 +555,39 @@ def list_all_basis_classes(filter_basis="all") -> list[BasisMixin]:
         cond_fn = is_eval_basis if filter_basis == "Eval" else is_conv_basis
         all_basis = [a for a in all_basis if cond_fn(a)]
     return all_basis
+
+
+def implementation_superclass(basis_cls) -> Optional[type]:
+    """The shared implementation base a public basis inherits its maths from.
+
+    ``MSplineEval`` and ``MSplineConv`` both derive from ``MSplineBasis``, which holds the
+    evaluation logic; the public classes add only the Eval/Conv behaviour. Several tests need
+    that pairing so they can call the superclass implementation directly and compare.
+
+    Read off the MRO rather than tabulated, so a renamed or newly added basis needs no edit
+    here. No mixin has to be excluded by name because none of them subclass ``Basis``.
+
+    Returns ``None`` where no such base exists: the composites (``AdditiveBasis``,
+    ``MultiplicativeBasis``), ``CustomBasis``, and ``Category``, which implements its own
+    evaluation directly. Callers comparing against a superclass should skip those.
+    """
+    for base in basis_cls.__mro__[1:]:
+        if base is not Basis and isinstance(base, type) and issubclass(base, Basis):
+            return base
+    return None
+
+
+def atomic_basis_superclass_pairs() -> list[tuple]:
+    """``(basis_cls, implementation_superclass)`` for every atomic basis that has one.
+
+    The single source for the tests that pair a public basis against the base implementing
+    its maths, so they cannot drift apart or fall behind a newly added basis.
+    """
+    return [
+        (cls, implementation_superclass(cls))
+        for cls in list_all_basis_classes()
+        if issubclass(cls, AtomicBasisMixin) and implementation_superclass(cls) is not None
+    ]
 
 
 def list_all_real_basis_classes(filter_basis="all"):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -13,6 +13,7 @@ import numpy as np
 import pynapple as nap
 import pytest
 
+import nemos
 import nemos._inspect_utils as inspect_utils
 import nemos.basis.basis as basis
 import nemos.convolve as convolve
@@ -22,6 +23,7 @@ from conftest import (
     CombinedBasis,
     SizeTerminal,
     custom_basis,
+    is_conv_basis,
     is_eval_basis,
     list_all_basis_classes,
     list_all_real_basis_classes,
@@ -43,6 +45,8 @@ from nemos.basis._basis import (
 from nemos.basis._basis_mixin import (
     AtomicBasisMixin,
     BoundedEvalBasisMixin,
+    ConvBasisMixin,
+    EvalBasisMixin,
 )
 from nemos.basis._composition_utils import generate_basis_label_pair, set_input_shape
 from nemos.basis._decaying_exponential import OrthExponentialBasis
@@ -60,6 +64,62 @@ from nemos.basis._spline_basis import (
 )
 from nemos.basis._zero_basis import ZeroBasis
 from nemos.utils import pynapple_concatenate_numpy
+
+
+@pytest.mark.metatest
+def test_list_all_basis_classes_covers_the_public_api():
+    """``list_all_basis_classes`` drives most parametrizations in this file, so a basis
+    missing from it is silently untested rather than failing.
+
+    The contract is the public API: every concrete ``Basis`` subclass exported from
+    ``nemos.basis`` must appear. Subclass discovery is deliberately not the reference, for
+    two reasons -- this module defines its own ``Basis`` subclasses for testing, and the
+    package holds concrete intermediates (``FourierBasis``, ``HistoryBasis``,
+    ``IdentityBasis``, ``ZeroBasis``) that users reach through their ``Eval``/``Conv`` forms
+    instead. Neither belongs in the helper.
+    """
+    public = {
+        obj
+        for name in nemos.basis.__all__
+        if inspect.isclass(obj := getattr(nemos.basis, name, None))
+        and issubclass(obj, Basis)
+        and not inspect_utils.is_abstract(obj)
+    }
+    covered = set(list_all_basis_classes())
+    assert public, "no public Basis subclasses found; is nemos.basis.__all__ populated?"
+
+    missing = public - covered
+    assert not missing, (
+        "exported from nemos.basis but absent from list_all_basis_classes, so untested by "
+        f"every parametrization built on it: {sorted(cls.__name__ for cls in missing)}"
+    )
+
+
+@pytest.mark.metatest
+def test_eval_conv_mixins_agree_with_the_name_convention():
+    """``is_eval_basis`` / ``is_conv_basis`` split the public bases into the ``Eval`` and
+    ``Conv`` parametrizations, so a misclassified basis is tested under the wrong contract.
+
+    Both predicates accept either the mixin or the name suffix, which is deliberate but only
+    safe while the two agree. This asserts they do, for every public basis: a class carrying
+    ``EvalBasisMixin`` but named ``...Conv`` (or the reverse) is a naming bug worth failing
+    on rather than silently resolving through whichever check runs first.
+    """
+    for cls in list_all_basis_classes():
+        by_mixin_eval = issubclass(cls, EvalBasisMixin)
+        by_mixin_conv = issubclass(cls, ConvBasisMixin)
+        assert not (
+            by_mixin_eval and by_mixin_conv
+        ), f"{cls.__name__} carries both EvalBasisMixin and ConvBasisMixin"
+        if cls.__name__.endswith("Eval"):
+            assert by_mixin_eval, f"{cls.__name__} is named Eval but lacks EvalBasisMixin"
+        if cls.__name__.endswith("Conv"):
+            assert by_mixin_conv, f"{cls.__name__} is named Conv but lacks ConvBasisMixin"
+        # every atomic basis must land in exactly one of the two parametrizations
+        if issubclass(cls, AtomicBasisMixin):
+            assert is_eval_basis(cls) != is_conv_basis(
+                cls
+            ), f"{cls.__name__} is atomic but is neither exactly Eval nor exactly Conv"
 
 
 class EvalBasis2D(BoundedEvalBasisMixin, AtomicBasisMixin, Basis):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1116,7 +1116,7 @@ class TestConvBasis:
             bas.set_params(bounds=(1, 2))
 
 
-@pytest.mark.parametrize("cls", list_all_basis_classes("Eval") + [CustomBasis])
+@pytest.mark.parametrize("cls", list_all_basis_classes("EvalLike"))
 class TestEvalBasis:
     @pytest.mark.parametrize("n_basis", [5, 6])
     @pytest.mark.parametrize("vmin, vmax", [(0, 1), (-1, 1)])
@@ -1604,7 +1604,7 @@ def test_call_equivalent_in_conv(n_basis, cls):
 
 @pytest.mark.parametrize(
     "cls",
-    list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+    list_all_basis_classes("NonComposite"),
 )
 class TestSharedMethods:
     @pytest.mark.parametrize(
@@ -4146,9 +4146,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_empty_inputs_compute_features(
@@ -4179,9 +4177,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_empty_inputs_evaluate(
@@ -4210,7 +4206,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "bas_cls",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        list_all_basis_classes("NonComposite"),
     )
     def test_mul_by_int_basis_with_label(self, bas_cls, basis_class_specific_params):
         basis_obj = self.instantiate_basis(
@@ -4223,7 +4219,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        list_all_basis_classes("NonComposite"),
     )
     def test_add_label_using_class_name(self, basis_a, basis_class_specific_params):
         basis_a_obj = self.instantiate_basis(
@@ -4334,9 +4330,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_input_shape_product_init(
@@ -4363,7 +4357,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "bas",
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
+        list_all_basis_classes("NonComposite"),
     )
     def test_rmul_lmul(self, bas, basis_class_specific_params):
         basis_obj = self.instantiate_basis(
@@ -4379,9 +4373,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_provide_label_at_init(self, basis_a, basis_b, basis_class_specific_params):
@@ -5251,9 +5243,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     @pytest.mark.parametrize("shape_a", [1, (), np.ones(3)])
@@ -5289,9 +5279,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     @pytest.mark.parametrize("shape_a", [2, (2,), np.ones((3, 2))])
@@ -5327,9 +5315,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     @pytest.mark.parametrize("shape_a", [(2, 2), np.ones((3, 2, 2))])
@@ -5383,9 +5369,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_set_input_value_types(
@@ -5404,9 +5388,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_deep_copy_basis(self, basis_a, basis_b, basis_class_specific_params):
@@ -5456,9 +5438,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_compute_n_basis_runtime(
@@ -5583,9 +5563,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "real_cls",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        list_all_real_basis_classes("NonComposite"),
     )
     @pytest.mark.parametrize("complex_cls", [basis.FourierEval])
     def test_multiply_complex(self, real_cls, complex_cls, basis_class_specific_params):
@@ -5616,9 +5594,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_bounds_property(self, basis_a, basis_b, basis_class_specific_params):
@@ -5806,9 +5782,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_empty_inputs_compute_features(
@@ -5843,9 +5817,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_empty_inputs_evaluate(
@@ -5879,9 +5851,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "bas_cls",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        list_all_real_basis_classes("NonComposite"),
     )
     def test_pow_by_int_basis_with_label(self, bas_cls, basis_class_specific_params):
         basis_obj = self.instantiate_basis(
@@ -5894,9 +5864,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        list_all_real_basis_classes("NonComposite"),
     )
     def test_add_label_using_class_name(self, basis_a, basis_class_specific_params):
         basis_a_obj = self.instantiate_basis(
@@ -5931,9 +5899,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_real_basis_classes("Eval")
-            + list_all_real_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_real_basis_classes("NonComposite")
         ),
     )
     def test_input_shape_product_init(
@@ -6833,9 +6799,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     @pytest.mark.parametrize("shape", [1, (), np.ones(3)])
@@ -6867,9 +6831,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     @pytest.mark.parametrize("shape", [2, (2,), np.ones((3, 2))])
@@ -6901,9 +6863,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     @pytest.mark.parametrize("shape", [(2, 2), np.ones((3, 2, 2))])
@@ -6953,9 +6913,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_set_input_value_types(
@@ -6974,9 +6932,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_deep_copy_basis(self, basis_a, basis_b, basis_class_specific_params):
@@ -7012,9 +6968,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_basis_classes("Eval")
-            + list_all_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_basis_classes("NonComposite")
         ),
     )
     def test_compute_n_basis_runtime(
@@ -7094,9 +7048,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     )
     @pytest.mark.parametrize(
         "bas",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        list_all_real_basis_classes("NonComposite"),
     )
     def test_vectorization_equivalence(self, bas, x_shape, basis_class_specific_params):
         """Test that vectorized computation equals explicit nested loops."""
@@ -7152,7 +7104,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "bas",
-        list_all_real_basis_classes("Eval") + [CustomBasis],
+        list_all_real_basis_classes("EvalLike"),
     )
     @pytest.mark.parametrize("x, y", [(np.random.randn(10, 2), np.random.randn(10, 2))])
     def test_eval_and_compute_features_equivalence(
@@ -7180,9 +7132,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "real_cls",
-        list_all_real_basis_classes("Eval")
-        + list_all_real_basis_classes("Conv")
-        + [CustomBasis],
+        list_all_real_basis_classes("NonComposite"),
     )
     @pytest.mark.parametrize("complex_cls", [basis.FourierEval])
     def test_multiply_complex(self, real_cls, complex_cls, basis_class_specific_params):
@@ -7239,9 +7189,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize(
         "basis_a, basis_b",
         create_atomic_basis_pairs(
-            list_all_real_basis_classes("Eval")
-            + list_all_real_basis_classes("Conv")
-            + [CustomBasis]
+            list_all_real_basis_classes("NonComposite")
         ),
     )
     def test_bounds_property(self, basis_a, basis_b, basis_class_specific_params):
@@ -7524,9 +7472,7 @@ def test_mul_of_basis_by_int(mul, basis_class, basis_class_specific_params):
 
 @pytest.mark.parametrize(
     "basis_class",
-    list_all_real_basis_classes("Eval")
-    + list_all_real_basis_classes("Conv")
-    + [CustomBasis],
+    list_all_real_basis_classes("NonComposite"),
 )
 def test_mul_of_basis_from_nested(basis_class, basis_class_specific_params):
     basis_obj = CombinedBasis.instantiate_basis(
@@ -7553,9 +7499,7 @@ def test_mul_of_basis_from_nested(basis_class, basis_class_specific_params):
 
 @pytest.mark.parametrize(
     "basis_class",
-    list_all_real_basis_classes("Eval")
-    + list_all_real_basis_classes("Conv")
-    + [CustomBasis],
+    list_all_real_basis_classes("NonComposite"),
 )
 def test_pow_of_basis_from_nested(basis_class, basis_class_specific_params):
     basis_obj = CombinedBasis.instantiate_basis(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -67,32 +67,39 @@ from nemos.basis._zero_basis import ZeroBasis
 from nemos.utils import pynapple_concatenate_numpy
 
 
+# Names in ``nemos.basis.__all__`` that ``list_all_basis_classes`` deliberately does not
+# return. ``TransformerBasis`` wraps a basis for the scikit-learn API rather than being one,
+# so it is not a ``Basis`` subclass and has no basis behaviour to test here.
+_PUBLIC_NOT_DISCOVERED = {"TransformerBasis"}
+
+
 @pytest.mark.metatest
-def test_list_all_basis_classes_covers_the_public_api():
-    """``list_all_basis_classes`` drives most parametrizations in this file, so a basis
-    missing from it is silently untested rather than failing.
+def test_list_all_basis_classes_matches_the_public_api():
+    """``list_all_basis_classes`` must account for everything ``nemos.basis`` exports.
 
-    The contract is the public API: every concrete ``Basis`` subclass exported from
-    ``nemos.basis`` must appear. Subclass discovery is deliberately not the reference, for
-    two reasons -- this module defines its own ``Basis`` subclasses for testing, and the
-    package holds concrete intermediates (``FourierBasis``, ``HistoryBasis``,
-    ``IdentityBasis``, ``ZeroBasis``) that users reach through their ``Eval``/``Conv`` forms
-    instead. Neither belongs in the helper.
+    Nearly every parametrization in this file derives from that helper, so discovery failing
+    to find a basis silently drops it from all of them. Discovery works by combining ``Basis``
+    with one of the behaviour mixins, which is exactly what can go wrong: a basis that does
+    not follow the mixin convention, or a **new** mixin (a hypothetical ``ConvNDMixin``) that
+    ``_discover_basis_classes`` does not know about, would be exported and yet invisible here.
+
+    The comparison is a raw name diff in both directions against a declared expectation,
+    rather than a filtered subset check. Filtering ``__all__`` down to concrete ``Basis``
+    subclasses first would swallow precisely the case worth catching.
     """
-    public = {
-        obj
-        for name in nemos.basis.__all__
-        if inspect.isclass(obj := getattr(nemos.basis, name, None))
-        and issubclass(obj, Basis)
-        and not inspect_utils.is_abstract(obj)
-    }
-    covered = set(list_all_basis_classes())
-    assert public, "no public Basis subclasses found; is nemos.basis.__all__ populated?"
+    public = set(nemos.basis.__all__)
+    discovered = {cls.__name__ for cls in list_all_basis_classes()}
 
-    missing = public - covered
-    assert not missing, (
-        "exported from nemos.basis but absent from list_all_basis_classes, so untested by "
-        f"every parametrization built on it: {sorted(cls.__name__ for cls in missing)}"
+    assert public - discovered == _PUBLIC_NOT_DISCOVERED, (
+        "the difference between nemos.basis.__all__ and what list_all_basis_classes finds "
+        "has changed. Exported but undiscovered means the basis is missing from every "
+        "parametrization built on the helper -- usually a mixin that is not carried, or a new "
+        f"behaviour mixin discovery has not been taught about: "
+        f"{sorted(public - discovered - _PUBLIC_NOT_DISCOVERED)}"
+    )
+    assert not (discovered - public), (
+        "discovered as a basis but not exported from nemos.basis, so it is tested but "
+        f"unreachable for users: {sorted(discovered - public)}"
     )
 
 
@@ -432,23 +439,12 @@ def test_all_basis_are_tested() -> None:
             f"The following classes are not tested: {[bas.__qualname__ for bas in all_bases.difference(tested_bases)]}"
         )
 
-    pytest_marks = getattr(TestSharedMethods, "pytestmark", [])
-
-    # Find the parametrize mark for TestSharedMethods
-    out = None
-    for mark in pytest_marks:
-        if mark.name == "parametrize":
-            # Return the arguments of the parametrize mark
-            out = mark.args[1]  # The second argument contains the list
-
-    if out is None:
-        raise ValueError("cannot fine parametrization.")
-
-    basis_tested_in_shared_methods = set(out)
-    all_one_dim_basis = set(
-        list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis]
-    )
-    assert basis_tested_in_shared_methods == all_one_dim_basis
+    # ``TestSharedMethods``, ``TestEvalBasis`` and ``TestConvBasis`` used to be checked here
+    # by reading their ``parametrize`` mark and comparing it against the discovered set. They
+    # now derive their parametrization from ``list_all_basis_classes`` directly, so their
+    # coverage is structural and such a check would compare an expression against itself.
+    # What can still go wrong -- discovery not finding an exported basis -- is caught by
+    # ``test_list_all_basis_classes_matches_the_public_api``.
 
 
 @pytest.mark.parametrize(
@@ -588,31 +584,13 @@ def test_add_docstring():
         CustomSubClass2()
 
 
-@pytest.mark.parametrize(
-    "basis_instance, super_class",
-    [
-        (basis.BSplineEval(10), BSplineBasis),
-        (basis.BSplineConv(10, window_size=11), BSplineBasis),
-        (basis.CyclicBSplineEval(10), CyclicBSplineBasis),
-        (basis.CyclicBSplineConv(10, window_size=11), CyclicBSplineBasis),
-        (basis.MSplineEval(10), MSplineBasis),
-        (basis.MSplineConv(10, window_size=11), MSplineBasis),
-        (basis.RaisedCosineLinearEval(10), RaisedCosineBasisLinear),
-        (basis.RaisedCosineLinearConv(10, window_size=11), RaisedCosineBasisLinear),
-        (basis.RaisedCosineLogEval(10), RaisedCosineBasisLog),
-        (basis.RaisedCosineLogConv(10, window_size=11), RaisedCosineBasisLog),
-        (basis.OrthExponentialEval(10, np.arange(1, 11)), OrthExponentialBasis),
-        (
-            basis.OrthExponentialConv(10, decay_rates=np.arange(1, 11), window_size=12),
-            OrthExponentialBasis,
-        ),
-        (basis.IdentityEval(), IdentityBasis),
-        (basis.HistoryConv(11), HistoryBasis),
-        (basis.FourierEval(11), FourierBasis),
-        (basis.Zero(), ZeroBasis),
-    ],
-)
-def test_expected_output_eval_on_grid(basis_instance, super_class):
+@pytest.mark.parametrize("cls_pub, super_class", _SUPERCLASS_PAIRS)
+def test_expected_output_eval_on_grid(
+    cls_pub, super_class, basis_class_specific_params
+):
+    basis_instance = CombinedBasis().instantiate_basis(
+        5, cls_pub, basis_class_specific_params, window_size=10
+    )
     x, y = super_class.evaluate_on_grid(basis_instance, 100)
     xx, yy = basis_instance.evaluate_on_grid(100)
     np.testing.assert_equal(xx, x)
@@ -770,18 +748,7 @@ def test_composite_split_by_feature_multiply(input_shape):
     )
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        basis.RaisedCosineLogConv,
-        basis.RaisedCosineLinearConv,
-        basis.BSplineConv,
-        basis.CyclicBSplineConv,
-        basis.MSplineConv,
-        basis.OrthExponentialConv,
-        basis.HistoryConv,
-    ],
-)
+@pytest.mark.parametrize("cls", list_all_basis_classes("Conv"))
 class TestConvBasis:
     @pytest.mark.parametrize("n_basis", [5, 6])
     @pytest.mark.parametrize("ws", [10, 20])
@@ -1119,22 +1086,7 @@ class TestConvBasis:
             bas.set_params(bounds=(1, 2))
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        CustomBasis,
-        basis.RaisedCosineLogEval,
-        basis.RaisedCosineLinearEval,
-        basis.BSplineEval,
-        basis.CyclicBSplineEval,
-        basis.MSplineEval,
-        basis.OrthExponentialEval,
-        basis.IdentityEval,
-        basis.FourierEval,
-        basis.Zero,
-        Category,
-    ],
-)
+@pytest.mark.parametrize("cls", list_all_basis_classes("Eval") + [CustomBasis])
 class TestEvalBasis:
     @pytest.mark.parametrize("n_basis", [5, 6])
     @pytest.mark.parametrize("vmin, vmax", [(0, 1), (-1, 1)])
@@ -1622,26 +1574,7 @@ def test_call_equivalent_in_conv(n_basis, cls):
 
 @pytest.mark.parametrize(
     "cls",
-    [
-        CustomBasis,
-        basis.RaisedCosineLogEval,
-        basis.RaisedCosineLogConv,
-        basis.RaisedCosineLinearEval,
-        basis.RaisedCosineLinearConv,
-        basis.BSplineEval,
-        basis.BSplineConv,
-        basis.CyclicBSplineEval,
-        basis.CyclicBSplineConv,
-        basis.MSplineEval,
-        basis.MSplineConv,
-        basis.OrthExponentialEval,
-        basis.OrthExponentialConv,
-        basis.IdentityEval,
-        basis.HistoryConv,
-        basis.FourierEval,
-        basis.Zero,
-        Category,
-    ],
+    list_all_basis_classes("Eval") + list_all_basis_classes("Conv") + [CustomBasis],
 )
 class TestSharedMethods:
     @pytest.mark.parametrize(
@@ -8634,17 +8567,23 @@ def test_composite_basis_repr_wrapping():
         assert "    ...\n" in out
 
 
+@pytest.mark.metatest
 def test_basis_public_api_matches_subclasses():
-    import nemos as nmo
+    """Coverage guard: ``nemos.basis.__all__`` names exactly the exposed Basis subclasses.
 
+    Pairs with ``test_list_all_basis_classes_covers_the_public_api``, which closes the next
+    link in the chain: this one checks source classes against the public API, that one checks
+    the public API against the test helper driving the parametrizations. A basis exported
+    without a behaviour mixin passes here and fails there.
+    """
     # Public contract of the module
-    public = set(nmo.basis.__all__)
+    public = set(nemos.basis.__all__)
 
     # All Basis subclasses exposed through the namespace
     basis_subclasses = {
         name
-        for name, obj in inspect.getmembers(nmo.basis, inspect.isclass)
-        if issubclass(obj, nmo.basis._basis.Basis) and obj is not nmo.basis._basis.Basis
+        for name, obj in inspect.getmembers(nemos.basis, inspect.isclass)
+        if issubclass(obj, Basis) and obj is not Basis
     }
 
     # Known public names that are not direct subclasses

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -15,6 +15,7 @@ import pytest
 
 import nemos
 import nemos._inspect_utils as inspect_utils
+import nemos.basis._basis_mixin as _basis_mixin
 import nemos.basis.basis as basis
 import nemos.convolve as convolve
 from conftest import (
@@ -22,6 +23,7 @@ from conftest import (
     BasisFuncsTesting,
     CombinedBasis,
     SizeTerminal,
+    _BASIS_BEHAVIOUR_MIXINS,
     atomic_basis_superclass_pairs,
     custom_basis,
     is_conv_basis,
@@ -69,6 +71,50 @@ from nemos.utils import pynapple_concatenate_numpy
 
 # Exported but not discovered: ``TransformerBasis`` wraps a basis for sklearn, it is not one.
 _PUBLIC_NOT_DISCOVERED = {"TransformerBasis"}
+
+# Mixins in _basis_mixin.py that do not give a basis its evaluation behaviour.
+_NON_BEHAVIOUR_MIXINS = {
+    "BasisMixin",  # shared base for all of them
+    "AtomicBasisMixin",  # atomic vs composite, orthogonal to how the input is mapped
+    "BoundedEvalBasisMixin",  # an EvalBasisMixin that also carries bounds
+    "BasisTransformerMixin",  # supplies to_transformer for the sklearn API
+}
+
+
+@pytest.mark.metatest
+def test_behaviour_mixins_match_the_mixin_module():
+    """``_BASIS_BEHAVIOUR_MIXINS`` drives basis discovery, so it must track its module.
+
+    Discovery finds a basis by combining ``Basis`` with one of those mixins. A new behaviour
+    mixin left out of the tuple makes every basis carrying it invisible, and hence absent from
+    every parametrization built on ``list_all_basis_classes``.
+
+    Both differences are asserted. The forward one pins the mixins in the module that are
+    deliberately not behaviour, so a genuinely new one shows up as an undeclared name rather
+    than being silently ignored. The reverse one must be empty: a behaviour mixin defined
+    outside ``_basis_mixin.py`` would escape this check entirely.
+    """
+    defined = {
+        name
+        for name, obj in inspect.getmembers(_basis_mixin, inspect.isclass)
+        if obj.__module__ == _basis_mixin.__name__
+    }
+    behaviour = {cls.__name__ for cls in _BASIS_BEHAVIOUR_MIXINS}
+
+    undeclared = defined - behaviour - _NON_BEHAVIOUR_MIXINS
+    assert not undeclared, (
+        "mixins in _basis_mixin.py that are neither a declared behaviour mixin nor declared "
+        "non-behaviour. If one of these gives a basis its evaluation behaviour, add it to "
+        "_BASIS_BEHAVIOUR_MIXINS in conftest, otherwise to _NON_BEHAVIOUR_MIXINS here: "
+        f"{sorted(undeclared)}"
+    )
+    stale = _NON_BEHAVIOUR_MIXINS - defined
+    assert not stale, f"declared non-behaviour but no longer in the module: {sorted(stale)}"
+
+    assert not (behaviour - defined), (
+        "behaviour mixins defined outside nemos/basis/_basis_mixin.py, so this guard cannot "
+        f"see them. Basis mixins should live in that module: {sorted(behaviour - defined)}"
+    )
 
 
 @pytest.mark.metatest
@@ -464,8 +510,7 @@ def test_all_basis_are_tested() -> None:
             f"The following classes are not tested: {[bas.__qualname__ for bas in all_bases.difference(tested_bases)]}"
         )
 
-    # Shared/Eval/Conv classes now derive their parametrization; discovery is guarded by
-    # test_list_all_basis_classes_matches_the_public_api.
+    # Shared/Eval/Conv classes derive their parametrization; discovery itself is guarded above.
 
 
 @pytest.mark.parametrize(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -22,6 +22,7 @@ from conftest import (
     BasisFuncsTesting,
     CombinedBasis,
     SizeTerminal,
+    atomic_basis_superclass_pairs,
     custom_basis,
     is_conv_basis,
     is_eval_basis,
@@ -93,6 +94,83 @@ def test_list_all_basis_classes_covers_the_public_api():
         "exported from nemos.basis but absent from list_all_basis_classes, so untested by "
         f"every parametrization built on it: {sorted(cls.__name__ for cls in missing)}"
     )
+
+
+# Every concrete basis is either covered by a parametrization derived from
+# ``list_all_basis_classes`` or declared here with a reason. The guards below assert that
+# partition exactly, so a newly added basis either joins the derived tests automatically or
+# fails until someone states why it cannot.
+
+# Bases with no implementation superclass, hence outside every public-vs-superclass test.
+_NO_IMPLEMENTATION_SUPERCLASS = {
+    # evaluates categorical input directly; shares no maths with an Eval/Conv sibling
+    "Category",
+    # composites combine two bases rather than implementing an evaluation of their own
+    "AdditiveBasis",
+    "MultiplicativeBasis",
+    # wraps a user-supplied callable and is not a Basis subclass at all
+    "CustomBasis",
+}
+
+# Bases that are not atomic, hence outside every atomic-only parametrization.
+_NON_ATOMIC_BASIS = {"AdditiveBasis", "MultiplicativeBasis", "CustomBasis"}
+
+
+@pytest.mark.metatest
+def test_every_basis_is_paired_with_a_superclass_or_declared():
+    """``list_all_basis_classes`` is the source of truth; every basis is paired or declared.
+
+    The tests comparing a public basis against the base implementing its maths derive from
+    ``atomic_basis_superclass_pairs``, which silently omits anything with no such base. This
+    turns that silence into a failure: a new basis either gets a superclass and joins those
+    tests, or is named in ``_NO_IMPLEMENTATION_SUPERCLASS`` with a reason.
+
+    Asserted against the full concrete list rather than against the pair helper itself, which
+    is built from the same expression and so could never disagree.
+    """
+    all_basis = {cls.__name__ for cls in list_all_basis_classes()}
+    paired = {cls.__name__ for cls, _ in atomic_basis_superclass_pairs()}
+
+    undeclared = all_basis - paired - _NO_IMPLEMENTATION_SUPERCLASS
+    assert not undeclared, (
+        "bases with no implementation superclass and no declaration, so excluded from every "
+        "public-vs-superclass comparison without saying so. Give them a superclass or add "
+        f"them to _NO_IMPLEMENTATION_SUPERCLASS with a reason: {sorted(undeclared)}"
+    )
+    stale = _NO_IMPLEMENTATION_SUPERCLASS & paired
+    assert not stale, (
+        "declared as having no implementation superclass but now paired with one, so the "
+        f"declaration is stale and hides real coverage: {sorted(stale)}"
+    )
+    gone = _NO_IMPLEMENTATION_SUPERCLASS - all_basis
+    assert not gone, f"declared but no such basis exists: {sorted(gone)}"
+
+
+@pytest.mark.metatest
+def test_every_basis_is_atomic_or_declared():
+    """Same partition for ``AtomicBasisMixin``, which gates the atomic-only parametrizations.
+
+    A basis that forgets the mixin would drop out of them, and a new composite would need to
+    be recognised as such rather than assumed atomic.
+    """
+    all_basis = {cls.__name__ for cls in list_all_basis_classes()}
+    atomic = {
+        cls.__name__
+        for cls in list_all_basis_classes()
+        if issubclass(cls, AtomicBasisMixin)
+    }
+
+    undeclared = all_basis - atomic - _NON_ATOMIC_BASIS
+    assert not undeclared, (
+        "bases carrying no AtomicBasisMixin and not declared non-atomic, so excluded from "
+        f"every atomic parametrization without saying so: {sorted(undeclared)}"
+    )
+    stale = _NON_ATOMIC_BASIS & atomic
+    assert not stale, (
+        f"declared non-atomic but now carrying AtomicBasisMixin: {sorted(stale)}"
+    )
+    gone = _NON_ATOMIC_BASIS - all_basis
+    assert not gone, f"declared but no such basis exists: {sorted(gone)}"
 
 
 @pytest.mark.metatest
@@ -316,6 +394,7 @@ def create_atomic_basis_pairs(full_list):
     ]
 
 
+@pytest.mark.metatest
 def test_all_basis_are_tested() -> None:
     """Meta-test.
 
@@ -441,65 +520,40 @@ def test_example_docstrings_add(
         assert f" {basis_name}" not in doc_components[1]
 
 
-@pytest.mark.parametrize(
-    "public_class, meth_super",
-    [
-        ("IdentityEval", "IdentityBasis"),
-        ("HistoryConv", "HistoryBasis"),
-        ("MSplineEval", "MSplineBasis"),
-        ("MSplineConv", "MSplineBasis"),
-        ("BSplineEval", "BSplineBasis"),
-        ("BSplineConv", "BSplineBasis"),
-        ("CyclicBSplineEval", "CyclicBSplineBasis"),
-        ("CyclicBSplineConv", "CyclicBSplineBasis"),
-        ("RaisedCosineLinearEval", "RaisedCosineBasisLinear"),
-        ("RaisedCosineLinearConv", "RaisedCosineBasisLinear"),
-        ("RaisedCosineLogEval", "RaisedCosineBasisLog"),
-        ("RaisedCosineLogConv", "RaisedCosineBasisLog"),
-        ("OrthExponentialEval", "OrthExponentialBasis"),
-        ("OrthExponentialConv", "OrthExponentialBasis"),
-        ("FourierEval", "FourierBasis"),
-    ],
-)
+# ``(public basis, the base implementing its maths)`` for every atomic basis that has one,
+# derived from the MRO rather than tabulated. Shared by the tests that compare a public class
+# against its superclass, so they cannot drift apart or fall behind a newly added basis.
+_SUPERCLASS_PAIRS = [
+    pytest.param(cls, sup, id=f"{cls.__name__}-{sup.__name__}")
+    for cls, sup in atomic_basis_superclass_pairs()
+]
+
+# every atomic basis, including the ones with no implementation superclass
+_ATOMIC_BASIS = [
+    pytest.param(cls, id=cls.__name__)
+    for cls in list_all_basis_classes()
+    if issubclass(cls, AtomicBasisMixin)
+]
+
+
+@pytest.mark.parametrize("cls_pub, cls_sup", _SUPERCLASS_PAIRS)
 @pytest.mark.parametrize("method", ["evaluate", "split_by_feature", "evaluate_on_grid"])
-def test_docstrings_decorator_superclass(public_class, meth_super, method):
-    cls_pub = getattr(basis, public_class)
-    cls_sup = getattr(basis, meth_super)
+def test_docstrings_decorator_superclass(cls_pub, cls_sup, method):
     meth_pub = getattr(cls_pub, method)
     meth_super = getattr(cls_sup, method)
     assert meth_pub.__doc__.startswith(meth_super.__doc__)
 
 
-@pytest.mark.parametrize(
-    "public_class",
-    [
-        "IdentityEval",
-        "HistoryConv",
-        "MSplineEval",
-        "MSplineConv",
-        "BSplineEval",
-        "BSplineConv",
-        "CyclicBSplineEval",
-        "CyclicBSplineConv",
-        "RaisedCosineLinearEval",
-        "RaisedCosineLinearConv",
-        "RaisedCosineLogEval",
-        "RaisedCosineLogConv",
-        "OrthExponentialEval",
-        "OrthExponentialConv",
-        "FourierEval",
-        "Zero",
-    ],
-)
+@pytest.mark.parametrize("cls_pub", _ATOMIC_BASIS)
 @pytest.mark.parametrize(
     "method, mixin",
     [("set_input_shape", "AtomicBasisMixin"), ("compute_features", None)],
 )
-def test_docstrings_decorator_mixinclass(public_class, mixin, method):
-    cls_pub = getattr(basis, public_class)
+def test_docstrings_decorator_mixinclass(cls_pub, mixin, method):
     if mixin is None:
-        is_eval = public_class.endswith("Eval") or public_class == "Zero"
-        mixin = "EvalBasisMixin" if is_eval else "ConvBasisMixin"
+        # which behaviour mixin supplies the method is decided by the mixin the class
+        # actually carries, not by its name
+        mixin = "EvalBasisMixin" if is_eval_basis(cls_pub) else "ConvBasisMixin"
         mixin_meth = getattr(getattr(basis, mixin), "_" + method)
     else:
         mixin_meth = getattr(getattr(basis, mixin), method)
@@ -565,31 +619,13 @@ def test_expected_output_eval_on_grid(basis_instance, super_class):
     np.testing.assert_equal(np.asarray(yy), np.asarray(y))
 
 
-@pytest.mark.parametrize(
-    "basis_instance, super_class",
-    [
-        (basis.BSplineEval(10), BSplineBasis),
-        (basis.BSplineConv(10, window_size=11), BSplineBasis),
-        (basis.CyclicBSplineEval(10), CyclicBSplineBasis),
-        (basis.CyclicBSplineConv(10, window_size=11), CyclicBSplineBasis),
-        (basis.MSplineEval(10), MSplineBasis),
-        (basis.MSplineConv(10, window_size=11), MSplineBasis),
-        (basis.RaisedCosineLinearEval(10), RaisedCosineBasisLinear),
-        (basis.RaisedCosineLinearConv(10, window_size=11), RaisedCosineBasisLinear),
-        (basis.RaisedCosineLogEval(10), RaisedCosineBasisLog),
-        (basis.RaisedCosineLogConv(10, window_size=11), RaisedCosineBasisLog),
-        (basis.OrthExponentialEval(10, np.arange(1, 11)), OrthExponentialBasis),
-        (
-            basis.OrthExponentialConv(10, decay_rates=np.arange(1, 11), window_size=12),
-            OrthExponentialBasis,
-        ),
-        (basis.IdentityEval(), IdentityBasis),
-        (basis.HistoryConv(11), HistoryBasis),
-        (basis.FourierEval(10), FourierBasis),
-        (basis.Zero(), ZeroBasis),
-    ],
-)
-def test_expected_output_compute_features(basis_instance, super_class):
+@pytest.mark.parametrize("cls_pub, super_class", _SUPERCLASS_PAIRS)
+def test_expected_output_compute_features(
+    cls_pub, super_class, basis_class_specific_params
+):
+    basis_instance = CombinedBasis().instantiate_basis(
+        5, cls_pub, basis_class_specific_params, window_size=10
+    )
     x = super_class.compute_features(basis_instance, np.linspace(0, 1, 100))
     xx = basis_instance.compute_features(np.linspace(0, 1, 100))
     nans = np.isnan(x.sum(axis=1))

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -67,9 +67,7 @@ from nemos.basis._zero_basis import ZeroBasis
 from nemos.utils import pynapple_concatenate_numpy
 
 
-# Names in ``nemos.basis.__all__`` that ``list_all_basis_classes`` deliberately does not
-# return. ``TransformerBasis`` wraps a basis for the scikit-learn API rather than being one,
-# so it is not a ``Basis`` subclass and has no basis behaviour to test here.
+# Exported but not discovered: ``TransformerBasis`` wraps a basis for sklearn, it is not one.
 _PUBLIC_NOT_DISCOVERED = {"TransformerBasis"}
 
 
@@ -103,10 +101,7 @@ def test_list_all_basis_classes_matches_the_public_api():
     )
 
 
-# Every concrete basis is either covered by a parametrization derived from
-# ``list_all_basis_classes`` or declared here with a reason. The guards below assert that
-# partition exactly, so a newly added basis either joins the derived tests automatically or
-# fails until someone states why it cannot.
+# Every basis is either covered by a derived parametrization or declared below with a reason.
 
 # Bases with no implementation superclass, hence outside every public-vs-superclass test.
 _NO_IMPLEMENTATION_SUPERCLASS = {
@@ -469,12 +464,8 @@ def test_all_basis_are_tested() -> None:
             f"The following classes are not tested: {[bas.__qualname__ for bas in all_bases.difference(tested_bases)]}"
         )
 
-    # ``TestSharedMethods``, ``TestEvalBasis`` and ``TestConvBasis`` used to be checked here
-    # by reading their ``parametrize`` mark and comparing it against the discovered set. They
-    # now derive their parametrization from ``list_all_basis_classes`` directly, so their
-    # coverage is structural and such a check would compare an expression against itself.
-    # What can still go wrong -- discovery not finding an exported basis -- is caught by
-    # ``test_list_all_basis_classes_matches_the_public_api``.
+    # Shared/Eval/Conv classes now derive their parametrization; discovery is guarded by
+    # test_list_all_basis_classes_matches_the_public_api.
 
 
 @pytest.mark.parametrize(
@@ -546,9 +537,7 @@ def test_example_docstrings_add(
         assert f" {basis_name}" not in doc_components[1]
 
 
-# ``(public basis, the base implementing its maths)`` for every atomic basis that has one,
-# derived from the MRO rather than tabulated. Shared by the tests that compare a public class
-# against its superclass, so they cannot drift apart or fall behind a newly added basis.
+# (public basis, base implementing its maths) for every atomic basis, derived from the MRO.
 _SUPERCLASS_PAIRS = [
     pytest.param(cls, sup, id=f"{cls.__name__}-{sup.__name__}")
     for cls, sup in atomic_basis_superclass_pairs()
@@ -577,8 +566,7 @@ def test_docstrings_decorator_superclass(cls_pub, cls_sup, method):
 )
 def test_docstrings_decorator_mixinclass(cls_pub, mixin, method):
     if mixin is None:
-        # which behaviour mixin supplies the method is decided by the mixin the class
-        # actually carries, not by its name
+        # decided by the mixin the class carries, not by its name
         mixin = "EvalBasisMixin" if is_eval_basis(cls_pub) else "ConvBasisMixin"
         mixin_meth = getattr(getattr(basis, mixin), "_" + method)
     else:

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -19,11 +19,11 @@ import nemos.basis._basis_mixin as _basis_mixin
 import nemos.basis.basis as basis
 import nemos.convolve as convolve
 from conftest import (
+    _BASIS_BEHAVIOUR_MIXINS,
     DEFAULT_KWARGS,
     BasisFuncsTesting,
     CombinedBasis,
     SizeTerminal,
-    _BASIS_BEHAVIOUR_MIXINS,
     atomic_basis_superclass_pairs,
     custom_basis,
     is_conv_basis,
@@ -68,7 +68,6 @@ from nemos.basis._spline_basis import (
 from nemos.basis._zero_basis import ZeroBasis
 from nemos.utils import pynapple_concatenate_numpy
 
-
 # Exported but not discovered: ``TransformerBasis`` wraps a basis for sklearn, it is not one.
 _PUBLIC_NOT_DISCOVERED = {"TransformerBasis"}
 
@@ -109,7 +108,9 @@ def test_behaviour_mixins_match_the_mixin_module():
         f"{sorted(undeclared)}"
     )
     stale = _NON_BEHAVIOUR_MIXINS - defined
-    assert not stale, f"declared non-behaviour but no longer in the module: {sorted(stale)}"
+    assert (
+        not stale
+    ), f"declared non-behaviour but no longer in the module: {sorted(stale)}"
 
     assert not (behaviour - defined), (
         "behaviour mixins defined outside nemos/basis/_basis_mixin.py, so this guard cannot "
@@ -214,9 +215,9 @@ def test_every_basis_is_atomic_or_declared():
         f"every atomic parametrization without saying so: {sorted(undeclared)}"
     )
     stale = _NON_ATOMIC_BASIS & atomic
-    assert not stale, (
-        f"declared non-atomic but now carrying AtomicBasisMixin: {sorted(stale)}"
-    )
+    assert (
+        not stale
+    ), f"declared non-atomic but now carrying AtomicBasisMixin: {sorted(stale)}"
     gone = _NON_ATOMIC_BASIS - all_basis
     assert not gone, f"declared but no such basis exists: {sorted(gone)}"
 
@@ -268,9 +269,13 @@ def test_eval_conv_mixins_agree_with_the_name_convention():
             by_mixin_eval and by_mixin_conv
         ), f"{cls.__name__} carries both EvalBasisMixin and ConvBasisMixin"
         if cls.__name__.endswith("Eval"):
-            assert by_mixin_eval, f"{cls.__name__} is named Eval but lacks EvalBasisMixin"
+            assert (
+                by_mixin_eval
+            ), f"{cls.__name__} is named Eval but lacks EvalBasisMixin"
         if cls.__name__.endswith("Conv"):
-            assert by_mixin_conv, f"{cls.__name__} is named Conv but lacks ConvBasisMixin"
+            assert (
+                by_mixin_conv
+            ), f"{cls.__name__} is named Conv but lacks ConvBasisMixin"
         # every atomic basis must land in exactly one of the two parametrizations
         if issubclass(cls, AtomicBasisMixin):
             assert is_eval_basis(cls) != is_conv_basis(
@@ -4178,9 +4183,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("shape", [(0, 1, 2), (1, 0, 2), (1, 2, 0), (0,), (0, 0)])
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_empty_inputs_compute_features(
         self, shape: tuple[int], basis_a, basis_b, basis_class_specific_params
@@ -4209,9 +4212,7 @@ class TestAdditiveBasis(CombinedBasis):
     @pytest.mark.parametrize("shape", [(0, 1, 2), (1, 0, 2), (1, 2, 0), (0,), (0, 0)])
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_empty_inputs_evaluate(
         self, shape: tuple[int], basis_a, basis_b, basis_class_specific_params
@@ -4362,9 +4363,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_input_shape_product_init(
         self, basis_a, basis_b, basis_class_specific_params
@@ -4405,9 +4404,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_provide_label_at_init(self, basis_a, basis_b, basis_class_specific_params):
         basis_a_obj = self.instantiate_basis(
@@ -5275,9 +5272,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     @pytest.mark.parametrize("shape_a", [1, (), np.ones(3)])
     @pytest.mark.parametrize("shape_b", [1, (), np.ones(3)])
@@ -5311,9 +5306,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     @pytest.mark.parametrize("shape_a", [2, (2,), np.ones((3, 2))])
     @pytest.mark.parametrize("shape_b", [3, (3,), np.ones((3, 3))])
@@ -5347,9 +5340,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     @pytest.mark.parametrize("shape_a", [(2, 2), np.ones((3, 2, 2))])
     @pytest.mark.parametrize("shape_b", [(3, 1), np.ones((3, 3, 1))])
@@ -5401,9 +5392,7 @@ class TestAdditiveBasis(CombinedBasis):
     )
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_set_input_value_types(
         self, inp_shape, expectation, basis_a, basis_b, basis_class_specific_params
@@ -5420,9 +5409,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_deep_copy_basis(self, basis_a, basis_b, basis_class_specific_params):
 
@@ -5470,9 +5457,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_compute_n_basis_runtime(
         self, basis_a, basis_b, basis_class_specific_params
@@ -5626,9 +5611,7 @@ class TestAdditiveBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_bounds_property(self, basis_a, basis_b, basis_class_specific_params):
         """Test that the bounds property correctly combines bounds from component bases."""
@@ -5814,9 +5797,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("shape", [(0, 1, 2), (1, 0, 2), (1, 2, 0), (0,), (0, 0)])
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_empty_inputs_compute_features(
         self, shape: tuple[int], basis_a, basis_b, basis_class_specific_params
@@ -5849,9 +5830,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     @pytest.mark.parametrize("shape", [(0, 1, 2), (1, 0, 2), (1, 2, 0), (0,), (0, 0)])
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_empty_inputs_evaluate(
         self, shape: tuple[int], basis_a, basis_b, basis_class_specific_params
@@ -5931,9 +5910,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_real_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_real_basis_classes("NonComposite")),
     )
     def test_input_shape_product_init(
         self, basis_a, basis_b, basis_class_specific_params
@@ -6831,9 +6808,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     @pytest.mark.parametrize("shape", [1, (), np.ones(3)])
     @pytest.mark.parametrize("add_shape", [(), (1,)])
@@ -6863,9 +6838,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     @pytest.mark.parametrize("shape", [2, (2,), np.ones((3, 2))])
     @pytest.mark.parametrize("add_shape", [(), (1,)])
@@ -6895,9 +6868,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     @pytest.mark.parametrize("shape", [(2, 2), np.ones((3, 2, 2))])
     @pytest.mark.parametrize("add_shape", [(), (1,)])
@@ -6945,9 +6916,7 @@ class TestMultiplicativeBasis(CombinedBasis):
     )
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_set_input_value_types(
         self, inp_shape, expectation, basis_a, basis_b, basis_class_specific_params
@@ -6964,9 +6933,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_deep_copy_basis(self, basis_a, basis_b, basis_class_specific_params):
 
@@ -7000,9 +6967,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_basis_classes("NonComposite")),
     )
     def test_compute_n_basis_runtime(
         self, basis_a, basis_b, basis_class_specific_params
@@ -7221,9 +7186,7 @@ class TestMultiplicativeBasis(CombinedBasis):
 
     @pytest.mark.parametrize(
         "basis_a, basis_b",
-        create_atomic_basis_pairs(
-            list_all_real_basis_classes("NonComposite")
-        ),
+        create_atomic_basis_pairs(list_all_real_basis_classes("NonComposite")),
     )
     def test_bounds_property(self, basis_a, basis_b, basis_class_specific_params):
         """Test that the bounds property correctly combines bounds from component bases."""

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -181,6 +181,36 @@ def test_every_basis_is_atomic_or_declared():
 
 
 @pytest.mark.metatest
+def test_eval_and_conv_filters_partition_the_basis_list():
+    """``list_all_basis_classes("Eval")`` and ``("Conv")`` must partition the unfiltered list.
+
+    Those two filtered lists drive the Eval-only and Conv-only parametrizations, so a
+    misclassification moves a basis into the wrong contract or out of both. The unfiltered
+    list is guarded against the public API elsewhere; this guards the filters applied to it.
+
+    Stated directly rather than left as a consequence of the atomic and mixin guards, because
+    those two together do not cover the non-atomic case: a composite that acquired
+    ``EvalBasisMixin`` would silently join every Eval parametrization, and nothing else here
+    would notice.
+    """
+    all_basis = set(list_all_basis_classes())
+    eval_basis = set(list_all_basis_classes("Eval"))
+    conv_basis = set(list_all_basis_classes("Conv"))
+
+    assert not (eval_basis & conv_basis), (
+        "classified as both Eval and Conv, so tested under both contracts: "
+        f"{sorted(cls.__name__ for cls in eval_basis & conv_basis)}"
+    )
+    unclassified = all_basis - eval_basis - conv_basis
+    assert {cls.__name__ for cls in unclassified} == _NON_ATOMIC_BASIS, (
+        "the set of bases that are neither Eval nor Conv has changed. Anything here is "
+        "excluded from both filtered parametrizations; anything newly absent has been "
+        "pulled into one of them. Composites and CustomBasis are the only expected members: "
+        f"{sorted(cls.__name__ for cls in unclassified)}"
+    )
+
+
+@pytest.mark.metatest
 def test_eval_conv_mixins_agree_with_the_name_convention():
     """``is_eval_basis`` / ``is_conv_basis`` split the public bases into the ``Eval`` and
     ``Conv`` parametrizations, so a misclassified basis is tested under the wrong contract.

--- a/tests/test_transformer_basis.py
+++ b/tests/test_transformer_basis.py
@@ -84,7 +84,7 @@ def test_transformer_has_the_same_public_attributes_as_basis(
 
 @pytest.mark.parametrize(
     "basis_cls",
-    list_all_basis_classes("Conv") + list_all_basis_classes("Eval") + [CustomBasis],
+    list_all_basis_classes("NonComposite"),
 )
 def test_to_transformer_and_constructor_are_equivalent(
     basis_cls, basis_class_specific_params
@@ -253,7 +253,7 @@ def test_transformerbasis_getattr(
 
 @pytest.mark.parametrize(
     "basis_cls",
-    list_all_basis_classes("Conv") + list_all_basis_classes("Eval") + [CustomBasis],
+    list_all_basis_classes("NonComposite"),
 )
 @pytest.mark.parametrize("n_basis_funcs_init", [5])
 @pytest.mark.parametrize("n_basis_funcs_new", [6, 10, 20])
@@ -291,7 +291,7 @@ def test_transformerbasis_set_params(
 
 @pytest.mark.parametrize(
     "basis_cls",
-    list_all_basis_classes("Conv") + list_all_basis_classes("Eval") + [CustomBasis],
+    list_all_basis_classes("NonComposite"),
 )
 def test_transformerbasis_setattr_basis(basis_cls, basis_class_specific_params):
 
@@ -315,7 +315,7 @@ def test_transformerbasis_setattr_basis(basis_cls, basis_class_specific_params):
 
 @pytest.mark.parametrize(
     "basis_cls",
-    list_all_basis_classes("Conv") + list_all_basis_classes("Eval") + [CustomBasis],
+    list_all_basis_classes("NonComposite"),
 )
 def test_transformerbasis_setattr_basis_attribute(
     basis_cls, basis_class_specific_params
@@ -353,7 +353,7 @@ def test_transformerbasis_setattr_basis_attribute(
 
 @pytest.mark.parametrize(
     "basis_cls",
-    list_all_basis_classes("Conv") + list_all_basis_classes("Eval") + [CustomBasis],
+    list_all_basis_classes("NonComposite"),
 )
 def test_transformerbasis_copy_basis_on_construct(
     basis_cls, basis_class_specific_params

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,12 @@ passenv =
 # Enable package caching
 package_cache = .tox/cache
 
+# Coverage guards first, so an uncovered component fails in seconds; they rerun in the suite.
+metatest_command = pytest -m metatest -x -q
+
 # Run both pytest and coverage since pytest was initialized with the --cov option in the pyproject.toml
 commands =
+    {[testenv]metatest_command}
     # x64 doctests run in their own process so they cannot pollute f32 doctests
     pytest -n auto --doctest-modules src/nemos/identifiability_constraints.py src/nemos/convolve.py -W "ignore:The fit did not converge:RuntimeWarning"
     pytest -n auto --doctest-modules --ignore=src/nemos/identifiability_constraints.py --ignore=src/nemos/convolve.py src/nemos/ -W "ignore:The fit did not converge:RuntimeWarning"
@@ -31,6 +35,7 @@ commands =
 [testenv:skip_solver_related]
 description = Run all tests except solver-related ones
 commands =
+    {[testenv]metatest_command}
     # x64 doctests run in their own process so they cannot pollute f32 doctests
     pytest -n auto --doctest-modules src/nemos/identifiability_constraints.py src/nemos/convolve.py -W "ignore:The fit did not converge:RuntimeWarning"
     # Run remaining doctests (solvers excluded separately)
@@ -49,6 +54,7 @@ extras = dev,jaxopt
 setenv =
     NEMOS_SOLVER_BACKEND = jaxopt
 commands =
+    {[testenv]metatest_command}
     pytest -n auto --doctest-modules src/nemos/solvers -W "ignore:The fit did not converge:RuntimeWarning"
     pytest -n auto -m solver_related --cov=nemos --cov-config=pyproject.toml --cov-report=xml
 


### PR DESCRIPTION
With this PR I introduce a mechanism for auto-discovery & filtering of public basis. 

All tests that parametrize over basis are going through the auto-discovery/filtering callable. Additionally stringent safeguards guarantee that all the bases that are public are listed by the auto-discovery (and therefore added to the appropriate tests).

A mark has been introduced to run all the meta-test checking that all basis are listed, all mixins are discovered and implemented in the same module. 

