### PR TITLE
Fix precision flaky

### DIFF
--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -313,8 +313,11 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         # - as the time_scaling tends to 0, the points will be linearly spaced across the whole domain.
         # - as the time_scaling tends to inf, basis will be small and dense around 0 and
         # progressively larger and less dense towards 1.
-        log_spaced_pts = jnp.log(self.time_scaling * sample_pts + 1) / jnp.log(
-            self.time_scaling + 1
+        # log1p keeps the transform accurate for the samples close to 0, where the basis
+        # elements are densest: forming ``1 + time_scaling * x`` first cancels the leading
+        # digits of the small term, costing up to 5% relative accuracy in float32.
+        log_spaced_pts = jnp.log1p(self.time_scaling * sample_pts) / jnp.log1p(
+            self.time_scaling
         )
         return log_spaced_pts
 

--- a/src/nemos/basis/_raised_cosine_basis.py
+++ b/src/nemos/basis/_raised_cosine_basis.py
@@ -313,9 +313,7 @@ class RaisedCosineBasisLog(RaisedCosineBasisLinear, abc.ABC):
         # - as the time_scaling tends to 0, the points will be linearly spaced across the whole domain.
         # - as the time_scaling tends to inf, basis will be small and dense around 0 and
         # progressively larger and less dense towards 1.
-        # log1p keeps the transform accurate for the samples close to 0, where the basis
-        # elements are densest: forming ``1 + time_scaling * x`` first cancels the leading
-        # digits of the small term, costing up to 5% relative accuracy in float32.
+        # log1p is robust for the samples near 0, where the basis elements are densest.
         log_spaced_pts = jnp.log1p(self.time_scaling * sample_pts) / jnp.log1p(
             self.time_scaling
         )

--- a/src/nemos/glm/initialize_parameters.py
+++ b/src/nemos/glm/initialize_parameters.py
@@ -33,10 +33,22 @@ def _log_softmax_inv(x):
     return log_x - jnp.mean(log_x, axis=-1, keepdims=True)
 
 
+def _softplus_inv(x):
+    """Inverse of softplus.
+
+    ``log(exp(x) - 1)`` is accurate at neither end in float32: the subtraction
+    cancels the leading digits of the result for the small rates that dominate
+    spike counts, and ``exp`` overflows to infinity above ``x = 88``. Adding
+    ``x`` back to ``log(1 - exp(-x))`` avoids both, and ``expm1`` keeps that
+    second factor accurate as ``x`` approaches zero.
+    """
+    return x + jnp.log(-jnp.expm1(-x))
+
+
 # dictionary of known inverse link functions.
 INVERSE_FUNCS = {
     exp: jnp.log,
-    softplus: lambda x: jnp.log(jnp.exp(x) - 1.0),
+    softplus: _softplus_inv,
     logistic: jax.scipy.special.logit,
     norm_cdf: jax.scipy.stats.norm.ppf,
     one_over_x: one_over_x,
@@ -47,7 +59,7 @@ INVERSE_FUNCS = {
 # Name-based lookup (for after pickling/copying)
 INVERSE_FUNCS_BY_SIMPLE_NAME = {
     "exp": jnp.log,
-    "softplus": lambda x: jnp.log(jnp.exp(x) - 1.0),
+    "softplus": _softplus_inv,
     "logistic": jax.scipy.special.logit,
     "norm_cdf": jax.scipy.stats.norm.ppf,
     "one_over_x": one_over_x,

--- a/src/nemos/glm/initialize_parameters.py
+++ b/src/nemos/glm/initialize_parameters.py
@@ -34,14 +34,7 @@ def _log_softmax_inv(x):
 
 
 def _softplus_inv(x):
-    """Inverse of softplus.
-
-    ``log(exp(x) - 1)`` is accurate at neither end in float32: the subtraction
-    cancels the leading digits of the result for the small rates that dominate
-    spike counts, and ``exp`` overflows to infinity above ``x = 88``. Adding
-    ``x`` back to ``log(1 - exp(-x))`` avoids both, and ``expm1`` keeps that
-    second factor accurate as ``x`` approaches zero.
-    """
+    """Robust inverse of softplus, for small rates and above the exp overflow."""
     return x + jnp.log(-jnp.expm1(-x))
 
 

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -1321,15 +1321,15 @@ class NegativeBinomialObservations(Observations):
         predicted_rate = jnp.clip(
             predicted_rate, min=jnp.finfo(predicted_rate.dtype).eps
         )
-        # in terms of z = scale * mu, the two terms of the log-likelihood above are
-        # y * log(z / (z + 1)) and -log1p(z) / scale. The equivalent form built on
-        # 1 / (z + 1) cancels the leading digits of z once the rate is small enough
-        # that z + 1 rounds to 1, so keep the log1p form.
+        # with z = scale * mu, the two ratios of the log-likelihood above are
+        # mu / (r + mu) = z / (z + 1) and r / (r + mu) = 1 / (z + 1). Both are
+        # written as log1p, which stays accurate over the whole range of z; forming
+        # the ratios first instead cancels the leading digits of z as soon as
+        # z + 1 rounds to 1.
         scaled_rate = self.scale * predicted_rate
-        log1p_rate = jnp.log1p(scaled_rate)
-        return -aggregate_sample_scores(
-            y * (jnp.log(scaled_rate) - log1p_rate) - log1p_rate / self.scale
-        )
+        log_ratio_mu = -jnp.log1p(1 / scaled_rate)
+        log_ratio_r = -jnp.log1p(scaled_rate)
+        return -aggregate_sample_scores(y * log_ratio_mu + log_ratio_r / self.scale)
 
     def log_likelihood(
         self,

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -1321,11 +1321,7 @@ class NegativeBinomialObservations(Observations):
         predicted_rate = jnp.clip(
             predicted_rate, min=jnp.finfo(predicted_rate.dtype).eps
         )
-        # with z = scale * mu, the two ratios of the log-likelihood above are
-        # mu / (r + mu) = z / (z + 1) and r / (r + mu) = 1 / (z + 1). Both are
-        # written as log1p, which stays accurate over the whole range of z; forming
-        # the ratios first instead cancels the leading digits of z as soon as
-        # z + 1 rounds to 1.
+        # robust log1p forms of log(mu / (r + mu)) and log(r / (r + mu)).
         scaled_rate = self.scale * predicted_rate
         log_ratio_mu = -jnp.log1p(1 / scaled_rate)
         log_ratio_r = -jnp.log1p(scaled_rate)

--- a/src/nemos/observation_models.py
+++ b/src/nemos/observation_models.py
@@ -1321,9 +1321,14 @@ class NegativeBinomialObservations(Observations):
         predicted_rate = jnp.clip(
             predicted_rate, min=jnp.finfo(predicted_rate.dtype).eps
         )
-        factor = 1 / (self.scale * predicted_rate + 1)
+        # in terms of z = scale * mu, the two terms of the log-likelihood above are
+        # y * log(z / (z + 1)) and -log1p(z) / scale. The equivalent form built on
+        # 1 / (z + 1) cancels the leading digits of z once the rate is small enough
+        # that z + 1 rounds to 1, so keep the log1p form.
+        scaled_rate = self.scale * predicted_rate
+        log1p_rate = jnp.log1p(scaled_rate)
         return -aggregate_sample_scores(
-            y * jnp.log(1 - factor) + jnp.log(factor) / self.scale
+            y * (jnp.log(scaled_rate) - log1p_rate) - log1p_rate / self.scale
         )
 
     def log_likelihood(


### PR DESCRIPTION
Observation models, log-raised cosines and the inverse of the softplus, all benefit from robust computation for near zero or large values of the inputs. This PR just makes minor edits that improves the robustness.